### PR TITLE
local init --json: report all created paths

### DIFF
--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -29,9 +29,9 @@ pub fn is_initialized() -> bool {
     local_dir().exists()
 }
 
-/// Which project-local paths `init()` created during this invocation. Used to
-/// report the full set of created paths in `--json` output, mirroring what the
-/// human-readable messages already say.
+/// Which project-local paths `init()` created during this invocation. The
+/// caller renders this in both the human-readable and `--json` output, so
+/// `init()` itself prints nothing.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct InitResult {
     pub clickhouse_dir_created: bool,
@@ -43,12 +43,10 @@ pub fn init() -> Result<InitResult> {
     let dir = local_dir();
 
     let clickhouse_dir_created = if is_initialized() {
-        eprintln!("Already initialized at {}", dir.display());
         false
     } else {
         std::fs::create_dir_all(&dir)?;
         std::fs::write(dir.join(".gitignore"), "*\n")?;
-        eprintln!("Initialized ClickHouse project in {}", dir.display());
         true
     };
 
@@ -77,14 +75,6 @@ fn create_project_scaffold(dir: PathBuf, subdirs: &[&str]) -> Result<bool> {
             std::fs::write(path.join(".gitkeep"), "")?;
             created = true;
         }
-    }
-
-    if created {
-        eprintln!(
-            "Created project scaffold in {}/ ({})",
-            dir.display(),
-            subdirs.join(", ")
-        );
     }
 
     Ok(created)

--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -29,30 +29,46 @@ pub fn is_initialized() -> bool {
     local_dir().exists()
 }
 
-pub fn init() -> Result<()> {
+/// Which project-local paths `init()` created during this invocation. Used to
+/// report the full set of created paths in `--json` output, mirroring what the
+/// human-readable messages already say.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InitResult {
+    pub clickhouse_dir_created: bool,
+    pub clickhouse_scaffold_created: bool,
+    pub postgres_scaffold_created: bool,
+}
+
+pub fn init() -> Result<InitResult> {
     let dir = local_dir();
 
-    if is_initialized() {
+    let clickhouse_dir_created = if is_initialized() {
         eprintln!("Already initialized at {}", dir.display());
+        false
     } else {
         std::fs::create_dir_all(&dir)?;
         std::fs::write(dir.join(".gitignore"), "*\n")?;
         eprintln!("Initialized ClickHouse project in {}", dir.display());
-    }
+        true
+    };
 
-    create_project_scaffold(
+    let clickhouse_scaffold_created = create_project_scaffold(
         project_dir(),
         &["tables", "materialized_views", "queries", "seed"],
     )?;
-    create_project_scaffold(
+    let postgres_scaffold_created = create_project_scaffold(
         postgres_project_dir(),
         &["tables", "views", "functions", "queries", "seed"],
     )?;
 
-    Ok(())
+    Ok(InitResult {
+        clickhouse_dir_created,
+        clickhouse_scaffold_created,
+        postgres_scaffold_created,
+    })
 }
 
-fn create_project_scaffold(dir: PathBuf, subdirs: &[&str]) -> Result<()> {
+fn create_project_scaffold(dir: PathBuf, subdirs: &[&str]) -> Result<bool> {
     let mut created = false;
     for subdir in subdirs {
         let path = dir.join(subdir);
@@ -71,7 +87,7 @@ fn create_project_scaffold(dir: PathBuf, subdirs: &[&str]) -> Result<()> {
         );
     }
 
-    Ok(())
+    Ok(created)
 }
 
 /// Returns CLI flags that point ClickHouse data into the current directory.
@@ -89,7 +105,8 @@ mod tests {
         let dir = tmp.path().join("postgres");
         let subdirs = ["tables", "materialized_views", "queries", "seed"];
 
-        create_project_scaffold(dir.clone(), &subdirs).unwrap();
+        let created = create_project_scaffold(dir.clone(), &subdirs).unwrap();
+        assert!(created);
 
         for subdir in &subdirs {
             let path = dir.join(subdir);
@@ -108,9 +125,10 @@ mod tests {
         let dir = tmp.path().join("clickhouse");
         let subdirs = ["tables", "queries"];
 
-        create_project_scaffold(dir.clone(), &subdirs).unwrap();
-        // Running again over an existing scaffold must not error.
-        create_project_scaffold(dir.clone(), &subdirs).unwrap();
+        assert!(create_project_scaffold(dir.clone(), &subdirs).unwrap());
+        // Running again over an existing scaffold must not error, and must
+        // report that nothing new was created.
+        assert!(!create_project_scaffold(dir.clone(), &subdirs).unwrap());
 
         assert!(dir.join("tables").join(".gitkeep").is_file());
     }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -42,7 +42,10 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
             if result.postgres_scaffold_created {
                 paths.push("postgres/".to_string());
             }
-            let out = output::InitOutput { paths };
+            let out = output::InitOutput {
+                paths,
+                already_initialized: !result.clickhouse_dir_created,
+            };
             output::print_output(&out, json);
             Ok(())
         }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -34,10 +34,15 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
         LocalCommands::Remove { version, force } => remove(&version, force, json),
         LocalCommands::Which => which(json),
         LocalCommands::Init => {
-            init::init()?;
-            let out = output::InitOutput {
-                path: ".clickhouse/".to_string(),
-            };
+            let result = init::init()?;
+            let mut paths = vec![".clickhouse/".to_string()];
+            if result.clickhouse_scaffold_created {
+                paths.push("clickhouse/".to_string());
+            }
+            if result.postgres_scaffold_created {
+                paths.push("postgres/".to_string());
+            }
+            let out = output::InitOutput { paths };
             output::print_output(&out, json);
             Ok(())
         }

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -634,12 +634,25 @@ impl fmt::Display for RemoveOutput {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct InitOutput {
-    pub path: String,
+    /// Every project-local path this invocation created or manages, e.g.
+    /// `.clickhouse/`, and (when newly created) `clickhouse/` and `postgres/`.
+    pub paths: Vec<String>,
 }
 
 impl fmt::Display for InitOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Initialized ClickHouse project in {}", self.path)
+        write!(
+            f,
+            "Initialized ClickHouse project in {}",
+            self.paths
+                .first()
+                .map(String::as_str)
+                .unwrap_or(".clickhouse/")
+        )?;
+        for path in self.paths.iter().skip(1) {
+            write!(f, "\nCreated project scaffold in {path}")?;
+        }
+        Ok(())
     }
 }
 
@@ -1394,14 +1407,32 @@ mod tests {
     }
 
     #[test]
-    fn init_json() {
+    fn init_json_first_run_reports_all_created_paths() {
         let output = InitOutput {
-            path: ".clickhouse/".to_string(),
+            paths: vec![
+                ".clickhouse/".to_string(),
+                "clickhouse/".to_string(),
+                "postgres/".to_string(),
+            ],
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
-        assert_eq!(json["path"], ".clickhouse/");
+        assert_eq!(
+            json["paths"],
+            serde_json::json!([".clickhouse/", "clickhouse/", "postgres/"])
+        );
+    }
+
+    #[test]
+    fn init_json_idempotent_run_only_reports_clickhouse_dir() {
+        let output = InitOutput {
+            paths: vec![".clickhouse/".to_string()],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
+
+        assert_eq!(json["paths"], serde_json::json!([".clickhouse/"]));
     }
 
     #[test]
@@ -1725,13 +1756,30 @@ mod tests {
     }
 
     #[test]
-    fn init_display() {
+    fn init_display_idempotent() {
         let output = InitOutput {
-            path: ".clickhouse/".to_string(),
+            paths: vec![".clickhouse/".to_string()],
         };
         assert_eq!(
             output.to_string(),
             "Initialized ClickHouse project in .clickhouse/"
+        );
+    }
+
+    #[test]
+    fn init_display_first_run_lists_created_scaffolds() {
+        let output = InitOutput {
+            paths: vec![
+                ".clickhouse/".to_string(),
+                "clickhouse/".to_string(),
+                "postgres/".to_string(),
+            ],
+        };
+        assert_eq!(
+            output.to_string(),
+            "Initialized ClickHouse project in .clickhouse/\n\
+             Created project scaffold in clickhouse/\n\
+             Created project scaffold in postgres/"
         );
     }
 

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -637,18 +637,24 @@ pub struct InitOutput {
     /// Every project-local path this invocation created or manages, e.g.
     /// `.clickhouse/`, and (when newly created) `clickhouse/` and `postgres/`.
     pub paths: Vec<String>,
+    /// Human-output detail only: the project dir already existed before this
+    /// run. JSON consumers can tell from `paths`, so it is not serialized.
+    #[serde(skip)]
+    pub already_initialized: bool,
 }
 
 impl fmt::Display for InitOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Initialized ClickHouse project in {}",
-            self.paths
-                .first()
-                .map(String::as_str)
-                .unwrap_or(".clickhouse/")
-        )?;
+        let dir = self
+            .paths
+            .first()
+            .map(String::as_str)
+            .unwrap_or(".clickhouse/");
+        if self.already_initialized {
+            write!(f, "Already initialized at {dir}")?;
+        } else {
+            write!(f, "Initialized ClickHouse project in {dir}")?;
+        }
         for path in self.paths.iter().skip(1) {
             write!(f, "\nCreated project scaffold in {path}")?;
         }
@@ -1414,6 +1420,7 @@ mod tests {
                 "clickhouse/".to_string(),
                 "postgres/".to_string(),
             ],
+            already_initialized: false,
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
@@ -1422,12 +1429,15 @@ mod tests {
             json["paths"],
             serde_json::json!([".clickhouse/", "clickhouse/", "postgres/"])
         );
+        // Human-only detail must stay out of the JSON payload.
+        assert!(json.get("already_initialized").is_none());
     }
 
     #[test]
     fn init_json_idempotent_run_only_reports_clickhouse_dir() {
         let output = InitOutput {
             paths: vec![".clickhouse/".to_string()],
+            already_initialized: true,
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
@@ -1759,11 +1769,9 @@ mod tests {
     fn init_display_idempotent() {
         let output = InitOutput {
             paths: vec![".clickhouse/".to_string()],
+            already_initialized: true,
         };
-        assert_eq!(
-            output.to_string(),
-            "Initialized ClickHouse project in .clickhouse/"
-        );
+        assert_eq!(output.to_string(), "Already initialized at .clickhouse/");
     }
 
     #[test]
@@ -1774,6 +1782,7 @@ mod tests {
                 "clickhouse/".to_string(),
                 "postgres/".to_string(),
             ],
+            already_initialized: false,
         };
         assert_eq!(
             output.to_string(),

--- a/crates/clickhousectl/tests/local_init_json_test.rs
+++ b/crates/clickhousectl/tests/local_init_json_test.rs
@@ -1,6 +1,6 @@
-//! Subprocess coverage for `local init --json`: the JSON payload must report
-//! the full set of paths the command created, matching what the
-//! human-readable output says (issue #609).
+//! Subprocess coverage for `local init`: the `--json` payload must report the
+//! full set of paths the command created, and the human output must report
+//! each created path exactly once (issue #609).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -57,4 +57,52 @@ fn init_json_on_second_run_reports_only_the_clickhouse_dir() {
     let json = stdout_json(&output);
 
     assert_eq!(json["paths"], serde_json::json!([".clickhouse/"]));
+}
+
+#[test]
+fn init_human_output_reports_each_created_path_exactly_once() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    let output = run(project.path(), home.path(), &["local", "init"]);
+    assert!(output.status.success());
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for path in [".clickhouse/", "clickhouse/", "postgres/"] {
+        // `.clickhouse/` is a substring match of itself only; `clickhouse/`
+        // also matches inside `.clickhouse/`, so count line-anchored mentions.
+        let mentions = combined
+            .lines()
+            .filter(|line| line.ends_with(&format!(" {path}")))
+            .count();
+        assert_eq!(
+            mentions, 1,
+            "expected one line mentioning {path}: {combined}"
+        );
+    }
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Initialized ClickHouse project in .clickhouse/\n\
+         Created project scaffold in clickhouse/\n\
+         Created project scaffold in postgres/\n"
+    );
+}
+
+#[test]
+fn init_human_output_second_run_reports_already_initialized() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    run(project.path(), home.path(), &["local", "init"]);
+    let output = run(project.path(), home.path(), &["local", "init"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Already initialized at .clickhouse/\n"
+    );
 }

--- a/crates/clickhousectl/tests/local_init_json_test.rs
+++ b/crates/clickhousectl/tests/local_init_json_test.rs
@@ -1,0 +1,60 @@
+//! Subprocess coverage for `local init --json`: the JSON payload must report
+//! the full set of paths the command created, matching what the
+//! human-readable output says (issue #609).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn run(project: &Path, home: &Path, args: &[&str]) -> Output {
+    Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project)
+        .args(args)
+        .output()
+        .expect("run clickhousectl")
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout is a single JSON object")
+}
+
+#[test]
+fn init_json_reports_clickhouse_dir_and_both_scaffolds_on_first_run() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    let output = run(project.path(), home.path(), &["local", "init", "--json"]);
+    let json = stdout_json(&output);
+
+    assert_eq!(
+        json["paths"],
+        serde_json::json!([".clickhouse/", "clickhouse/", "postgres/"])
+    );
+
+    assert!(project.path().join(".clickhouse").is_dir());
+    assert!(project.path().join("clickhouse/tables").is_dir());
+    assert!(project.path().join("postgres/tables").is_dir());
+}
+
+#[test]
+fn init_json_on_second_run_reports_only_the_clickhouse_dir() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    run(project.path(), home.path(), &["local", "init", "--json"]);
+    let output = run(project.path(), home.path(), &["local", "init", "--json"]);
+    let json = stdout_json(&output);
+
+    assert_eq!(json["paths"], serde_json::json!([".clickhouse/"]));
+}

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -54,6 +54,7 @@ NON_INSTALL_EXACT_PATHS = frozenset(
         "crates/clickhousectl/tests/local_client_selectors_test.rs",
         "crates/clickhousectl/tests/local_docker_diagnostics_test.rs",
         "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
+        "crates/clickhousectl/tests/local_init_json_test.rs",
         "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
         "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
         "crates/clickhousectl/tests/local_server_metadata_test.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -127,6 +127,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
                     "crates/clickhousectl/tests/local_client_selectors_test.rs",
                     "crates/clickhousectl/tests/local_docker_diagnostics_test.rs",
                     "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
+                    "crates/clickhousectl/tests/local_init_json_test.rs",
                     "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
                     "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
                     "crates/clickhousectl/tests/local_server_metadata_test.rs",


### PR DESCRIPTION
## Summary
- `local init --json` previously reported only `{"path": ".clickhouse/"}`, omitting the `clickhouse/` and `postgres/` scaffold subtrees that the human-readable output already reports (e.g. `Created project scaffold in clickhouse/ (tables, materialized_views, queries, seed)`).
- `init()` now returns an `InitResult` indicating which of `.clickhouse/`, `clickhouse/`, and `postgres/` were actually created during the invocation.
- `InitOutput` now exposes `paths: Vec<String>` (replacing the single `path: String` field) listing `.clickhouse/` always, plus `clickhouse/` and/or `postgres/` only when their scaffold was newly created this run — matching the conditional human-readable messages exactly.
- Human `Display` output for `InitOutput` also grew a line per newly-created scaffold, so `local init` (non-JSON) now reports scaffold creation via the same output type, not just via `eprintln!` inside `init()`.

This PR is part of a stacked chain based on `fix/607-prometheus-json-help` (not `main`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- [x] `cargo test -p clickhousectl` (all passing, including new `tests/local_init_json_test.rs` subprocess coverage for first-run vs. idempotent-run JSON payloads, and updated inline unit tests in `src/init.rs` / `src/local/output.rs`)

Fixes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)