### PR TITLE
Confirm postgres role changes with --wait instead of trusting acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,13 +727,20 @@ clickhousectl cloud postgres restore <pg-id> \
 
 # Lifecycle
 clickhousectl cloud postgres restart <pg-id>
-clickhousectl cloud postgres promote <pg-id>
-clickhousectl cloud postgres switchover <pg-id>
+clickhousectl cloud postgres promote <replica-id>
+clickhousectl cloud postgres promote <replica-id> --wait                    # poll until isPrimary=true
+clickhousectl cloud postgres switchover <primary-id>
+clickhousectl cloud postgres switchover <primary-id> --wait --wait-timeout 600
 ```
 
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
 
 `postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.
+
+`postgres promote` and `postgres switchover` change which service is primary. Both are issued as-is, and the API acknowledges them before (or without) applying them, so exit 0 on its own means accepted, not applied:
+
+- `--wait` (optionally `--wait-timeout SECONDS`, default 300) is how you confirm the roles actually changed. It polls the target every 5s until it reports the expected `isPrimary` — `true` for `promote`, the opposite of the value read just before the command for `switchover` — and exits 1 with the last observed role if it never does. stdout then carries the polled state rather than the state-change response, which for `promote` omits `isPrimary` entirely. Without `--wait` neither command reads the service. A `switchover --wait` whose pre-command read omits `isPrimary` is refused before the command is issued, because there is no prior role to compare a swap against.
+- The previous primary is demoted asynchronously and can keep reporting `isPrimary=true` for minutes afterwards. No client can see that pair from one service, so `promote` always reports the dual-primary window on stderr; verify with `clickhousectl cloud postgres list --filter isPrimary=true` that exactly one service is primary.
 
 ### Backups
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -167,6 +167,8 @@ CONTEXT FOR AGENTS:
   Manage ClickHouse Cloud managed Postgres services. Subcommands cover CRUD, lifecycle
   (restart/promote/switchover), CA certs, runtime config, password reset, read replicas,
   and point-in-time restore. Service IDs come from `postgres list`.
+  Role changes are eventually consistent: `promote` and `switchover` accept --wait to poll
+  until the target reports the new isPrimary and fail if it never does.
   Write commands require API key auth — OAuth is read-only.")]
     Postgres {
         #[command(subcommand)]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,5 +1,5 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
-use crate::cloud::output::{ABSENT, or_absent, print_line};
+use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
@@ -11,6 +11,7 @@ use clickhouse_cloud_api::models::{
 };
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tabled::{Table, Tabled, settings::Style};
 
 #[derive(Subcommand)]
@@ -151,15 +152,45 @@ CONTEXT FOR AGENTS:
     },
 
     /// Promote a read replica to primary
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Issues the promote command as-is. The API acknowledges it before (or without)
+  applying it, and the response omits isPrimary, so exit 0 alone does not confirm
+  the replica became primary. Pass --wait to poll the service until it reports
+  isPrimary=true; it exits 1 with the last observed role if that never happens.
+  The previous primary is demoted asynchronously and can keep reporting
+  isPrimary=true for minutes; verify with
+  `clickhousectl cloud postgres list --filter isPrimary=true` that exactly one
+  service is primary.")]
     Promote {
         postgres_id: String,
+        /// Poll until the service reports isPrimary=true, and fail if it never does
+        #[arg(long)]
+        wait: bool,
+        /// Seconds to poll for with --wait (default: 300)
+        #[arg(long, requires = "wait", value_name = "SECONDS")]
+        wait_timeout: Option<u16>,
         #[arg(long)]
         org_id: Option<String>,
     },
 
     /// Switch over between primary and replica
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Issues the switchover command as-is. The API acknowledges it before (or without)
+  applying it, so exit 0 alone does not confirm the roles swapped. Pass --wait to
+  read the service's isPrimary first and poll until it reports the opposite value;
+  it exits 1 with the last observed role if that never happens, and refuses before
+  issuing the command when the pre-command read omits isPrimary. Without --wait no
+  read is performed.")]
     Switchover {
         postgres_id: String,
+        /// Poll until the roles actually swap, and fail if they never do
+        #[arg(long)]
+        wait: bool,
+        /// Seconds to poll for with --wait (default: 300)
+        #[arg(long, requires = "wait", value_name = "SECONDS")]
+        wait_timeout: Option<u16>,
         #[arg(long)]
         org_id: Option<String>,
     },
@@ -416,26 +447,36 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
         }
         PostgresCommands::Promote {
             postgres_id,
+            wait,
+            wait_timeout,
             org_id,
         } => {
-            postgres_state_change(
+            postgres_role_change(
                 client,
                 &postgres_id,
-                PostgresServiceSetStateCommand::Promote,
-                org_id.as_deref(),
+                PostgresRoleCommand::Promote,
+                RoleChangeOptions {
+                    wait: wait_duration(wait, wait_timeout),
+                    org_id: org_id.as_deref(),
+                },
                 json,
             )
             .await
         }
         PostgresCommands::Switchover {
             postgres_id,
+            wait,
+            wait_timeout,
             org_id,
         } => {
-            postgres_state_change(
+            postgres_role_change(
                 client,
                 &postgres_id,
-                PostgresServiceSetStateCommand::Switchover,
-                org_id.as_deref(),
+                PostgresRoleCommand::Switchover,
+                RoleChangeOptions {
+                    wait: wait_duration(wait, wait_timeout),
+                    org_id: org_id.as_deref(),
+                },
                 json,
             )
             .await
@@ -675,26 +716,32 @@ fn enum_label<T: serde::Serialize>(v: Option<&T>) -> String {
     }
 }
 
+// `print_line`, not `println!`: role changes render this after `--wait`
+// polling, minutes after the caller may have stopped reading, and a closed
+// stdout must not turn a completed operation into a panic (#598).
 fn render_postgres_service(svc: &PostgresService) {
-    println!("  ID: {}", or_absent(svc.id.as_ref()));
-    println!("  Name: {}", or_absent(svc.name.as_deref()));
-    println!("  State: {}", state_label(svc.state.as_ref()));
-    println!("  Provider: {}", enum_label(svc.provider.as_ref()));
-    println!("  Region: {}", or_absent(svc.region.as_deref()));
-    println!("  Size: {}", enum_label(svc.size.as_ref()));
-    println!("  Storage (GB): {}", or_absent(svc.storage_size));
-    println!(
+    print_line(format!("  ID: {}", or_absent(svc.id.as_ref())));
+    print_line(format!("  Name: {}", or_absent(svc.name.as_deref())));
+    print_line(format!("  State: {}", state_label(svc.state.as_ref())));
+    print_line(format!("  Provider: {}", enum_label(svc.provider.as_ref())));
+    print_line(format!("  Region: {}", or_absent(svc.region.as_deref())));
+    print_line(format!("  Size: {}", enum_label(svc.size.as_ref())));
+    print_line(format!("  Storage (GB): {}", or_absent(svc.storage_size)));
+    print_line(format!(
         "  PG version: {}",
         enum_label(svc.postgres_version.as_ref())
-    );
-    println!("  HA type: {}", enum_label(svc.ha_type.as_ref()));
-    println!("  Primary: {}", or_absent(svc.is_primary));
-    println!("  Host: {}", or_absent(svc.hostname.as_deref()));
-    println!("  Username: {}", or_absent(svc.username.as_deref()));
-    println!(
+    ));
+    print_line(format!("  HA type: {}", enum_label(svc.ha_type.as_ref())));
+    print_line(format!("  Primary: {}", or_absent(svc.is_primary)));
+    print_line(format!("  Host: {}", or_absent(svc.hostname.as_deref())));
+    print_line(format!(
+        "  Username: {}",
+        or_absent(svc.username.as_deref())
+    ));
+    print_line(format!(
         "  Created: {}",
         or_absent(svc.created_at.map(|c| c.to_rfc3339()))
-    );
+    ));
     if let Some(svc_tags) = svc.tags.as_ref().filter(|t| !t.is_empty()) {
         let tags: Vec<String> = svc_tags
             .iter()
@@ -703,7 +750,7 @@ fn render_postgres_service(svc: &PostgresService) {
                 (key, None) => or_absent(key).to_string(),
             })
             .collect();
-        println!("  Tags: {}", tags.join(", "));
+        print_line(format!("  Tags: {}", tags.join(", ")));
     }
 }
 
@@ -1365,6 +1412,10 @@ pub async fn postgres_restore(
     Ok(())
 }
 
+/// Issues a state command that does not change which service is primary.
+///
+/// `promote` and `switchover` go through [`postgres_role_change`] instead, which
+/// adds the `--wait` convergence polling this has no use for.
 pub async fn postgres_state_change(
     client: &CloudClient,
     postgres_id: &str,
@@ -1392,7 +1443,7 @@ pub async fn postgres_state_change(
 }
 
 // ---------------------------------------------------------------------------
-// Tests (CLI parsing + helpers)
+// Role changes: promote / switchover (issue #604)
 // ---------------------------------------------------------------------------
 
 impl CloudClient {
@@ -1409,7 +1460,280 @@ impl CloudClient {
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
     }
+
+    /// Issue a `restart`/`promote`/`switchover` command against a Postgres service.
+    pub async fn set_postgres_service_state(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+        command: PostgresServiceSetStateCommand,
+    ) -> CloudResult<PostgresService> {
+        let request = PostgresServiceSetState { command };
+        let response = self
+            .api()
+            .postgres_service_patch_state(org_id, postgres_id, &request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
 }
+
+/// Seconds `--wait` polls for when `--wait-timeout` is not given.
+const DEFAULT_ROLE_WAIT_SECS: u16 = 300;
+
+/// Gap between role polls. The API acknowledges a role change long before it
+/// applies it, so polling faster than this only burns rate limit.
+const ROLE_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// The `cloud postgres` commands that change which service is primary.
+///
+/// `restart` is not one of them: it keeps going through
+/// [`postgres_state_change`], which needs no role bookkeeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostgresRoleCommand {
+    Promote,
+    Switchover,
+}
+
+impl PostgresRoleCommand {
+    fn api_command(self) -> PostgresServiceSetStateCommand {
+        match self {
+            Self::Promote => PostgresServiceSetStateCommand::Promote,
+            Self::Switchover => PostgresServiceSetStateCommand::Switchover,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Promote => "promote",
+            Self::Switchover => "switchover",
+        }
+    }
+}
+
+pub struct RoleChangeOptions<'a> {
+    /// How long to poll for convergence, or `None` to return once the API
+    /// acknowledges the command.
+    pub wait: Option<Duration>,
+    pub org_id: Option<&'a str>,
+}
+
+/// Translates `--wait` / `--wait-timeout` into a polling budget.
+fn wait_duration(wait: bool, wait_timeout: Option<u16>) -> Option<Duration> {
+    wait.then(|| Duration::from_secs(u64::from(wait_timeout.unwrap_or(DEFAULT_ROLE_WAIT_SECS))))
+}
+
+/// The `isPrimary` value the target must report once `cmd` has taken effect.
+///
+/// `None` means the CLI has nothing to compare against: a switchover swaps the
+/// target's role, so without the pre-command `isPrimary` there is no swap to
+/// detect.
+fn expected_primary_after(cmd: PostgresRoleCommand, before: Option<bool>) -> Option<bool> {
+    match cmd {
+        PostgresRoleCommand::Promote => Some(true),
+        PostgresRoleCommand::Switchover => before.map(|primary| !primary),
+    }
+}
+
+/// Whether the polled service has reached the expected role.
+#[derive(Debug, PartialEq)]
+enum RoleConvergence {
+    Converged(PostgresService),
+    NotConverged(PostgresService),
+}
+
+/// Polls `fetch` until the service reports `isPrimary=expected_primary`.
+///
+/// The first poll happens immediately: `promote` flips the replica in under a
+/// second, so the common case must not pay a full interval.
+async fn poll_role_convergence<F, Fut>(
+    mut fetch: F,
+    expected_primary: bool,
+    timeout: Duration,
+    interval: Duration,
+) -> CloudResult<RoleConvergence>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = CloudResult<PostgresService>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let svc = fetch().await?;
+        if svc.is_primary == Some(expected_primary) {
+            return Ok(RoleConvergence::Converged(svc));
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(RoleConvergence::NotConverged(svc));
+        }
+        tokio::time::sleep(interval.min(remaining)).await;
+    }
+}
+
+/// Error text for a role change the API accepted but never applied.
+fn role_timeout_message(
+    cmd: PostgresRoleCommand,
+    postgres_id: &str,
+    expected_primary: bool,
+    observed: Option<bool>,
+    timeout: Duration,
+) -> String {
+    format!(
+        "{} did not take effect within {}s: Postgres service {postgres_id} reports isPrimary={} \
+         (expected {expected_primary}). The API accepted the request; re-check with \
+         `clickhousectl cloud postgres get {postgres_id}`.",
+        cmd.label(),
+        timeout.as_secs(),
+        or_absent(observed),
+    )
+}
+
+/// stderr notes for a role change, in print order.
+///
+/// Both commands are eventually consistent and neither reports that: the
+/// `promote` response omits `isPrimary` entirely and the old primary has been
+/// observed reporting `isPrimary=true` for minutes afterwards, so a caller that
+/// trusts exit 0 sees two primaries (#604).
+fn role_change_notes(cmd: PostgresRoleCommand, postgres_id: &str, waited: bool) -> Vec<String> {
+    let mut notes = Vec::new();
+    match cmd {
+        PostgresRoleCommand::Promote => {
+            notes.push(
+                "The previous primary is demoted asynchronously and can keep reporting \
+                 isPrimary=true for several minutes; verify with `clickhousectl cloud postgres \
+                 list --filter isPrimary=true` that exactly one service is primary."
+                    .to_string(),
+            );
+            if !waited {
+                notes.push(format!(
+                    "The promote response does not carry the new role; pass --wait to poll \
+                     Postgres service {postgres_id} until it reports isPrimary=true."
+                ));
+            }
+        }
+        PostgresRoleCommand::Switchover => {
+            if !waited {
+                notes.push(format!(
+                    "Switchover is acknowledged before (or without) the roles swapping; pass \
+                     --wait to poll Postgres service {postgres_id} until they actually change."
+                ));
+            }
+        }
+    }
+    notes
+}
+
+/// The `isPrimary` value `--wait` polls for, resolved before the command is issued.
+///
+/// `promote` always targets `true`. A switchover swaps the target's role, so it
+/// reads the service first and refuses when that read omits `isPrimary`: with no
+/// pre-command role to compare a swap against, `--wait` could only report an
+/// unverifiable success (#604). This is the only place a role change reads the
+/// service before issuing the command.
+async fn wait_target(
+    client: &CloudClient,
+    org_id: &str,
+    postgres_id: &str,
+    cmd: PostgresRoleCommand,
+) -> CloudResult<bool> {
+    let before = match cmd {
+        PostgresRoleCommand::Promote => None,
+        PostgresRoleCommand::Switchover => {
+            client
+                .get_postgres_service(org_id, postgres_id)
+                .await?
+                .is_primary
+        }
+    };
+    expected_primary_after(cmd, before).ok_or_else(|| {
+        CloudError::new(format!(
+            "--wait cannot confirm a switchover of Postgres service {postgres_id}: the API \
+             response omitted isPrimary, so there is no pre-command role to compare a swap \
+             against. Re-run without --wait to issue the switchover unconfirmed."
+        ))
+    })
+}
+
+/// Handles `cloud postgres promote` and `cloud postgres switchover`.
+///
+/// The command is issued as-is; the API acknowledges it before (or without)
+/// applying it, so `--wait` is the only way to learn whether a role changed.
+pub async fn postgres_role_change(
+    client: &CloudClient,
+    postgres_id: &str,
+    cmd: PostgresRoleCommand,
+    opts: RoleChangeOptions<'_>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, opts.org_id).await?;
+
+    let wait = match opts.wait {
+        Some(timeout) => Some((
+            timeout,
+            wait_target(client, &org_id, postgres_id, cmd).await?,
+        )),
+        None => None,
+    };
+
+    let accepted = client
+        .set_postgres_service_state(&org_id, postgres_id, cmd.api_command())
+        .await?;
+
+    let mut timeout_error = None;
+    let mut svc = accepted;
+
+    if let Some((timeout, expected_primary)) = wait {
+        let outcome = poll_role_convergence(
+            || client.get_postgres_service(&org_id, postgres_id),
+            expected_primary,
+            timeout,
+            ROLE_POLL_INTERVAL,
+        )
+        .await?;
+        svc = match outcome {
+            RoleConvergence::Converged(svc) => svc,
+            RoleConvergence::NotConverged(svc) => {
+                timeout_error = Some(role_timeout_message(
+                    cmd,
+                    postgres_id,
+                    expected_primary,
+                    svc.is_primary,
+                    timeout,
+                ));
+                svc
+            }
+        };
+    }
+
+    let waited = wait.is_some();
+    for note in role_change_notes(cmd, postgres_id, waited) {
+        eprint_line(note);
+    }
+
+    // `print_line`, not `println!`: with --wait this output can land minutes
+    // after the caller stopped reading, and a closed pipe must not turn a
+    // completed role change into a panic (#598).
+    if json {
+        print_line(serde_json::to_string_pretty(&svc)?);
+    } else {
+        print_line(match (timeout_error.is_some(), waited) {
+            (true, _) => format!("{} not confirmed", cmd.label()),
+            (false, true) => format!("{} confirmed", cmd.label()),
+            (false, false) => format!("{} accepted", cmd.label()),
+        });
+        print_line("");
+        render_postgres_service(&svc);
+    }
+
+    match timeout_error {
+        Some(message) => Err(CloudError::new(message)),
+        None => Ok(()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (CLI parsing + helpers)
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -2029,6 +2353,297 @@ mod tests {
             parse_postgres(&["clickhousectl", "cloud", "postgres", "switchover", "pg-1"]),
             PostgresCommands::Switchover { .. }
         ));
+    }
+
+    // --- role change (promote / switchover) parsing, issue #604 ---
+
+    #[test]
+    fn promote_and_switchover_do_not_wait_by_default() {
+        let PostgresCommands::Promote {
+            wait, wait_timeout, ..
+        } = parse_postgres(&["clickhousectl", "cloud", "postgres", "promote", "pg-1"])
+        else {
+            panic!("expected promote");
+        };
+        assert!(!wait);
+        assert_eq!(wait_timeout, None);
+
+        let PostgresCommands::Switchover {
+            wait, wait_timeout, ..
+        } = parse_postgres(&["clickhousectl", "cloud", "postgres", "switchover", "pg-1"])
+        else {
+            panic!("expected switchover");
+        };
+        assert!(!wait);
+        assert_eq!(wait_timeout, None);
+    }
+
+    #[test]
+    fn promote_parses_wait_flags() {
+        let PostgresCommands::Promote {
+            postgres_id,
+            wait,
+            wait_timeout,
+            org_id,
+        } = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "promote",
+            "pg-1",
+            "--wait",
+            "--wait-timeout",
+            "45",
+            "--org-id",
+            "org-1",
+        ])
+        else {
+            panic!("expected promote");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert!(wait);
+        assert_eq!(wait_timeout, Some(45));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn switchover_parses_wait_flags() {
+        let PostgresCommands::Switchover {
+            postgres_id,
+            wait,
+            wait_timeout,
+            ..
+        } = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "switchover",
+            "pg-1",
+            "--wait",
+            "--wait-timeout",
+            "600",
+        ])
+        else {
+            panic!("expected switchover");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert!(wait);
+        assert_eq!(wait_timeout, Some(600));
+    }
+
+    /// `--wait-timeout` without `--wait` would silently not wait, so clap
+    /// rejects it as a usage error instead.
+    #[test]
+    fn wait_timeout_requires_wait() {
+        for command in ["promote", "switchover"] {
+            let err = match PostgresCli::try_parse_from([
+                "clickhousectl",
+                command,
+                "pg-1",
+                "--wait-timeout",
+                "30",
+            ]) {
+                Ok(_) => {
+                    panic!("--wait-timeout without --wait should be a usage error for {command}")
+                }
+                Err(err) => err,
+            };
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "{command}: {err}"
+            );
+            assert_eq!(err.exit_code(), 2, "{command}: {err}");
+        }
+    }
+
+    #[test]
+    fn wait_duration_maps_flags_to_a_polling_budget() {
+        assert_eq!(wait_duration(false, None), None);
+        assert_eq!(wait_duration(false, Some(10)), None);
+        assert_eq!(
+            wait_duration(true, None),
+            Some(Duration::from_secs(u64::from(DEFAULT_ROLE_WAIT_SECS)))
+        );
+        assert_eq!(wait_duration(true, Some(30)), Some(Duration::from_secs(30)));
+        // A zero budget still polls once: `poll_role_convergence` fetches
+        // before it checks the deadline.
+        assert_eq!(wait_duration(true, Some(0)), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn expected_primary_after_a_role_change() {
+        assert_eq!(
+            expected_primary_after(PostgresRoleCommand::Promote, None),
+            Some(true)
+        );
+        assert_eq!(
+            expected_primary_after(PostgresRoleCommand::Promote, Some(false)),
+            Some(true)
+        );
+        assert_eq!(
+            expected_primary_after(PostgresRoleCommand::Switchover, Some(true)),
+            Some(false)
+        );
+        assert_eq!(
+            expected_primary_after(PostgresRoleCommand::Switchover, Some(false)),
+            Some(true)
+        );
+        // Nothing to compare against, so nothing to wait for.
+        assert_eq!(
+            expected_primary_after(PostgresRoleCommand::Switchover, None),
+            None
+        );
+    }
+
+    // --- role change convergence polling, issue #604 ---
+
+    fn primary_response(is_primary: Option<bool>) -> PostgresService {
+        PostgresService {
+            name: Some("pg".to_string()),
+            is_primary,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn polling_returns_immediately_when_the_role_already_converged() {
+        let mut calls = 0;
+        let outcome = poll_role_convergence(
+            || {
+                calls += 1;
+                std::future::ready(Ok(primary_response(Some(true))))
+            },
+            true,
+            Duration::from_secs(60),
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(outcome, RoleConvergence::Converged(_)));
+        assert_eq!(calls, 1, "the first poll must not wait for an interval");
+    }
+
+    #[tokio::test]
+    async fn polling_converges_once_the_role_flips() {
+        let mut calls = 0;
+        let outcome = poll_role_convergence(
+            || {
+                calls += 1;
+                std::future::ready(Ok(primary_response(Some(calls >= 3))))
+            },
+            true,
+            Duration::from_secs(60),
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        let RoleConvergence::Converged(svc) = outcome else {
+            panic!("expected convergence");
+        };
+        assert_eq!(svc.is_primary, Some(true));
+        assert_eq!(calls, 3);
+    }
+
+    /// A role change the API accepted but never applied is the #604 failure:
+    /// polling must report the last observed role, not success.
+    #[tokio::test]
+    async fn polling_reports_non_convergence_with_the_last_observed_role() {
+        let outcome = poll_role_convergence(
+            || std::future::ready(Ok(primary_response(Some(true)))),
+            false,
+            Duration::from_millis(20),
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        let RoleConvergence::NotConverged(svc) = outcome else {
+            panic!("expected non-convergence");
+        };
+        assert_eq!(svc.is_primary, Some(true));
+    }
+
+    /// An omitted `isPrimary` is not the expected value, so it cannot count as
+    /// convergence — the promote response omits it entirely.
+    #[tokio::test]
+    async fn an_absent_is_primary_never_counts_as_converged() {
+        let outcome = poll_role_convergence(
+            || std::future::ready(Ok(primary_response(None))),
+            true,
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(outcome, RoleConvergence::NotConverged(_)));
+    }
+
+    #[tokio::test]
+    async fn polling_propagates_a_fetch_error() {
+        let error = poll_role_convergence(
+            || std::future::ready(Err(CloudError::new("boom"))),
+            true,
+            Duration::from_secs(60),
+            Duration::ZERO,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.message, "boom");
+    }
+
+    #[test]
+    fn role_timeout_message_names_the_observed_role() {
+        let message = role_timeout_message(
+            PostgresRoleCommand::Switchover,
+            "pg-1",
+            false,
+            Some(true),
+            Duration::from_secs(300),
+        );
+        assert!(
+            message.contains("switchover did not take effect within 300s")
+                && message.contains("isPrimary=true")
+                && message.contains("expected false")
+                && message.contains("postgres get pg-1"),
+            "unexpected message: {message}"
+        );
+
+        let absent = role_timeout_message(
+            PostgresRoleCommand::Promote,
+            "pg-1",
+            true,
+            None,
+            Duration::from_secs(5),
+        );
+        assert!(
+            absent.contains(&format!("isPrimary={ABSENT}")),
+            "an omitted isPrimary must render as {ABSENT}: {absent}"
+        );
+    }
+
+    #[test]
+    fn role_change_notes_warn_about_eventual_consistency() {
+        let promote_no_wait = role_change_notes(PostgresRoleCommand::Promote, "pg-1", false);
+        assert_eq!(promote_no_wait.len(), 2);
+        assert!(promote_no_wait[0].contains("previous primary is demoted asynchronously"));
+        assert!(promote_no_wait[1].contains("--wait"));
+
+        // With --wait the CLI already confirmed the new primary, but the old
+        // primary's demotion is still not something it can see.
+        let promote_waited = role_change_notes(PostgresRoleCommand::Promote, "pg-1", true);
+        assert_eq!(promote_waited.len(), 1);
+        assert!(promote_waited[0].contains("previous primary"));
+
+        let switchover_no_wait = role_change_notes(PostgresRoleCommand::Switchover, "pg-1", false);
+        assert_eq!(switchover_no_wait.len(), 1);
+        assert!(
+            switchover_no_wait[0].contains("acknowledged before (or without) the roles swapping")
+        );
+        assert!(switchover_no_wait[0].contains("--wait"));
+        assert!(
+            role_change_notes(PostgresRoleCommand::Switchover, "pg-1", true).is_empty(),
+            "a confirmed swap needs no caveat"
+        );
     }
 
     // --- helper unit tests ---

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -758,6 +758,300 @@ async fn postgres_list_applies_supported_filters_client_side() {
     assert_eq!(names("name=nope"), Vec::<String>::new());
 }
 
+// ── Postgres promote / switchover role changes (issue #604) ───────────────
+
+const ROLE_TEST_POSTGRES_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+fn postgres_role_service(ha_type: &str, is_primary: Option<bool>) -> serde_json::Value {
+    let mut service = serde_json::json!({
+        "id": ROLE_TEST_POSTGRES_ID,
+        "name": "my-postgres",
+        "state": "running",
+        "haType": ha_type,
+    });
+    if let Some(is_primary) = is_primary {
+        service["isPrimary"] = serde_json::json!(is_primary);
+    }
+    service
+}
+
+/// Mounts the GET a role change may issue: only `--wait` reads the service,
+/// once before a switchover to learn the prior role and then once per poll.
+/// `expected_calls` pins that, so a command run without `--wait` is verified to
+/// issue no GET at all.
+async fn mount_postgres_get(mock: &MockServer, service: serde_json::Value, expected_calls: u64) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{ROLE_TEST_POSTGRES_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": service,
+            "status": 200,
+            "requestId": "stub-postgres-get",
+        })))
+        .expect(expected_calls)
+        .mount(mock)
+        .await;
+}
+
+async fn mount_postgres_state(mock: &MockServer, service: serde_json::Value, expected_calls: u64) {
+    Mock::given(method("PATCH"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{ROLE_TEST_POSTGRES_ID}/state"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": service,
+            "status": 200,
+            "requestId": "stub-postgres-state",
+        })))
+        .expect(expected_calls)
+        .mount(mock)
+        .await;
+}
+
+/// Without `--wait`, switchover is issued as-is: no read of the service before
+/// or after, just the state PATCH, and stdout is the state-change response.
+#[tokio::test]
+async fn postgres_switchover_without_wait_issues_only_the_state_change() {
+    let mock = MockServer::start().await;
+    mount_postgres_get(&mock, postgres_role_service("sync", Some(true)), 0).await;
+    mount_postgres_state(&mock, postgres_role_service("sync", Some(true)), 1).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "switchover",
+            ROLE_TEST_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![(
+            "PATCH".to_string(),
+            format!("/v1/organizations/org-1/postgres/{ROLE_TEST_POSTGRES_ID}/state")
+        )],
+        "switchover without --wait must issue exactly one request"
+    );
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the resource object as JSON");
+    assert_eq!(stdout["id"], ROLE_TEST_POSTGRES_ID);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--wait"),
+        "should say --wait is how the swap gets confirmed, got: {stderr}"
+    );
+}
+
+/// The #604 failure: the state endpoint answers 200 and the roles never swap.
+/// With `--wait` the CLI polls the service and exits non-zero when the role it
+/// captured before the command is still the role afterwards.
+#[tokio::test]
+async fn postgres_switchover_wait_fails_when_the_roles_never_swap() {
+    let mock = MockServer::start().await;
+    // One read before the command to learn the prior role, one poll after it.
+    mount_postgres_get(&mock, postgres_role_service("sync", Some(true)), 2).await;
+    mount_postgres_state(&mock, postgres_role_service("sync", Some(true)), 1).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "switchover",
+            ROLE_TEST_POSTGRES_ID,
+            "--wait",
+            "--wait-timeout",
+            "0",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("switchover did not take effect within 0s")
+            && stderr.contains("isPrimary=true")
+            && stderr.contains("expected false"),
+        "should report non-convergence, got: {stderr}"
+    );
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("the last observed state should still be emitted as JSON");
+    assert_eq!(stdout["isPrimary"], serde_json::json!(true));
+}
+
+/// `--wait` succeeds once the target reports the new role, and still says the
+/// old primary's demotion is not something the CLI can confirm.
+#[tokio::test]
+async fn postgres_promote_wait_confirms_the_new_primary() {
+    let mock = MockServer::start().await;
+    // Promote always targets isPrimary=true, so nothing is read before the
+    // command; the single poll afterwards sees the new primary.
+    mount_postgres_get(&mock, postgres_role_service("async", Some(true)), 1).await;
+    // The promote response omits `isPrimary` entirely, exactly as the API does.
+    mount_postgres_state(&mock, postgres_role_service("async", None), 1).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "promote",
+            ROLE_TEST_POSTGRES_ID,
+            "--wait",
+            "--wait-timeout",
+            "0",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the polled resource object as JSON");
+    assert_eq!(
+        stdout["isPrimary"],
+        serde_json::json!(true),
+        "the polled state must replace the promote response that omits isPrimary"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("previous primary is demoted asynchronously"),
+        "the dual-primary window must be reported, got: {stderr}"
+    );
+}
+
+/// Without `--wait`, promote keeps its old behaviour (exit 0 on acceptance, no
+/// read of the service) but says on stderr that the role change is not confirmed.
+#[tokio::test]
+async fn postgres_promote_without_wait_reports_eventual_consistency() {
+    let mock = MockServer::start().await;
+    mount_postgres_get(&mock, postgres_role_service("async", Some(false)), 0).await;
+    mount_postgres_state(&mock, postgres_role_service("async", None), 1).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "promote",
+            ROLE_TEST_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the resource object as JSON");
+    assert!(
+        stdout.get("isPrimary").is_none(),
+        "an omitted isPrimary must stay omitted, got: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("previous primary is demoted asynchronously") && stderr.contains("--wait"),
+        "should point at --wait and the dual-primary window, got: {stderr}"
+    );
+}
+
+/// Every response field is optional, so the pre-command GET can omit
+/// `isPrimary`. A switchover swaps that role, so `--wait` then has nothing to
+/// confirm a swap against: the command must refuse before issuing a state
+/// change it could only report as an unverified success (#604).
+#[tokio::test]
+async fn postgres_switchover_wait_refuses_an_unknown_prior_role() {
+    let mock = MockServer::start().await;
+    mount_postgres_get(&mock, postgres_role_service("sync", None), 1).await;
+    mount_postgres_state(&mock, postgres_role_service("sync", None), 0).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "switchover",
+            ROLE_TEST_POSTGRES_ID,
+            "--wait",
+            "--wait-timeout",
+            "0",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("omitted isPrimary") && stderr.contains("--wait"),
+        "should explain why --wait cannot confirm the swap, got: {stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a refused switchover must print no resource, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// Start a human-mode (no `--json`, no agent env) switchover without waiting
+/// for it, so the test can close its stdout first (see the #598 tests).
+fn spawn_postgres_switchover_human(mock: &MockServer, project_dir: &Path) -> std::process::Child {
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", project_dir.join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project_dir)
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "postgres",
+            "switchover",
+            ROLE_TEST_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl")
+}
+
+/// The human rendering of the role-change result lands after the command
+/// already took effect — with `--wait`, minutes after — so a closed stdout must
+/// not turn an accepted switchover into a panic and exit 101 (#598).
+#[tokio::test]
+async fn postgres_switchover_human_output_survives_a_closed_stdout() {
+    let mock = MockServer::start().await;
+    mount_postgres_get(&mock, postgres_role_service("sync", Some(true)), 0).await;
+    mount_postgres_state(&mock, postgres_role_service("sync", Some(true)), 1).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("home")).unwrap();
+    let mut child = spawn_postgres_switchover_human(&mock, dir.path());
+    drop(child.stdout.take().expect("stdout was piped"));
+    let status = child.wait().expect("failed to wait for clickhousectl");
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a closed stdout must not turn an accepted switchover into a panic"
+    );
+    let shape = received_request_shape(&mock).await;
+    assert!(
+        shape.contains(&(
+            "PATCH".to_string(),
+            format!("/v1/organizations/org-1/postgres/{ROLE_TEST_POSTGRES_ID}/state")
+        )),
+        "the switchover must still reach the API: {shape:?}"
+    );
+}
+
 const DELETE_TEST_SERVICE_ID: &str = "11111111-2222-3333-4444-555555555555";
 const DELETE_TEST_API_KEY_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const DELETE_TEST_PENDING_API_KEY_ID: &str = "99999999-8888-7777-6666-555555555555";


### PR DESCRIPTION
Fixes #604

> **Stacked PR** — based on `fix/603-postgres-filter-validation` (#626), not `main`. The promote note relies on that branch's `postgres list --filter isPrimary=` support.

## What was wrong

`cloud postgres switchover` exited 0 after issuing a switchover the API accepted but never performed, and `promote` exited 0 while both the replica and the old primary reported `isPrimary=true` for minutes. The state endpoint acknowledges a role change before — or without — applying it, and returns 200 either way (the spec documents only 200/400/500 and no "no standby" error). Acceptance is not evidence that a role changed.

## What this does — and deliberately does not do

The CLI does **not** try to predict what the server will do. An earlier revision of this PR pre-read the service and refused `switchover` when `haType` was `none`, with a `--force` bypass. That was a client-side guess about server behaviour that was never verified against the live API, so it was dropped in review. Without `--wait`, switchover and promote are issued exactly as before: one PATCH, no pre-command read, print the acknowledgement.

What changes is that the outcome can now be **confirmed**:

- **`--wait` / `--wait-timeout SECONDS`** (default 300) polls the target every 5s until it reports the expected `isPrimary` — `true` for promote, the opposite of the pre-command value for switchover — and exits 1 with the last observed role if it never converges. stdout then carries the polled state instead of the acknowledgement, which for promote omits `isPrimary` entirely. `--wait-timeout` without `--wait` is a clap usage error (exit 2).
- switchover `--wait` needs the prior `isPrimary` to know what "swapped" means. When that read omits the field (every response field is optional), the command refuses **before** the PATCH rather than report an unverifiable change as success.
- **promote always reports the dual-primary window** on stderr: the previous primary is demoted asynchronously and nothing in the API links it to the target, so the note points at `postgres list --filter isPrimary=true`.
- Late output goes through `print_line`, so a reader that went away during a multi-minute wait cannot turn a completed role change into exit 101 (#598).

Both commands share one handler, and `CloudClient` gains `set_postgres_service_state` (the `get_postgres_service` wrapper arrives in #624).

Upstream: the API should reject a switchover that has no standby instead of acknowledging it. That is not something the CLI can fix.

## Tests

- clap: `--wait`/`--wait-timeout` parsing and defaults; `--wait-timeout` without `--wait` asserts `MissingRequiredArgument` and exit code 2 for both commands.
- unit: expected-role resolution, timeout message, `--wait` budget mapping, stderr note set.
- async: polling loop — immediate convergence, late convergence, non-convergence returning the last observed role, absent `isPrimary` never counting as converged, fetch-error propagation.
- wiremock subprocess (`tests/cli_request_shape_test.rs`): switchover without `--wait` issues exactly one PATCH and no GET; `--wait` failing when the roles never swap while still emitting the last observed state as JSON; `--wait` refusing an unknown prior role with no PATCH issued; promote `--wait` confirming the new primary; promote without `--wait` reporting eventual consistency; human output surviving a closed stdout.

README documents the new behaviour; no changes to `clickhouse-cloud-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
