### PR TITLE
Document that cloud service query does not support multi-statement SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ clickhousectl cloud service stop <service-id>
 # Run SQL over HTTP via the Query API (no local clickhouse binary needed)
 clickhousectl cloud service query --name my-service --query "SELECT 1"
 clickhousectl cloud service query --id <service-id> --query "SELECT count() FROM system.tables" --format JSONEachRow
-clickhousectl cloud service query --name my-service --queries-file schema.sql   # "-" reads from stdin
+clickhousectl cloud service query --name my-service --queries-file query.sql   # single statement only; "-" reads from stdin
 clickhousectl cloud service query --name my-service --database mydb --query "SHOW TABLES"
 echo "SELECT 1+1" | clickhousectl cloud service query --name my-service
 
@@ -640,6 +640,8 @@ clickhousectl cloud service delete <service-id> --force
 Use `clickhousectl cloud service create --help` for the complete option list. If omitted, `--provider` defaults to `aws`, `--region` defaults to `us-east-1`, and the IP allowlist defaults to `0.0.0.0/0`; production workflows should normally set all three explicitly. When the create response includes an initial password, it is shown only once.
 
 `--query` and `--queries-file` are mutually exclusive. If neither is supplied, `cloud service query` reads SQL from stdin; `--queries-file -` also reads stdin explicitly.
+
+Whatever the source, the SQL must be a single statement. The Query API runs exactly one statement per request, so a multi-statement `.sql` script is rejected by ClickHouse (error 62, `Multi-statements are not allowed`). Run statements one invocation at a time, or put a real client on PATH with `clickhousectl local use latest` and run the script through `clickhouse client` connected to the service.
 
 Private endpoint IDs supplied to `private-endpoint create --endpoint-id` and `service update --add-private-endpoint-id` are format-checked before the request is sent, because adding one registers it for the whole organization and a typo has to be unpicked from both the service and the organization. Each provider uses its own format — AWS a `vpce-` VPC endpoint ID, GCP the numeric Private Service Connect connection ID, Azure the private endpoint Resource ID or `resourceGuid` — and the provider is not known when the flag is parsed, so only provider-independent mistakes are rejected (exit code `2`): empty values, values containing whitespace, and any value carrying `vpce-` that is not exactly a well-formed AWS VPC endpoint ID (`vpce-` plus 8 or 17 lowercase hex characters) — which also catches a pasted VPC endpoint ARN or endpoint service name. Azure Resource IDs (values starting with `/`) are exempt from that check, since an Azure resource may itself be named `vpce-...`. Whether the endpoint actually exists and belongs to you is not validated by the CLI or, currently, by the Cloud API. Removal flags are never format-checked, so an already-registered bogus ID stays removable.
 

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -446,7 +446,11 @@ CONTEXT FOR AGENTS:
   SQL sources: --query and --queries-file are mutually exclusive. When neither
   is supplied, SQL is read from stdin. Default format: PrettyCompact on a TTY,
   TabSeparated when piped. --json selects JSONEachRow and cannot be combined
-  with --format; an explicit --format takes precedence over agent auto-JSON."
+  with --format; an explicit --format takes precedence over agent auto-JSON.
+  The Query API runs exactly one statement per request, so multi-statement SQL
+  (a typical ';'-separated .sql script) is rejected by the server. Run
+  statements one invocation at a time, or connect with `clickhouse client`
+  (see above) to run a script."
     )]
     Query {
         /// Service name to query (exactly one of --name or --id is required)
@@ -457,11 +461,14 @@ CONTEXT FOR AGENTS:
         #[arg(long, conflicts_with = "name")]
         id: Option<String>,
 
-        /// Execute a SQL query
+        /// Execute a SQL query (a single statement; the Query API does not
+        /// accept multi-statement SQL)
         #[arg(long, short, conflicts_with = "queries_file")]
         query: Option<String>,
 
-        /// Execute queries from a SQL file (use "-" for stdin)
+        /// Execute a query from a SQL file (use "-" for stdin); the file must
+        /// contain a single statement — multi-statement files are not
+        /// supported
         #[arg(long, conflicts_with = "query")]
         queries_file: Option<String>,
 


### PR DESCRIPTION
## What

This PR previously added client-side `;`-splitting of multi-statement SQL for `cloud service query`. That approach has been dropped: correctly finding statement boundaries means re-implementing ClickHouse's lexer (quoting, comments, heredocs, escapes) in the CLI, and any divergence silently corrupts what gets sent. We are not putting a query parser in the CLI.

Instead, this PR documents the limitation where users hit it:

- `--query` / `--queries-file` help text now says the SQL must be a single statement and that multi-statement files are not supported.
- The `CONTEXT FOR AGENTS` after-help explains that the Query API runs exactly one statement per request, so multi-statement SQL is rejected by the server, and points at `clickhouse client` (via `local use latest`) for running scripts.
- README says the same, including the server error users see (error 62, `Multi-statements are not allowed`).

No behavior changes; docs/help only.

## Stacked PR

Part of a stacked chain: this PR is based on `fix/611-private-endpoint-id-validation`, not `main`.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)