### PR TITLE
Fix panic (exit 101) in `cloud service delete --force`

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ clickhousectl cloud service delete <service-id>
 clickhousectl cloud service delete <service-id> --force
 ```
 
+`--force` stops the service and then polls it until the stop completes, which takes minutes on a real service, printing each state change to stderr (stdout stays reserved for the result). Progress output is best-effort: if whatever was reading it goes away — a pager you quit, a supervising process that stopped reading — the lines are dropped and the deletion still runs to completion and exits 0.
+
 Use `clickhousectl cloud service create --help` for the complete option list. If omitted, `--provider` defaults to `aws`, `--region` defaults to `us-east-1`, and the IP allowlist defaults to `0.0.0.0/0`; production workflows should normally set all three explicitly. When the create response includes an initial password, it is shown only once.
 
 `--query` and `--queries-file` are mutually exclusive. If neither is supplied, `cloud service query` reads SQL from stdin; `--queries-file -` also reads stdin explicitly.

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -1,6 +1,6 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
-use crate::cloud::output::{or_absent, print_human};
+use crate::cloud::output::{eprint_line, or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use clap::Subcommand;
@@ -502,18 +502,20 @@ pub(crate) fn service_query_key_cleanup(
         return Ok((vec![], false));
     };
     let Some(api_key_id) = key.api_key_id else {
-        eprintln!(
+        // `eprint_line`, not `eprintln!`: a warning on the way to deleting a
+        // service must not panic on a closed stderr (#598).
+        eprint_line(format!(
             "Warning: the stored query key for service {service_id} predates exact management \
              API key IDs; service deletion will continue without unsafe cloud key cleanup."
-        );
+        ));
         return Ok((vec![], false));
     };
     let Some(key_org_id) = key.organization_id else {
-        eprintln!(
+        eprint_line(format!(
             "Warning: the stored query key for service {service_id} has a management API key ID \
              but no provisioning organization; cloud key cleanup was skipped and the local \
              record was retained."
-        );
+        ));
         return Ok((vec![], true));
     };
     if key_org_id != org_id {

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -30,6 +30,33 @@ pub(crate) fn or_absent<T: std::fmt::Display>(value: Option<T>) -> String {
         .unwrap_or_else(|| ABSENT.to_string())
 }
 
+/// Write one line to stderr, discarding a write failure.
+///
+/// `eprintln!` *panics* when the write fails, and the write fails with
+/// `BrokenPipe` as soon as whatever was reading stderr goes away (a pager the
+/// user quit, a supervising harness that stopped reading). That turns a
+/// long-running command into a panic and exit 101 — see #598, where
+/// `cloud service delete --force` streamed stop-poll progress for minutes and
+/// crashed instead of deleting the service. Progress and status lines are never
+/// worth a panic: the exit code, not the line, reports the outcome.
+///
+/// Same rule as `telemetry::print_first_run_notice` and
+/// `update::print_cached_update_notice`.
+pub(crate) fn eprint_line(line: impl std::fmt::Display) {
+    use std::io::Write;
+    let _ = writeln!(std::io::stderr(), "{line}");
+}
+
+/// Write one line to stdout, discarding a write failure.
+///
+/// The stdout counterpart of [`eprint_line`], for a result line printed after
+/// the operation it describes already succeeded: a closed stdout must not
+/// convert a completed deletion into a panic.
+pub(crate) fn print_line(line: impl std::fmt::Display) {
+    use std::io::Write;
+    let _ = writeln!(std::io::stdout(), "{line}");
+}
+
 /// Serialize `value` and print it as an indented, human-readable tree.
 ///
 /// - Object keys are printed verbatim (camelCase, as the API returns them).

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -2,7 +2,7 @@ use crate::cloud::api_keys::{cleanup_service_query_key, service_query_key_cleanu
 use crate::cloud::backups::BackupConfigCommands;
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
-use crate::cloud::output::{ABSENT, or_absent, print_human};
+use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_human, print_line};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use clap::builder::PossibleValuesParser;
@@ -26,6 +26,12 @@ struct QueryEndpointReadiness {
     initial_backoff: Duration,
     max_backoff: Duration,
 }
+
+/// Gap between `GET service` calls while `service delete --force` waits for a
+/// stop to finish. A real stop takes minutes, so the loop can emit dozens of
+/// progress lines — see [`crate::cloud::output::eprint_line`] for why none of
+/// them may panic.
+const STOP_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 const QUERY_ENDPOINT_READINESS: QueryEndpointReadiness = QueryEndpointReadiness {
     timeout: Duration::from_secs(120),
@@ -1428,7 +1434,15 @@ async fn service_delete(
             .map(|service| or_absent(service.state.as_ref()))
             .unwrap_or_default();
         if matches!(state.as_str(), "running" | "idle" | "starting") {
-            eprintln!("Stopping service {} before deletion...", service_id);
+            // Every write below goes through `eprint_line`/`print_line`, never
+            // `eprintln!`/`println!`: this loop streams progress for as long as
+            // the stop takes (minutes), so it routinely outlives whatever was
+            // reading its output, and a panicking write turned a successful
+            // delete into exit 101 (#598).
+            eprint_line(format!(
+                "Stopping service {} before deletion...",
+                service_id
+            ));
             client
                 .change_service_state(&org_id, service_id, ServiceStatePatchRequestCommand::Stop)
                 .await?;
@@ -1437,11 +1451,11 @@ async fn service_delete(
                 std::io::stderr().is_terminal() && !json && std::env::var_os("CI").is_none();
             let mut progress = StopPollProgress::default();
             loop {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                tokio::time::sleep(STOP_POLL_INTERVAL).await;
                 let service = client.get_service(&org_id, service_id).await?;
                 let state = or_absent(service.state.as_ref());
                 if let Some(line) = progress.render(&state, verbose_polling) {
-                    eprintln!("{line}");
+                    eprint_line(line);
                 }
                 if classify_stop_poll_state(service.state.as_ref())? {
                     break;
@@ -1458,10 +1472,12 @@ async fn service_delete(
     if !retain_query_key {
         credentials::remove_service_query_key(service_id)?;
     }
+    // The service is already gone by here, so a closed stdout must not turn a
+    // completed deletion into a panic — see `print_line` and #598.
     if json {
-        println!("{}", serde_json::to_string_pretty(&response)?);
+        print_line(serde_json::to_string_pretty(&response)?);
     } else {
-        println!("Service {} deletion initiated", service_id);
+        print_line(format!("Service {} deletion initiated", service_id));
     }
     Ok(())
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -611,11 +611,15 @@ fn write_service_query_key(root: &Path, organization_id: Option<&str>, api_key_i
     .unwrap();
 }
 
-fn invoke_service_delete(
+/// Start a `service delete` without waiting for it, so a test can close the
+/// child's pipes while the command is still running (see the #598 tests).
+fn spawn_service_delete(
     mock: &MockServer,
     project_dir: &Path,
     force: bool,
-) -> std::process::Output {
+    stdout: Stdio,
+    stderr: Stdio,
+) -> std::process::Child {
     let url = mock.uri();
     let mut args = vec![
         "cloud",
@@ -638,8 +642,36 @@ fn invoke_service_delete(
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .current_dir(project_dir)
         .args(args)
-        .output()
+        .stdin(Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
         .expect("failed to spawn clickhousectl")
+}
+
+fn invoke_service_delete(
+    mock: &MockServer,
+    project_dir: &Path,
+    force: bool,
+) -> std::process::Output {
+    spawn_service_delete(mock, project_dir, force, Stdio::piped(), Stdio::piped())
+        .wait_with_output()
+        .expect("failed to run clickhousectl")
+}
+
+/// The HTTP methods and paths the mock received, in order.
+async fn received_request_shape(mock: &MockServer) -> Vec<(String, String)> {
+    mock.received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|request| {
+            (
+                request.method.as_str().to_string(),
+                request.url.path().to_string(),
+            )
+        })
+        .collect()
 }
 
 fn successful_delete_response(request_id: &str) -> ResponseTemplate {
@@ -899,18 +931,8 @@ async fn forced_service_delete_surfaces_not_found_for_an_absent_service() {
     // The delete request never succeeded, so local query-key cleanup and the
     // organization-scoped key deletion (which would follow a successful
     // delete) must not have been attempted.
-    let requests = mock.received_requests().await.unwrap();
-    let request_shape = requests
-        .iter()
-        .map(|request| {
-            (
-                request.method.as_str().to_string(),
-                request.url.path().to_string(),
-            )
-        })
-        .collect::<Vec<_>>();
     assert_eq!(
-        request_shape,
+        received_request_shape(&mock).await,
         vec![
             (
                 "GET".to_string(),
@@ -996,6 +1018,134 @@ async fn forced_service_delete_reports_only_poll_state_transitions_when_redirect
         format!(
             "Stopping service {DELETE_TEST_SERVICE_ID} before deletion...\n  state: stopping\n  state: stopped\n"
         )
+    );
+}
+
+/// Mock a `--force` delete of a service that is observed mid-`stopping`:
+/// `running` on the pre-stop check, then `stopping` and `stopped` from the
+/// poll loop.
+async fn mount_forced_delete_stop_sequence(mock: &MockServer) {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let states = ["running", "stopping", "stopped"];
+    let request_index = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(move |_: &wiremock::Request| {
+            let index = request_index.fetch_add(1, Ordering::SeqCst);
+            let state = states[index.min(states.len() - 1)];
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "id": DELETE_TEST_SERVICE_ID,
+                    "name": "demo",
+                    "state": state,
+                },
+                "status": 200,
+                "requestId": format!("stub-service-get-{index}"),
+            }))
+        })
+        .expect(3)
+        .mount(mock)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}/state"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": DELETE_TEST_SERVICE_ID,
+                "name": "demo",
+                "state": "stopping",
+            },
+            "status": 200,
+            "requestId": "stub-service-stop",
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-service-delete"))
+        .expect(1)
+        .mount(mock)
+        .await;
+}
+
+/// #598: a `--force` delete that observed the service mid-`stopping` panicked
+/// with exit 101. The stop poll streams a progress line per state change for as
+/// long as the stop takes (minutes on a real service), so it outlives readers
+/// that go away — a pager the user quit, a supervising harness that stopped
+/// reading — and `eprintln!` panics when the write fails with `BrokenPipe`.
+/// The delete must still run to completion and exit 0.
+#[tokio::test]
+async fn forced_service_delete_survives_a_closed_stderr_while_stopping() {
+    let mock = MockServer::start().await;
+    mount_forced_delete_stop_sequence(&mock).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut child = spawn_service_delete(&mock, dir.path(), true, Stdio::null(), Stdio::piped());
+    // Dropping the read end closes the pipe while the command is still
+    // polling. Rust ignores `SIGPIPE`, so the child's next write to stderr
+    // fails with `EPIPE` rather than killing the process — exactly the state a
+    // reader that walked away leaves behind.
+    drop(child.stderr.take().expect("stderr was piped"));
+    let status = child.wait().expect("failed to wait for clickhousectl");
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a closed stderr must not turn a completed forced delete into a panic"
+    );
+    // Not just "didn't panic": the stop-then-delete sequence still completed.
+    let shape = received_request_shape(&mock).await;
+    assert_eq!(
+        shape.last(),
+        Some(&(
+            "DELETE".to_string(),
+            format!("/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}")
+        )),
+        "unexpected request sequence: {shape:?}"
+    );
+}
+
+/// The stdout counterpart of #598: the result line is printed after the
+/// service is already gone, so a closed stdout must not turn a completed
+/// deletion into a panic either.
+#[tokio::test]
+async fn service_delete_survives_a_closed_stdout() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-service-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut child = spawn_service_delete(&mock, dir.path(), false, Stdio::piped(), Stdio::piped());
+    drop(child.stdout.take().expect("stdout was piped"));
+    let status = child.wait().expect("failed to wait for clickhousectl");
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a closed stdout must not turn a completed deletion into a panic"
+    );
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![(
+            "DELETE".to_string(),
+            format!("/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}")
+        )]
     );
 }
 


### PR DESCRIPTION
Fixes #598.

> Stacked PR: based on `fix/601-service-delete-not-found`, not `main`. Review only the top commit; the rest belongs to the PR below it in the chain.

## What was actually wrong

`cloud service delete --force` exited **101** after printing `state: stopping`. The issue guessed at an `unwrap()` in the stop-then-delete polling path. There isn't one:

- Clippy's `unwrap_used` / `expect_used` / `indexing_slicing` / `panic` lints over the non-test build report nothing in that path (the only hits in `cloud/` are an `Option::unwrap` guarded by a `1 =>` match arm and two enum parses outside this path).
- `service.state` is already read through `or_absent` and `classify_stop_poll_state`, which turn an absent state into a clean `CloudError`, and `stopping` into "keep waiting". Existing tests pin both.

The issue's exact trigger was not reproduced — the original run had a reader attached, and the interactive session is gone — so this is the only reachable panic the audit found, not a confirmed root cause. If #598 recurs after this lands, the cause is elsewhere and the issue should reopen.

That reachable panic is **the write itself**. `eprintln!`/`println!` panic when the write fails, and the write fails with `BrokenPipe` the moment whatever was reading the stream goes away. `--force` streams one progress line per state change for as long as the stop takes — minutes, dozens of lines on a real service — so it routinely outlives its reader (a pager the user quit, a supervising process that stopped reading). The panic then replaced a completed deletion with exit 101; the reported retry succeeded because the service was already stopped, so no polling output was produced. This repo has been bitten by the same class before (`main.rs` clap printing, `telemetry::print_first_run_notice`, `update::print_cached_update_notice` all carry the "not `eprintln!`, which panics on a closed stderr" comment).

Both new tests reproduce **exit 101 exactly** against the unfixed binary, and exit 0 with the fix.

## What changed

- `cloud::output::eprint_line` / `print_line`: write one line through the locked handle and discard a write failure, with the reasoning documented at the definition. Progress and result lines are not worth a panic — the exit code, not the line, reports the outcome.
- Every write in the delete path now goes through them: the "Stopping service …" notice, each poll progress line, the two query-key cleanup warnings in `api_keys.rs`, and the final `--json` / human result line (printed after the service is already gone).
- Named the poll interval `STOP_POLL_INTERVAL` while touching the loop.
- README: `--force` polls for minutes, streams state changes to stderr, and that progress output is best-effort while the deletion itself still completes and exits 0.

No request/response models, clap surface, or exit-code contract changed.

## Tests

- `forced_service_delete_survives_a_closed_stderr_while_stopping` — wiremock subprocess test; the service reports `running` → `stopping` → `stopped` during a `--force` delete while the child's stderr read end is closed mid-poll. Asserts exit 0 *and* that the stop-then-delete sequence still reached the API. Fails with `Some(101)` without the fix.
- `service_delete_survives_a_closed_stdout` — the stdout counterpart on the plain (fast) delete path. Also fails with `Some(101)` without the fix.
- Existing coverage unchanged: mid-`stopping` progress dedup, the absent-state error, `--force` clap parsing, and the not-found force path. Factored `spawn_service_delete` out of `invoke_service_delete` and shared `received_request_shape`.

Verified: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test -p clickhousectl` fully green (all 21 suites). `clickhouse-cloud-api` untouched.

## Follow-ups (not in this PR)

- The stop poll has no overall deadline: a service wedged in `stopping` makes `--force` wait forever rather than failing cleanly.
- Handlers outside this path still use `println!`/`eprintln!`, so a closed reader can still panic elsewhere (e.g. `cloud service query | head` exits 1 with `Broken pipe` via `write_all(...)?` — an error, not a panic, but not exit 0 either). Worth a separate issue if the project wants pipe-safe output as a global rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
