### PR TITLE
Fix clickpipe scale usage error for missing scale flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ clickhousectl cloud clickpipe resync <service-id> <clickpipe-id>   # CDC pipes o
 # Delete a ClickPipe
 clickhousectl cloud clickpipe delete <service-id> <clickpipe-id>
 
-# Update scaling
+# Update scaling (at least one of --replicas/--cpu-millicores/--memory-gb is required)
 clickhousectl cloud clickpipe scale <service-id> <clickpipe-id> \
   --replicas 2 --cpu-millicores 250 --memory-gb 1
 

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -2,7 +2,7 @@ use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::resolve_org_id;
 use clap::builder::PossibleValuesParser;
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
 use tabled::{Table, Tabled, settings::Style};
 
 // Valid wire values for each ClickPipe enum the CLI accepts as a string argument.
@@ -156,6 +156,9 @@ pub enum ClickPipeCommands {
     },
 
     /// Update scaling configuration
+    #[command(
+        group(ArgGroup::new("scale_target").required(true).multiple(true).args(["replicas", "cpu_millicores", "memory_gb"]))
+    )]
     Scale {
         /// Service ID
         service_id: String,
@@ -2765,21 +2768,77 @@ mod tests {
         assert_eq!(cpu_millicores, Some(500));
         assert_eq!(memory_gb, Some(1.5));
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn scale_requires_at_least_one_of_replicas_cpu_or_memory() {
+        assert_rejected(&["scale", "svc-1", "pipe-1"]);
+    }
+
+    #[test]
+    fn scale_accepts_a_single_flag() {
+        let ClickPipeCommands::Scale {
+            replicas,
+            cpu_millicores,
+            memory_gb,
+            ..
+        } = parse_clickpipe(&["scale", "svc-1", "pipe-1", "--replicas", "4"])
+        else {
+            panic!("expected scale");
+        };
+        assert_eq!(replicas, Some(4));
+        assert_eq!(cpu_millicores, None);
+        assert_eq!(memory_gb, None);
 
         let ClickPipeCommands::Scale {
             replicas,
             cpu_millicores,
             memory_gb,
-            org_id,
             ..
-        } = parse_clickpipe(&["scale", "svc-1", "pipe-1"])
+        } = parse_clickpipe(&["scale", "svc-1", "pipe-1", "--cpu-millicores", "500"])
+        else {
+            panic!("expected scale");
+        };
+        assert_eq!(replicas, None);
+        assert_eq!(cpu_millicores, Some(500));
+        assert_eq!(memory_gb, None);
+
+        let ClickPipeCommands::Scale {
+            replicas,
+            cpu_millicores,
+            memory_gb,
+            ..
+        } = parse_clickpipe(&["scale", "svc-1", "pipe-1", "--memory-gb", "1.5"])
         else {
             panic!("expected scale");
         };
         assert_eq!(replicas, None);
         assert_eq!(cpu_millicores, None);
-        assert_eq!(memory_gb, None);
-        assert_eq!(org_id, None);
+        assert_eq!(memory_gb, Some(1.5));
+    }
+
+    #[test]
+    fn scale_accepts_any_combination_of_flags() {
+        let ClickPipeCommands::Scale {
+            replicas,
+            cpu_millicores,
+            memory_gb,
+            ..
+        } = parse_clickpipe(&[
+            "scale",
+            "svc-1",
+            "pipe-1",
+            "--replicas",
+            "4",
+            "--memory-gb",
+            "1.5",
+        ])
+        else {
+            panic!("expected scale");
+        };
+        assert_eq!(replicas, Some(4));
+        assert_eq!(cpu_millicores, None);
+        assert_eq!(memory_gb, Some(1.5));
     }
 
     #[test]
@@ -4337,7 +4396,7 @@ mod tests {
         assert_write(&["start", "svc-1", "pipe-1"], true);
         assert_write(&["stop", "svc-1", "pipe-1"], true);
         assert_write(&["resync", "svc-1", "pipe-1"], true);
-        assert_write(&["scale", "svc-1", "pipe-1"], true);
+        assert_write(&["scale", "svc-1", "pipe-1", "--replicas", "4"], true);
         assert_write(&["settings", "get", "svc-1", "pipe-1"], false);
         assert_write(&["settings", "update", "svc-1", "pipe-1"], true);
         assert_write(

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -7094,3 +7094,81 @@ async fn private_endpoint_create_forwards_non_aws_endpoint_ids() {
         assert_eq!(body["id"], endpoint_id);
     }
 }
+
+// ── `clickpipe scale` requires at least one target (issue #605) ────────────
+//
+// Without --replicas/--cpu-millicores/--memory-gb the CLI used to send an
+// empty PATCH body, which the API 400s on and the CLI surfaced as a generic
+// "Internal error" (exit 1). It must now be a clap usage error (exit 2)
+// raised before any request is sent.
+
+#[tokio::test]
+async fn clickpipe_scale_without_any_flag_is_a_usage_error() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path_regex(
+            r"^/v1/organizations/[^/]+/services/[^/]+/clickpipes/[^/]+/scaling$",
+        ))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["clickpipe", "scale", "svc-1", "pipe-1", "--org-id", "org-1"],
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("replicas")
+            || stderr.contains("cpu-millicores")
+            || stderr.contains("memory-gb"),
+        "stderr should name the scale flags: {stderr}"
+    );
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "a rejected scale command must not reach the API"
+    );
+}
+
+#[tokio::test]
+async fn clickpipe_scale_with_a_single_flag_sends_the_request() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path_regex(
+            r"^/v1/organizations/[^/]+/services/[^/]+/clickpipes/[^/]+/scaling$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": "11111111-2222-3333-4444-555555555555",
+                "name": "pipe-1",
+                "scaling": { "replicas": 4 },
+            },
+            "status": 200,
+            "requestId": "stub-clickpipe-scale",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "scale",
+            "svc-1",
+            "pipe-1",
+            "--org-id",
+            "org-1",
+            "--replicas",
+            "4",
+        ],
+    );
+
+    assert_success(&output);
+    let requests = mock.received_requests().await.unwrap();
+    let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body["replicas"], 4);
+}


### PR DESCRIPTION
## Summary
- `cloud clickpipe scale <svc> <pipe>` with none of `--replicas`/`--cpu-millicores`/`--memory-gb` sent an empty PATCH body, which the API 400s on and the CLI surfaced generically as `Error: Internal error` (exit 1).
- Added a required, `multiple(true)` clap `ArgGroup` over the three flags on the `Scale` command variant so the empty case is now rejected as a client-side usage error (exit 2) before any request is sent, naming the valid flags in the usage message.

Stacked PR: based on `fix/604-postgres-switchover-promote`, not `main`.

## Test plan
- [x] Clap parse tests next to the `Scale` command definition: zero flags rejected, each single flag accepted, and a multi-flag combination accepted (`crates/clickhousectl/src/cloud/clickpipes.rs`).
- [x] Updated the existing read/write classification test and the previous "no flags" parse test, which both relied on the old permissive behavior.
- [x] Added subprocess wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs`: no-flag invocation exits 2 without hitting the mock API; single-flag invocation sends the expected PATCH body.
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clickhousectl` all pass.
- [x] Updated `README.md` clickpipe scale example to note the flag requirement.

Fixes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)