### PR TITLE
Fix cloud postgres delete --json returning raw API envelope

### DIFF
--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -990,14 +990,27 @@ pub async fn postgres_delete(
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
+
+    // The delete endpoint itself only ever returns the raw API envelope
+    // (`ApiResponse<serde_json::Value>`, no resource in `result`), so fetch the
+    // resource before deleting it and render that instead: `--json` output must
+    // stay consistent with every other `cloud postgres` subcommand, which emits
+    // the resource object rather than `{"status":...,"requestId":...}` (#614).
     let resp = client
+        .api()
+        .postgres_service_get(&org_id, postgres_id)
+        .await
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
+    let svc = unwrap_api(resp)?;
+
+    client
         .api()
         .postgres_service_delete(&org_id, postgres_id)
         .await
         .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&resp)?);
+        println!("{}", serde_json::to_string_pretty(&svc)?);
     } else {
         println!("Postgres service {} deletion initiated", postgres_id);
     }

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,5 +1,5 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
-use crate::cloud::output::{ABSENT, or_absent};
+use crate::cloud::output::{ABSENT, or_absent, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
@@ -996,12 +996,7 @@ pub async fn postgres_delete(
     // resource before deleting it and render that instead: `--json` output must
     // stay consistent with every other `cloud postgres` subcommand, which emits
     // the resource object rather than `{"status":...,"requestId":...}` (#614).
-    let resp = client
-        .api()
-        .postgres_service_get(&org_id, postgres_id)
-        .await
-        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
-    let svc = unwrap_api(resp)?;
+    let svc = client.get_postgres_service(&org_id, postgres_id).await?;
 
     client
         .api()
@@ -1009,10 +1004,15 @@ pub async fn postgres_delete(
         .await
         .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
 
+    // The service is already gone by here, so a closed stdout must not turn a
+    // completed deletion into a panic — see `print_line` and #598.
     if json {
-        println!("{}", serde_json::to_string_pretty(&svc)?);
+        print_line(serde_json::to_string_pretty(&svc)?);
     } else {
-        println!("Postgres service {} deletion initiated", postgres_id);
+        print_line(format!(
+            "Postgres service {} deletion initiated",
+            postgres_id
+        ));
     }
     Ok(())
 }
@@ -1318,6 +1318,22 @@ pub async fn postgres_state_change(
 // ---------------------------------------------------------------------------
 // Tests (CLI parsing + helpers)
 // ---------------------------------------------------------------------------
+
+impl CloudClient {
+    /// Fetch a single Postgres service.
+    pub async fn get_postgres_service(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+    ) -> CloudResult<PostgresService> {
+        let response = self
+            .api()
+            .postgres_service_get(org_id, postgres_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -581,6 +581,59 @@ async fn service_delete_running_conflict_suggests_force() {
     );
 }
 
+// ── Postgres deletion JSON output (issue #614) ────────────────────────────
+
+/// `postgres delete --json` must emit the Postgres resource object, not the
+/// raw `{"status":...,"requestId":...}` API envelope the delete endpoint
+/// itself returns: the handler fetches the resource before issuing the
+/// delete and renders that instead, consistent with every other
+/// `cloud postgres` subcommand.
+#[tokio::test]
+async fn postgres_delete_json_emits_the_resource_object_not_the_envelope() {
+    let mock = MockServer::start().await;
+    let postgres_id = "11111111-2222-3333-4444-555555555555";
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{postgres_id}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": postgres_id,
+                "name": "my-postgres",
+                "state": "running",
+            },
+            "status": 200,
+            "requestId": "stub-postgres-get",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{postgres_id}"
+        )))
+        .respond_with(successful_delete_response("stub-postgres-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["postgres", "delete", postgres_id, "--org-id", "org-1"],
+    );
+
+    assert_success(&output);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the resource object as JSON");
+    assert_eq!(stdout["id"], postgres_id);
+    assert_eq!(stdout["name"], "my-postgres");
+    assert_eq!(stdout["state"], "running");
+    assert!(
+        stdout.get("status").is_none() && stdout.get("requestId").is_none(),
+        "must not emit the raw API envelope, got: {stdout}"
+    );
+}
+
 const DELETE_TEST_SERVICE_ID: &str = "11111111-2222-3333-4444-555555555555";
 const DELETE_TEST_API_KEY_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const DELETE_TEST_PENDING_API_KEY_ID: &str = "99999999-8888-7777-6666-555555555555";


### PR DESCRIPTION
## Summary
- `cloud postgres delete --json` was printing the raw API envelope (`{"status":200,"requestId":"..."}`) returned directly by the delete endpoint, instead of the Postgres resource object every other `cloud postgres` subcommand emits under `--json`.
- The delete endpoint's response body genuinely has no resource in `result` (it's `ApiResponse<serde_json::Value>`), so the fix fetches the service via `postgres_service_get` before issuing the delete, and renders that fetched object under `--json`. Human output (`Postgres service <id> deletion initiated`) was already not envelope-shaped, so it is unchanged.
- Note: `cloud service delete --json` has the same underlying envelope shape (its `DeleteResponse` wrapper only carries `status`/`requestId`), but that's out of scope for this issue, which is specifically about `cloud postgres delete`.

This PR is part of a stacked chain based on `fix/613-postgres-usage-exit-codes` (not `main`).

## Test plan
- [x] Added `postgres_delete_json_emits_the_resource_object_not_the_envelope` wiremock subprocess test in `crates/clickhousectl/tests/cli_request_shape_test.rs`, asserting the resource fields are present and `status`/`requestId` are absent from `--json` output.
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p clickhousectl` (all passing)

Fixes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)