### PR TITLE
Document that --json is ignored by prometheus commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,7 +972,7 @@ clickhousectl cloud --json service list
 clickhousectl cloud --json service get <service-id>
 ```
 
-`clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, and any tool that sets the standard `AGENT` env var) and emits JSON to stdout automatically without setting `--json`. Protocol-oriented commands retain their natural output: Prometheus commands emit text, `cloud service query` uses a ClickHouse format such as `JSONEachRow`, and Postgres runtime configuration is JSON already.
+`clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, and any tool that sets the standard `AGENT` env var) and emits JSON to stdout automatically without setting `--json`. Protocol-oriented commands retain their natural output: `cloud org prometheus` and `cloud service prometheus` always emit raw Prometheus exposition text and silently ignore `--json`, `cloud service query` uses a ClickHouse format such as `JSONEachRow`, and Postgres runtime configuration is JSON already.
 
 Local runtime failures also use structured output when `local --json` is set or a coding agent is detected. The CLI writes exactly one error object to stderr and preserves the documented exit code:
 

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -53,6 +53,10 @@ CONTEXT FOR AGENTS:
     },
 
     /// Get organization Prometheus configuration
+    #[command(after_help = "\
+OUTPUT FORMAT:
+  Output is always raw Prometheus exposition text, never JSON. --json is
+  accepted for consistency with other commands but is silently ignored.")]
     Prometheus {
         /// Organization ID (auto-detected if not specified)
         #[arg(long)]
@@ -957,6 +961,21 @@ mod tests {
             "wrong classification for: {}",
             args.join(" ")
         );
+    }
+
+    #[test]
+    fn org_prometheus_help_documents_json_is_ignored() {
+        let error = Cli::try_parse_from(["clickhousectl", "cloud", "org", "prometheus", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+        assert!(
+            help.contains("always raw Prometheus exposition text"),
+            "{help}"
+        );
+        assert!(help.contains("--json"), "{help}");
+        assert!(help.contains("silently ignored"), "{help}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -401,6 +401,10 @@ CONTEXT FOR AGENTS:
     },
 
     /// Get service Prometheus metrics
+    #[command(after_help = "\
+OUTPUT FORMAT:
+  Output is always raw Prometheus exposition text, never JSON. --json is
+  accepted for consistency with other commands but is silently ignored.")]
     Prometheus {
         /// Service ID
         service_id: String,
@@ -2525,6 +2529,22 @@ mod tests {
         assert!(help.contains("Legacy or non-owned records"), "{help}");
         assert!(help.contains("is never run"), "{help}");
         assert!(help.contains("automatically after a query fails"), "{help}");
+    }
+
+    #[test]
+    fn service_prometheus_help_documents_json_is_ignored() {
+        let error =
+            Cli::try_parse_from(["clickhousectl", "cloud", "service", "prometheus", "--help"])
+                .err()
+                .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+        assert!(
+            help.contains("always raw Prometheus exposition text"),
+            "{help}"
+        );
+        assert!(help.contains("--json"), "{help}");
+        assert!(help.contains("silently ignored"), "{help}");
     }
 
     #[test]


### PR DESCRIPTION
## What

`cloud org prometheus <id> --json` and `cloud service prometheus <id> --json` silently accept `--json` but always emit raw Prometheus exposition text (exit 0, not parseable as JSON). This is correct behavior — converting Prometheus text to JSON would lose the format contract — but it was undocumented, which is confusing, especially for agent consumers that expect parseable JSON.

## Why

Docs-only change, no behavior change:

- Added an `after_help` block to both `OrgCommands::Prometheus` and `ServiceCommands::Prometheus` clap variants stating that output is always Prometheus exposition text and `--json` is silently ignored.
- Sharpened the README's "JSON output" section to name both commands explicitly rather than referring to "Prometheus commands" generically.

## Test plan

- Added clap `--help` parse tests next to each command definition asserting the new help text is present (`org_prometheus_help_documents_json_is_ignored`, `service_prometheus_help_documents_json_is_ignored`), following the existing pattern used for `service query` and clickpipes postgres help.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p clickhousectl` (all green; one unrelated pre-existing timing-sensitive test, `wall_clock_timeout_fails_and_rolls_back_fresh_data`, flaked once on a slow run and passed on rerun/full-suite rerun — unrelated to this change)
- `cargo test -p clickhouse-cloud-api --test spec_coverage_test` (unaffected, all green)

Fixes #607.

Note: this PR is part of a stacked chain and is based on `main` (bottom of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)