### PR TITLE
Document that cloud postgres delete needs no stop first

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ clickhousectl cloud postgres update <pg-id> \
   --size m7i.4xlarge \
   --add-tag env=prod --remove-tag legacy
 
-# Delete
+# Delete (works from any state, including running; no stop needed first)
 clickhousectl cloud postgres delete <pg-id>
 
 # CA certificates

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -82,6 +82,12 @@ pub enum PostgresCommands {
     },
 
     /// Delete a Postgres service
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Permanently deletes a managed Postgres service. This action is irreversible.
+  Unlike `cloud service delete`, no stop is needed first: the Cloud API deletes a
+  Postgres service from any state, including 'running'.
+  Related: `clickhousectl cloud postgres list` for service IDs.")]
     Delete {
         postgres_id: String,
         #[arg(long)]


### PR DESCRIPTION
Closes #615

> **Stacked PR** — based on `fix/614-postgres-delete-json` (#624), not `main`. Review/merge that one first; this diff is docs-only.

## What

Issue #615 asked for `--force` on `cloud postgres delete` so a running Postgres service can be deleted in one step, mirroring `cloud service delete --force`. Investigating it showed the premise does not hold for Postgres, so this PR documents the actual behaviour instead of adding a flag.

## Why there is no flag

`cloud service delete --force` exists because that API refuses to delete a running ClickHouse service and there is a stop command to issue first. The Postgres API has **neither** half:

- `DELETE /v1/organizations/{organizationId}/postgres/{postgresId}` declares no state precondition (checked against the live spec; the library's own integration cleanup, `tests/common/support.rs::ensure_postgres_gone`, deletes running services directly).
- `PATCH /v1/organizations/{organizationId}/postgres/{postgresId}/state` accepts only `restart`, `promote` and `switchover` — there is no Postgres stop command. `PostgresServiceSetStateCommand` has no `Stop` variant because the spec has no such value.

A running Postgres service is therefore already deleted in one step, with no flag. An earlier revision of this PR added `--force` as an accepted no-op for surface parity; that was dropped in review — a flag that performs nothing teaches the wrong thing about the one on `service delete`, which really does stop the service.

## Change

- `postgres delete` gains a `CONTEXT FOR AGENTS` help block stating that no stop is needed first because the Cloud API deletes a Postgres service from any state, including `running`.
- The README `postgres delete` example says the same in one line.

No code paths, request shapes, exit codes or `--json` output change. Passing `--force` remains a clap usage error (exit 2), as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
