### PR TITLE
Fix misalignment with OpenAPI spec for Kafka pipes

### DIFF
--- a/crates/clickhouse-cloud-api/src/lib.rs
+++ b/crates/clickhouse-cloud-api/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 pub mod meta;
 #[allow(non_camel_case_types)]
 pub mod models;
+pub mod serde_helpers;
 
 pub use client::Client;
 pub use error::Error;

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -7657,7 +7657,7 @@ pub struct ClickPipeKafkaSource {
     pub iam_role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offset: Option<ClickPipeKafkaOffset>,
-    #[serde(rename = "reversePrivateEndpointIds", default)]
+    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
     pub reverse_private_endpoint_ids: Vec<String>,
     #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none", default)]
     pub schema_registry: Option<ClickPipeKafkaSchemaRegistry>,
@@ -7983,7 +7983,7 @@ pub struct ClickPipePatchKafkaSource {
     pub credentials: serde_json::Value,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
-    #[serde(rename = "reversePrivateEndpointIds", default)]
+    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
     pub reverse_private_endpoint_ids: Vec<String>,
 }
 
@@ -8214,7 +8214,7 @@ pub struct ClickPipePostKafkaSource {
     pub iam_role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offset: Option<ClickPipeKafkaOffset>,
-    #[serde(rename = "reversePrivateEndpointIds", default)]
+    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
     pub reverse_private_endpoint_ids: Vec<String>,
     #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none", default)]
     pub schema_registry: Option<ClickPipeMutateKafkaSchemaRegistry>,

--- a/crates/clickhouse-cloud-api/src/serde_helpers.rs
+++ b/crates/clickhouse-cloud-api/src/serde_helpers.rs
@@ -1,0 +1,17 @@
+//! Serde helpers used by generated models.
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a `Vec<T>` field, treating an explicit JSON `null` the same as
+/// an empty array. Required because the ClickHouse Cloud API emits `null` for
+/// some array-valued fields that its OpenAPI spec declares as non-nullable
+/// `array`s (e.g. `reversePrivateEndpointIds` on Kafka sources). With plain
+/// `#[serde(default)]`, a missing field works but an explicit `null` fails
+/// with "invalid type: null, expected a sequence".
+pub fn null_to_empty<'de, T, D>(d: D) -> Result<Vec<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Option::<Vec<T>>::deserialize(d).map(Option::unwrap_or_default)
+}

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
@@ -150,6 +150,18 @@ pub async fn create_pipe_and_wait_running(
     )
     .await?;
 
+    // Round-trip the list endpoint so server-shape regressions (e.g. a Vec<T>
+    // field returned as `null` instead of `[]`) surface here instead of only
+    // affecting `chctl cloud clickpipe list` in production.
+    let pipes = client
+        .click_pipe_get_list(&ctx.org_id, &ch.service_id)
+        .await?
+        .result
+        .ok_or("clickpipe list returned no result")?;
+    if !pipes.iter().any(|p| p.id.to_string() == clickpipe_id) {
+        return Err(format!("clickpipe {clickpipe_id} missing from list response").into());
+    }
+
     Ok(clickpipe_id)
 }
 

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1295,6 +1295,65 @@ async fn list_click_pipes() {
     assert_eq!(pipes[0].name, "kafka-pipe");
 }
 
+/// Mirror the shape the live API actually returns for a Kafka pipe — including
+/// `reversePrivateEndpointIds: null`, which the spec declares as a required
+/// array but the server happily emits as null when unset. Before the fix,
+/// this fails with `invalid type: null, expected a sequence`.
+#[tokio::test]
+async fn list_click_pipes_with_null_array_fields() {
+    let (s, c) = setup().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes"))
+        .respond_with(ok_json(serde_json::json!([
+            {
+                "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "serviceId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "name": "kafka-pipe",
+                "state": "Running",
+                "scaling": {
+                    "replicas": 1,
+                    "replicaCpuMillicores": 125,
+                    "replicaMemoryGb": 0.5
+                },
+                "source": {
+                    "kafka": {
+                        "type": "confluent",
+                        "format": "JSONEachRow",
+                        "brokers": "broker.example:9092",
+                        "topics": "events",
+                        "consumerGroup": "clickpipes-aaaaaaaa",
+                        "authentication": "PLAIN",
+                        "reversePrivateEndpointIds": null
+                    }
+                },
+                "destination": {
+                    "database": "default",
+                    "table": "events",
+                    "managedTable": true,
+                    "tableDefinition": {
+                        "engine": {"type": "MergeTree"},
+                        "sortingKey": ["id"]
+                    },
+                    "columns": []
+                },
+                "fieldMappings": [],
+                "settings": {},
+                "createdAt": "2026-05-13T17:47:28.132987Z",
+                "updatedAt": "2026-05-13T17:47:28.132987Z"
+            }
+        ])))
+        .mount(&s)
+        .await;
+
+    let resp = c.click_pipe_get_list("org-1", "svc-1").await.unwrap();
+    let pipes = resp.result.unwrap();
+    assert_eq!(pipes.len(), 1);
+    assert_eq!(pipes[0].name, "kafka-pipe");
+    let kafka = pipes[0].source.kafka.as_ref().expect("kafka source present");
+    assert!(kafka.reverse_private_endpoint_ids.is_empty());
+}
+
 #[tokio::test]
 async fn create_click_pipe() {
     let (s, c) = setup().await;


### PR DESCRIPTION
## Summary

`chctl cloud clickpipe list` crashes on services that contain a Kafka
pipe whose `reversePrivateEndpointIds` field is `null` (43 of 78 Kafka
pipes in the test org). One bad pipe takes down the whole response.

The OpenAPI spec declares the field non-nullable `array` but the live
API emits `null`. `#[serde(default)]` rescues missing keys, not
explicit `null`, so deserialization fails with `invalid type: null,
expected a sequence`.

## Fix

Add a `null_to_empty` serde helper that coerces JSON `null` to an
empty `Vec`. Apply it to the three Kafka source structs that carry
the offending field. Narrow scope: this is a bridge until the
upstream OpenAPI emitter is fixed 
(`control-plane/apps/openapi/src/service/OpenapiDocRegistry.ts:151-157`
drops `nullable: true` for `type: 'array'` fields). Once that lands,
re-running the codegen flips these fields to `Option<Vec<String>>`
and the shim comes out.

## Test plan

- [x] `cargo test -p clickhouse-cloud-api` — 119/119 pass. New
      `list_click_pipes_with_null_array_fields` test mirrors the
      real-world response shape and is the regression guard.
- [x] E2E pipe creations now round-trip through
      `click_pipe_get_list` so future server-shape regressions
      surface in tests.
- [x] `chctl cloud clickpipe list` against all 108 services in the
      test org — 0 failures (was 15+ before).

## Files

| File | Change |
|---|---|
| `src/serde_helpers.rs` | New — `null_to_empty` deserializer |
| `src/lib.rs` | `pub mod serde_helpers;` |
| `src/models.rs` | Annotate 3 `reversePrivateEndpointIds` fields |
| `tests/client_test.rs` | Regression test |
| `tests/clickpipes/stages/mod.rs` | E2E list round-trip |
