### PR TITLE
Validate cloud postgres list --filter keys and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Manage ClickHouse Cloud managed Postgres services. All write commands require AP
 # List / get
 clickhousectl cloud postgres list
 clickhousectl cloud postgres list --filter state=running
+clickhousectl cloud postgres list --filter region=us-east-1 --filter isPrimary=true
 clickhousectl cloud postgres get <pg-id>
 
 # Create
@@ -731,6 +732,8 @@ clickhousectl cloud postgres switchover <pg-id>
 ```
 
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
+
+`postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.
 
 ### Backups
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -19,9 +19,10 @@ pub enum PostgresCommands {
     List {
         #[arg(long)]
         org_id: Option<String>,
-        /// Filter results by field (e.g. --filter state=running)
-        #[arg(long)]
-        filter: Vec<String>,
+        /// Filter results client-side by field (repeatable), e.g. --filter
+        /// state=running. Keys: state, region, name, provider, isPrimary
+        #[arg(long, value_parser = parse_postgres_list_filter)]
+        filter: Vec<PostgresListFilter>,
     },
 
     /// Get details for a single Postgres service
@@ -559,30 +560,99 @@ fn write_pem_file(path: &Path, pem: &str) -> CloudResult<()> {
     Ok(())
 }
 
-fn apply_filter(item: &PostgresServiceListItem, filters: &[String]) -> bool {
-    for filter in filters {
-        let Some((key, val)) = filter.split_once('=') else {
-            continue;
-        };
-        // A response field the API omitted matches no filter value.
-        let matches = match key.trim() {
-            "state" => item
-                .state
-                .as_ref()
-                .is_some_and(|s| format!("{:?}", s).eq_ignore_ascii_case(val)),
-            "region" => item.region.as_deref() == Some(val),
-            "name" => item.name.as_deref() == Some(val),
-            "provider" => item
-                .provider
-                .as_ref()
-                .is_some_and(|p| format!("{:?}", p).eq_ignore_ascii_case(val)),
-            _ => true,
-        };
-        if !matches {
-            return false;
-        }
+/// A parsed, validated `cloud postgres list --filter KEY=VALUE` predicate.
+///
+/// `--filter` is applied client-side over the list response, so an unsupported
+/// key cannot be rejected by the API. Parsing into this closed set at clap time
+/// is what makes an unknown key a usage error (exit 2) instead of a silently
+/// unfiltered full listing (issue #603).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PostgresListFilter {
+    /// Matched case-insensitively against the `state` wire value.
+    State(String),
+    /// Matched exactly against the region ID the API returned.
+    Region(String),
+    /// Matched exactly: service names are case-sensitive.
+    Name(String),
+    /// Matched case-insensitively against the `provider` wire value.
+    Provider(String),
+    /// Matched against the `isPrimary` boolean shown in the `Primary` column.
+    IsPrimary(bool),
+}
+
+/// The supported filter keys, in the order they are listed to the user. Spelled
+/// as the API's wire field names, which is what `--json` output shows.
+const POSTGRES_LIST_FILTER_KEYS: [&str; 5] = ["state", "region", "name", "provider", "isPrimary"];
+
+fn postgres_list_filter_keys() -> String {
+    POSTGRES_LIST_FILTER_KEYS.join(", ")
+}
+
+/// Parses one `KEY=VALUE` filter. Every rejection is a clap `value_parser`
+/// error, so the process exits 2 with the valid keys listed.
+fn parse_postgres_list_filter(raw: &str) -> std::result::Result<PostgresListFilter, String> {
+    let Some((key, value)) = raw.split_once('=') else {
+        return Err(format!(
+            "invalid filter '{raw}': expected KEY=VALUE, where KEY is one of {}",
+            postgres_list_filter_keys()
+        ));
+    };
+    let key = key.trim();
+    let value = value.trim();
+    // Keys are matched case-insensitively so `isprimary` works alongside the
+    // documented `isPrimary`; values keep their case for the per-key rules.
+    let canonical = POSTGRES_LIST_FILTER_KEYS
+        .into_iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(key))
+        .ok_or_else(|| {
+            format!(
+                "unknown filter key '{key}': expected one of {}",
+                postgres_list_filter_keys()
+            )
+        })?;
+    if value.is_empty() {
+        return Err(format!(
+            "filter '{canonical}' requires a value: expected {canonical}=VALUE"
+        ));
     }
-    true
+    Ok(match canonical {
+        "state" => PostgresListFilter::State(value.to_string()),
+        "region" => PostgresListFilter::Region(value.to_string()),
+        "name" => PostgresListFilter::Name(value.to_string()),
+        "provider" => PostgresListFilter::Provider(value.to_string()),
+        "isPrimary" => PostgresListFilter::IsPrimary(parse_filter_bool(canonical, value)?),
+        other => unreachable!("unhandled filter key '{other}'"),
+    })
+}
+
+/// `yes`/`no` are accepted because that is how the `Primary` column renders.
+fn parse_filter_bool(key: &str, value: &str) -> std::result::Result<bool, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "yes" => Ok(true),
+        "false" | "no" => Ok(false),
+        _ => Err(format!(
+            "invalid value '{value}' for filter '{key}': expected true or false"
+        )),
+    }
+}
+
+fn apply_filter(item: &PostgresServiceListItem, filters: &[PostgresListFilter]) -> bool {
+    // A response field the API omitted matches no filter value.
+    filters.iter().all(|filter| match filter {
+        // Compared against the serde wire value (`Display`), not the Rust
+        // Debug form: the latter never matches an `Unknown(..)` state.
+        PostgresListFilter::State(want) => item
+            .state
+            .as_ref()
+            .is_some_and(|state| state.to_string().eq_ignore_ascii_case(want)),
+        PostgresListFilter::Region(want) => item.region.as_deref() == Some(want.as_str()),
+        PostgresListFilter::Name(want) => item.name.as_deref() == Some(want.as_str()),
+        PostgresListFilter::Provider(want) => item
+            .provider
+            .as_ref()
+            .is_some_and(|provider| provider.to_string().eq_ignore_ascii_case(want)),
+        PostgresListFilter::IsPrimary(want) => item.is_primary == Some(*want),
+    })
 }
 
 fn state_label(s: Option<&clickhouse_cloud_api::models::PgStateProperty>) -> String {
@@ -730,7 +800,7 @@ pub struct PostgresRestoreOptions<'a> {
 pub async fn postgres_list(
     client: &CloudClient,
     org_id: Option<&str>,
-    filters: &[String],
+    filters: &[PostgresListFilter],
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
@@ -1372,11 +1442,93 @@ mod tests {
             "state=running",
             "--filter",
             "region=us-east-1",
+            "--filter",
+            "isPrimary=false",
         ]);
         let PostgresCommands::List { filter, .. } = cmd else {
             panic!("expected list");
         };
-        assert_eq!(filter, vec!["state=running", "region=us-east-1"]);
+        assert_eq!(
+            filter,
+            vec![
+                PostgresListFilter::State("running".to_string()),
+                PostgresListFilter::Region("us-east-1".to_string()),
+                PostgresListFilter::IsPrimary(false),
+            ]
+        );
+    }
+
+    fn list_filter_error(filter: &str) -> String {
+        let err = PostgresCli::try_parse_from(["clickhousectl", "list", "--filter", filter])
+            .err()
+            .expect("expected parse error");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        assert_eq!(err.exit_code(), 2, "filter errors must be usage errors");
+        err.to_string()
+    }
+
+    #[test]
+    fn rejects_an_unknown_postgres_list_filter_key() {
+        let message = list_filter_error("bogus=1");
+        assert!(message.contains("unknown filter key 'bogus'"), "{message}");
+        // The valid keys are listed so the user can correct the invocation.
+        for key in ["state", "region", "name", "provider", "isPrimary"] {
+            assert!(message.contains(key), "{key} missing from: {message}");
+        }
+    }
+
+    #[test]
+    fn rejects_a_postgres_list_filter_without_a_value() {
+        let message = list_filter_error("state=");
+        assert!(
+            message.contains("filter 'state' requires a value"),
+            "{message}"
+        );
+        // Whitespace-only is empty too.
+        let message = list_filter_error("name=   ");
+        assert!(
+            message.contains("filter 'name' requires a value"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_postgres_list_filter_without_an_equals_sign() {
+        let message = list_filter_error("state");
+        assert!(
+            message.contains("invalid filter 'state': expected KEY=VALUE"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_boolean_is_primary_postgres_list_filter() {
+        let message = list_filter_error("isPrimary=maybe");
+        assert!(
+            message.contains("invalid value 'maybe' for filter 'isPrimary'"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn parses_postgres_list_filter_keys_case_insensitively() {
+        assert_eq!(
+            parse_postgres_list_filter("ISPRIMARY=YES"),
+            Ok(PostgresListFilter::IsPrimary(true))
+        );
+        assert_eq!(
+            parse_postgres_list_filter(" state = running "),
+            Ok(PostgresListFilter::State("running".to_string()))
+        );
+        // `no`/`false` both read as false, matching the `Primary` column.
+        assert_eq!(
+            parse_postgres_list_filter("isPrimary=no"),
+            Ok(PostgresListFilter::IsPrimary(false))
+        );
+        assert_eq!(
+            parse_postgres_list_filter("isPrimary=false"),
+            Ok(PostgresListFilter::IsPrimary(false))
+        );
     }
 
     #[test]
@@ -2146,20 +2298,102 @@ mod tests {
         assert_eq!(enum_label(item.size.as_ref()), ABSENT);
     }
 
+    fn filters(raw: &[&str]) -> Vec<PostgresListFilter> {
+        raw.iter()
+            .map(|f| parse_postgres_list_filter(f).expect("valid filter"))
+            .collect()
+    }
+
     #[test]
     fn apply_filter_does_not_match_absent_response_fields() {
         let absent = PostgresServiceListItem::default();
-        assert!(!apply_filter(&absent, &["region=us-east-1".to_string()]));
-        assert!(!apply_filter(&absent, &["state=running".to_string()]));
-        // An unknown filter key stays permissive, as before.
-        assert!(apply_filter(&absent, &["bogus=1".to_string()]));
+        for filter in [
+            "region=us-east-1",
+            "state=running",
+            "name=my-pg",
+            "provider=aws",
+            "isPrimary=true",
+            "isPrimary=false",
+        ] {
+            assert!(
+                !apply_filter(&absent, &filters(&[filter])),
+                "absent field must not match {filter}"
+            );
+        }
 
         let present = PostgresServiceListItem {
             region: Some("us-east-1".to_string()),
             state: Some(clickhouse_cloud_api::models::PgStateProperty::Running),
+            name: Some("my-pg".to_string()),
+            provider: Some(clickhouse_cloud_api::models::PgProvider::Aws),
+            is_primary: Some(true),
             ..Default::default()
         };
-        assert!(apply_filter(&present, &["region=us-east-1".to_string()]));
-        assert!(apply_filter(&present, &["state=running".to_string()]));
+        assert!(apply_filter(
+            &present,
+            &filters(&[
+                "region=us-east-1",
+                "state=running",
+                "name=my-pg",
+                "provider=aws",
+                "isPrimary=true",
+            ])
+        ));
+        // Every filter must hold: one mismatch drops the item.
+        assert!(!apply_filter(
+            &present,
+            &filters(&["region=us-east-1", "isPrimary=false"])
+        ));
+    }
+
+    #[test]
+    fn apply_filter_compares_states_by_wire_value_not_debug_form() {
+        use clickhouse_cloud_api::models::PgStateProperty;
+
+        // Multi-word wire values and the `Unknown` catch-all both matched
+        // nothing while the comparison used `format!("{:?}")` (issue #603).
+        let restoring = PostgresServiceListItem {
+            state: Some(PgStateProperty::Restoring_backup),
+            ..Default::default()
+        };
+        assert!(apply_filter(
+            &restoring,
+            &filters(&["state=restoring_backup"])
+        ));
+        assert!(apply_filter(
+            &restoring,
+            &filters(&["state=RESTORING_BACKUP"])
+        ));
+        assert!(!apply_filter(&restoring, &filters(&["state=running"])));
+
+        let unknown = PostgresServiceListItem {
+            state: Some(PgStateProperty::Unknown("hibernating".to_string())),
+            ..Default::default()
+        };
+        assert!(apply_filter(&unknown, &filters(&["state=hibernating"])));
+        assert!(!apply_filter(&unknown, &filters(&["state=running"])));
+    }
+
+    #[test]
+    fn apply_filter_compares_providers_by_wire_value() {
+        use clickhouse_cloud_api::models::PgProvider;
+
+        let gcp = PostgresServiceListItem {
+            provider: Some(PgProvider::Gcp),
+            ..Default::default()
+        };
+        assert!(apply_filter(&gcp, &filters(&["provider=gcp"])));
+        assert!(!apply_filter(&gcp, &filters(&["provider=aws"])));
+
+        let unknown = PostgresServiceListItem {
+            provider: Some(PgProvider::Unknown("azure".to_string())),
+            ..Default::default()
+        };
+        assert!(apply_filter(&unknown, &filters(&["provider=azure"])));
+    }
+
+    #[test]
+    fn apply_filter_with_no_filters_keeps_every_item() {
+        assert!(apply_filter(&PostgresServiceListItem::default(), &[]));
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -634,6 +634,130 @@ async fn postgres_delete_json_emits_the_resource_object_not_the_envelope() {
     );
 }
 
+// ── Postgres list --filter validation (issue #603) ────────────────────────
+
+fn postgres_list_response() -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "result": [
+            {
+                "id": "11111111-2222-3333-4444-555555555555",
+                "name": "primary-pg",
+                "state": "running",
+                "region": "us-east-1",
+                "provider": "aws",
+                "isPrimary": true,
+            },
+            {
+                "id": "66666666-7777-8888-9999-000000000000",
+                "name": "replica-pg",
+                "state": "restoring_backup",
+                "region": "us-east-1",
+                "provider": "aws",
+                "isPrimary": false,
+            },
+            {
+                // Absent `isPrimary`/`state`: must match no filter value.
+                "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "name": "unknown-pg",
+                "region": "us-east-1",
+            },
+        ],
+        "status": 200,
+        "requestId": "stub-postgres-list",
+    }))
+}
+
+/// An unsupported `--filter` key used to return the whole unfiltered list with
+/// exit 0. It is now a clap usage error (exit 2) that names the valid keys, and
+/// no request reaches the API.
+#[tokio::test]
+async fn postgres_list_rejects_an_unknown_filter_key_before_calling_the_api() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres"))
+        .respond_with(postgres_list_response())
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    for filter in ["bogus=1", "state=", "isPrimary=maybe", "state"] {
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &["postgres", "list", "--org-id", "org-1", "--filter", filter],
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "--filter {filter} must be a usage error, stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "--filter {filter} must print no results, got: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres", "list", "--org-id", "org-1", "--filter", "bogus=1",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown filter key 'bogus'"), "{stderr}");
+    assert!(
+        stderr.contains("state, region, name, provider, isPrimary"),
+        "the valid keys must be listed, got: {stderr}"
+    );
+}
+
+/// `isPrimary` is a supported key (it is the `Primary` column), `state` matches
+/// the serde wire value including multi-word states, and an item whose field the
+/// API omitted matches nothing.
+#[tokio::test]
+async fn postgres_list_applies_supported_filters_client_side() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres"))
+        .respond_with(postgres_list_response())
+        .mount(&mock)
+        .await;
+
+    let names = |filter: &str| -> Vec<String> {
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &["postgres", "list", "--org-id", "org-1", "--filter", filter],
+        );
+        assert_success(&output);
+        let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+            .expect("stdout should be a JSON array");
+        stdout
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|item| item["name"].as_str().unwrap_or_default().to_string())
+            .collect()
+    };
+
+    assert_eq!(names("isPrimary=true"), vec!["primary-pg".to_string()]);
+    assert_eq!(names("isPrimary=false"), vec!["replica-pg".to_string()]);
+    assert_eq!(
+        names("state=restoring_backup"),
+        vec!["replica-pg".to_string()]
+    );
+    assert_eq!(names("state=running"), vec!["primary-pg".to_string()]);
+    assert_eq!(
+        names("region=us-east-1"),
+        vec![
+            "primary-pg".to_string(),
+            "replica-pg".to_string(),
+            "unknown-pg".to_string()
+        ]
+    );
+    assert_eq!(names("name=nope"), Vec::<String>::new());
+}
+
 const DELETE_TEST_SERVICE_ID: &str = "11111111-2222-3333-4444-555555555555";
 const DELETE_TEST_API_KEY_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const DELETE_TEST_PENDING_API_KEY_ID: &str = "99999999-8888-7777-6666-555555555555";


### PR DESCRIPTION
Fixes #603.

Stacked PR: base is `feat/615-postgres-delete-force`, not `main`.

## What was broken

`cloud postgres list --filter` matched keys with a catch-all `_ => true`, so any key outside `{state, region, name, provider}` — including `isPrimary`, which the listing shows as the `Primary` column — silently returned the **whole unfiltered list** with exit 0. A filter with an empty value (`state=`) or no `=` at all was ignored the same way. The `state` and `provider` predicates also compared `format!("{:?}", ..)` Debug forms against the wire value, so an `Unknown(..)` state could never match.

## What changed

- `--filter` is parsed at clap time by a `value_parser` into a closed `PostgresListFilter` enum. An unknown key, a missing `=`, an empty/whitespace-only value, or a non-boolean `isPrimary` is now a **usage error (exit 2)** whose message lists the valid keys — and no API request is issued.
- `isPrimary` is a supported key (`true`/`false`, plus the `yes`/`no` the `Primary` column renders).
- `state` and `provider` are compared against the serde wire value via `Display`, case-insensitively, so multi-word states and `Unknown(..)` values match correctly. `region`/`name` match exactly; keys themselves are case-insensitive.
- Per CLAUDE.md, an absent (API-omitted) response field matches no filter value, and all filters must hold for an item to be kept.
- README documents the supported keys, the matching rules and the exit-2 behaviour.

`cloud service list --filter` is **not** affected: it forwards server-side resource-tag filters (`tag:env=production`) to the API as query parameters and shares none of this code, so client-side key validation there would wrongly reject valid server-side syntax.

## Tests

- Clap parse tests next to the command definition: the accepted forms (including case-insensitive keys and `yes`/`no`), and one test per rejection asserting `ErrorKind::ValueValidation` and `exit_code() == 2`.
- Inline `apply_filter` tests: wire-value comparison for `state`/`provider` (including `Restoring_backup` and `Unknown(..)`), absent fields matching nothing, multi-filter conjunction, and the empty-filter passthrough.
- `tests/cli_request_shape_test.rs`: subprocess + wiremock tests pinning exit 2 with an `expect(0)` mock for invalid filters (no API call, no stdout), and the client-side filtering results for `isPrimary`, `state=restoring_backup`, `region` and a non-matching `name`.

Verified with `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p clickhousectl` (all green). The `clickhouse-cloud-api` crate is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)