### PR TITLE
Default Kafka ClickPipes to no auth when no auth flags are given

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,19 @@ clickhousectl cloud clickpipe create kafka <service-id> \
   --database default --table events \
   --column "event_id:Int64" --column "name:String"
 
+# From a Kafka broker that requires no authentication: omit every auth flag.
+# `--auth` is optional; when it is omitted the mechanism is inferred from the
+# credential flags you passed (`--username`/`--password` → PLAIN,
+# `--access-key-id`/`--secret-key` → IAM_USER, `--iam-role` → IAM_ROLE,
+# `--client-certificate`/`--client-key` → MUTUAL_TLS), and no authentication is
+# sent when none were passed.
+clickhousectl cloud clickpipe create kafka <service-id> \
+  --name my-kafka-pipe \
+  --brokers 'broker:9092' --topics events \
+  --format JSONEachRow \
+  --database default --table events \
+  --column "event_id:Int64" --column "name:String"
+
 # From Amazon Kinesis
 clickhousectl cloud clickpipe create kinesis <service-id> \
   --name my-kinesis-pipe \
@@ -933,6 +946,11 @@ clickhousectl cloud clickpipe schema-discover <service-id> kafka \
   --format JSONEachRow \
   --auth SCRAM-SHA-256 \
   --username "$KAFKA_USERNAME" --password "$KAFKA_PASSWORD"
+
+# Discover schema from a Kafka broker that requires no authentication
+clickhousectl cloud clickpipe schema-discover <service-id> kafka \
+  --brokers 'broker:9092' --topics events \
+  --format JSONEachRow
 
 # Discover schema from Kinesis
 clickhousectl cloud clickpipe schema-discover <service-id> kinesis \

--- a/README.md
+++ b/README.md
@@ -833,7 +833,9 @@ clickhousectl cloud clickpipe create kafka <service-id> \
 # credential flags you passed (`--username`/`--password` → PLAIN,
 # `--access-key-id`/`--secret-key` → IAM_USER, `--iam-role` → IAM_ROLE,
 # `--client-certificate`/`--client-key` → MUTUAL_TLS), and no authentication is
-# sent when none were passed.
+# sent when none were passed. Each credential pair must be given in full — half
+# a pair (e.g. `--client-certificate` without `--client-key`) is a usage error,
+# not a request with no authentication.
 clickhousectl cloud clickpipe create kafka <service-id> \
   --name my-kafka-pipe \
   --brokers 'broker:9092' --topics events \

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -2867,7 +2867,11 @@ pub struct ClickPipePatchSource {
 /// `ClickPipePostKafkaSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostKafkaSource {
-    pub authentication: ClickPipePostKafkaSourceAuthentication,
+    /// Omitted for a broker that requires no authentication: the spec enum has
+    /// no "none" value, and the control plane's own field is `omitempty`, so
+    /// absence — not a sentinel value — is how "no auth" is expressed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipePostKafkaSourceAuthentication>,
     pub brokers: String,
     #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,

--- a/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
@@ -200,7 +200,7 @@ async fn cloud_clickpipe_create_kafka_sasl_smoke() -> TestResult<()> {
                 brokers: "broker.invalid:9092".to_string(),
                 topics: "smoke-topic".to_string(),
                 consumer_group: Some(format!("smoke-cg-{}", ctx.run_id)),
-                authentication: ClickPipePostKafkaSourceAuthentication::PLAIN,
+                authentication: Some(ClickPipePostKafkaSourceAuthentication::PLAIN),
                 credentials: serde_json::json!({
                     "username": "smoke-user",
                     "password": "smoke-pass",
@@ -231,7 +231,7 @@ async fn cloud_clickpipe_create_kafka_msk_iam_smoke() -> TestResult<()> {
                 format: ClickPipePostKafkaSourceFormat::JSONEachRow,
                 brokers: "msk.invalid:9098".to_string(),
                 topics: "smoke-topic".to_string(),
-                authentication: ClickPipePostKafkaSourceAuthentication::IAM_ROLE,
+                authentication: Some(ClickPipePostKafkaSourceAuthentication::IAM_ROLE),
                 credentials: serde_json::Value::Null,
                 iam_role: Some("arn:aws:iam::000000000000:role/smoke-fake-role".to_string()),
                 offset: Some(ClickPipeKafkaOffset {

--- a/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
@@ -250,6 +250,39 @@ async fn cloud_clickpipe_create_kafka_msk_iam_smoke() -> TestResult<()> {
 
 #[tokio::test]
 #[ignore = "requires live ClickHouse Cloud credentials and a pre-provisioned service"]
+async fn cloud_clickpipe_create_kafka_no_auth_smoke() -> TestResult<()> {
+    // A broker that requires no authentication: `authentication` is absent from
+    // the body entirely (the spec enum has no unauthenticated value) and
+    // `credentials` is null, exactly as the CLI builds it when no auth flags
+    // are given. Pins that the control plane accepts that shape (issue #606).
+    let ctx = SmokeCtx::from_env()?;
+    let request = ClickPipePostRequest {
+        name: ctx.pipe_name("kafka-noauth"),
+        source: ClickPipePostSource {
+            kafka: Some(ClickPipePostKafkaSource {
+                r#type: ClickPipePostKafkaSourceType::default(),
+                format: ClickPipePostKafkaSourceFormat::JSONEachRow,
+                brokers: "broker.invalid:9092".to_string(),
+                topics: "smoke-topic".to_string(),
+                consumer_group: Some(format!("smoke-cg-noauth-{}", ctx.run_id)),
+                authentication: None,
+                credentials: serde_json::Value::Null,
+                offset: Some(ClickPipeKafkaOffset {
+                    strategy: ClickPipeKafkaOffsetStrategy::From_beginning,
+                    timestamp: None,
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        destination: managed_destination("smoke_kafka_noauth"),
+        ..Default::default()
+    };
+    assert_create_shape_accepted(&ctx, request).await
+}
+
+#[tokio::test]
+#[ignore = "requires live ClickHouse Cloud credentials and a pre-provisioned service"]
 async fn cloud_clickpipe_create_kinesis_iam_user_smoke() -> TestResult<()> {
     let ctx = SmokeCtx::from_env()?;
     let request = ClickPipePostRequest {

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/kafka.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/kafka.rs
@@ -176,7 +176,7 @@ async fn run_scram_tls_inner(
                 format: ClickPipePostKafkaSourceFormat::JSONEachRow,
                 brokers,
                 topics: topic.clone(),
-                authentication: ClickPipePostKafkaSourceAuthentication::SCRAM_SHA_512,
+                authentication: Some(ClickPipePostKafkaSourceAuthentication::SCRAM_SHA_512),
                 credentials: serde_json::json!({
                     "username": clickpipe_user,
                     "password": clickpipe_pass,
@@ -301,7 +301,7 @@ async fn run_mtls_inner(
                 format: ClickPipePostKafkaSourceFormat::JSONEachRow,
                 brokers,
                 topics: topic.clone(),
-                authentication: ClickPipePostKafkaSourceAuthentication::MUTUAL_TLS,
+                authentication: Some(ClickPipePostKafkaSourceAuthentication::MUTUAL_TLS),
                 credentials: serde_json::json!({
                     "certificate": certs.client_cert_pem,
                     "privateKey": certs.client_key_pem,

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -3650,6 +3650,35 @@ fn click_pipe_schema_discovery_request_kafka_source() {
     assert!(v["source"].get("pubsub").is_none());
 }
 
+// A Kafka broker with no authentication has no spec enum value; absence of the
+// `authentication` key is the wire representation, so `None` must be omitted
+// rather than serialized as a mechanism or as `null`.
+#[test]
+fn click_pipe_post_kafka_source_omits_absent_authentication() {
+    let no_auth = ClickPipePostKafkaSource {
+        brokers: "broker1:9092".to_string(),
+        topics: "events".to_string(),
+        authentication: None,
+        credentials: serde_json::Value::Null,
+        ..Default::default()
+    };
+    let v = serde_json::to_value(&no_auth).unwrap();
+    assert!(
+        v.get("authentication").is_none(),
+        "absent authentication must be omitted, got {v}"
+    );
+    assert_eq!(v["brokers"], "broker1:9092");
+
+    let plain = ClickPipePostKafkaSource {
+        authentication: Some(ClickPipePostKafkaSourceAuthentication::PLAIN),
+        credentials: serde_json::json!({"username": "u", "password": "p"}),
+        ..Default::default()
+    };
+    let v = serde_json::to_value(&plain).unwrap();
+    assert_eq!(v["authentication"], "PLAIN");
+    assert_eq!(v["credentials"]["username"], "u");
+}
+
 #[test]
 fn click_pipe_schema_discovery_request_supports_new_sources() {
     let object_storage = ClickPipeSchemaDiscoveryRequest {

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -99,6 +99,13 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     ("ClickPipeMutateDestination", "table"),
     ("ClickPipeMutateDestination", "managedTable"),
     ("ClickPipeMutateDestination", "tableDefinition"),
+    // A Kafka broker that requires no authentication has no representation in
+    // the spec enum (PLAIN..MUTUAL_TLS only) and the schema carries no
+    // `required[]`, so requiredness resolves from the description heuristic.
+    // Absence is the wire representation of "no auth": the control plane's own
+    // field is `omitempty` and the equivalent PATCH property is nullable.
+    // Keeping this `T` would force every request to claim an auth mechanism.
+    ("ClickPipePostKafkaSource", "authentication"),
     // Empty TLS/IAM strings fail validation for sources that do not use them.
     ("ClickPipeMutatePostgresSource", "caCertificate"),
     ("ClickPipeMutatePostgresSource", "iamRole"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -568,12 +568,12 @@ pub struct KafkaSourceFields {
     #[arg(long)]
     pub ca_certificate: Option<String>,
 
-    /// Path to client certificate file (for MUTUAL_TLS auth)
-    #[arg(long)]
+    /// Path to client certificate file (for MUTUAL_TLS auth; requires --client-key)
+    #[arg(long, requires = "client_key")]
     pub client_certificate: Option<String>,
 
-    /// Path to client private key file (for MUTUAL_TLS auth)
-    #[arg(long)]
+    /// Path to client private key file (for MUTUAL_TLS auth; requires --client-certificate)
+    #[arg(long, requires = "client_certificate")]
     pub client_key: Option<String>,
 
     /// Path to schema registry CA certificate file
@@ -2472,6 +2472,44 @@ mod tests {
         .unwrap_or_else(|| panic!("expected parse failure for: {}", args.join(" ")))
     }
 
+    /// Minimal `clickpipe create kafka` invocation, before any auth flags.
+    fn kafka_create_cli_args() -> Vec<&'static str> {
+        vec![
+            "create",
+            "kafka",
+            "svc-1",
+            "--name",
+            "pipe-1",
+            "--brokers",
+            "broker:9092",
+            "--topics",
+            "topic",
+            "--format",
+            "JSONEachRow",
+            "--database",
+            "db",
+            "--table",
+            "events",
+        ]
+    }
+
+    /// Minimal `clickpipe schema-discover <SERVICE_ID> kafka` invocation, before
+    /// any auth flags. `KafkaSourceFields` is flattened into both commands, so
+    /// credential-pairing rules must hold for each.
+    fn kafka_discover_cli_args() -> Vec<&'static str> {
+        vec![
+            "schema-discover",
+            "svc-1",
+            "kafka",
+            "--brokers",
+            "broker:9092",
+            "--topics",
+            "topic",
+            "--format",
+            "JSONEachRow",
+        ]
+    }
+
     fn postgres_cli_args(mapping: Option<&str>) -> Vec<&str> {
         let mut args = vec![
             "create",
@@ -3316,6 +3354,54 @@ mod tests {
         assert!(args.source.reverse_private_endpoint_ids.is_empty());
         assert!(args.columns.is_empty());
         assert_eq!(args.org_id, None);
+    }
+
+    #[test]
+    fn kafka_credential_flags_must_be_given_in_pairs() {
+        // Every Kafka credential pair is joined with clap `requires`. Half a
+        // pair must be a usage error: since `--auth` is now optional and the
+        // mechanism is inferred only from a *complete* pair, an unpaired flag
+        // would otherwise infer nothing and silently send an unauthenticated
+        // create that exits 0 (issue #606).
+        let bases: [fn() -> Vec<&'static str>; 2] =
+            [kafka_create_cli_args, kafka_discover_cli_args];
+        for base in bases {
+            for (half, missing) in [
+                (["--username", "user"], "--password"),
+                (["--password", "password"], "--username"),
+                (["--access-key-id", "access"], "--secret-key"),
+                (["--secret-key", "secret"], "--access-key-id"),
+                (["--client-certificate", "/tmp/client.pem"], "--client-key"),
+                (["--client-key", "/tmp/client.key"], "--client-certificate"),
+            ] {
+                let mut args = base();
+                args.extend(half);
+                let error = clickpipe_parse_error(&args);
+                assert_eq!(
+                    error.kind(),
+                    clap::error::ErrorKind::MissingRequiredArgument,
+                    "{}",
+                    args.join(" ")
+                );
+                assert_eq!(error.exit_code(), 2, "{}", args.join(" "));
+                assert!(error.to_string().contains(missing), "{error}");
+            }
+
+            for pair in [
+                ["--username", "user", "--password", "password"],
+                ["--access-key-id", "access", "--secret-key", "secret"],
+                [
+                    "--client-certificate",
+                    "/tmp/client.pem",
+                    "--client-key",
+                    "/tmp/client.key",
+                ],
+            ] {
+                let mut args = base();
+                args.extend(pair);
+                parse_clickpipe(&args);
+            }
+        }
     }
 
     #[test]
@@ -5015,8 +5101,12 @@ mod tests {
 
     #[test]
     fn infer_kafka_authentication_ignores_half_specified_credentials() {
-        // Half a credential pair is not enough to infer a mechanism; clap
-        // rejects these pairings, so absence keeps the fallback honest.
+        // Half a credential pair is not enough to infer a mechanism. Every
+        // pair is also paired with clap `requires`, so a half-specified
+        // invocation never reaches this function (see
+        // `kafka_credential_flags_must_be_given_in_pairs`); these assertions
+        // pin the defensive behaviour of the inference itself, so a future
+        // caller cannot turn half a pair into an unintended mechanism.
         let mut args = kafka_args().source;
         args.username = Some("user".into());
         assert_eq!(infer_kafka_authentication(&args), None);

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -515,7 +515,8 @@ pub struct KafkaSourceFields {
     #[arg(long)]
     pub consumer_group: Option<String>,
 
-    /// Authentication method
+    /// Authentication method (inferred from the credential flags when omitted;
+    /// no authentication is sent when no credential flags are given)
     #[arg(long, value_parser = PossibleValuesParser::new(KAFKA_AUTHS))]
     pub auth: Option<String>,
 
@@ -1235,20 +1236,47 @@ async fn clickpipe_create_object_storage(
     Ok(())
 }
 
+/// Infer the Kafka authentication mechanism from the credential flags that were
+/// passed when `--auth` is omitted. Returning `None` means "no authentication":
+/// the spec enum has no value for an unauthenticated broker, so the request
+/// omits `authentication` entirely (see `build_kafka_source`). Never default to
+/// a mechanism the user did not ask for — that used to reject no-auth brokers
+/// client-side with a bogus "PLAIN requires --username and --password".
+fn infer_kafka_authentication(
+    args: &KafkaSourceFields,
+) -> Option<clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication> {
+    use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
+    if args.username.is_some() && args.password.is_some() {
+        Some(Auth::PLAIN)
+    } else if args.access_key_id.is_some() && args.secret_key.is_some() {
+        Some(Auth::IAM_USER)
+    } else if args.iam_role.is_some() {
+        Some(Auth::IAM_ROLE)
+    } else if args.client_certificate.is_some() && args.client_key.is_some() {
+        Some(Auth::MUTUAL_TLS)
+    } else {
+        None
+    }
+}
+
 /// Build the Kafka `credentials` JSON body, whose shape is a `oneOf` determined
 /// by the auth mode (see the `ClickPipePostKafkaSource.credentials` schema).
 /// IAM_ROLE sends a null body — the role ARN flows through the separate
-/// top-level `iamRole` field on the source, not through credentials.
+/// top-level `iamRole` field on the source, not through credentials. An absent
+/// mechanism (no authentication) likewise sends a null body.
 ///
 /// `mtls_contents` is the pre-read (certificate, privateKey) PEM bundle used
 /// only for MUTUAL_TLS; the caller reads these from disk so this function
 /// stays pure and testable.
 fn build_kafka_credentials(
-    authentication: &clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication,
+    authentication: Option<&clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication>,
     args: &KafkaSourceFields,
     mtls_contents: Option<(String, String)>,
 ) -> CloudResult<serde_json::Value> {
     use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
+    let Some(authentication) = authentication else {
+        return Ok(serde_json::Value::Null);
+    };
     match authentication {
         Auth::PLAIN | Auth::SCRAM_SHA_256 | Auth::SCRAM_SHA_512 => {
             match (args.username.as_deref(), args.password.as_deref()) {
@@ -1256,8 +1284,7 @@ fn build_kafka_credentials(
                     Ok(serde_json::json!({ "username": username, "password": password }))
                 }
                 _ => Err(CloudError::new(format!(
-                    "{} requires --username and --password",
-                    args.auth.as_deref().unwrap_or("PLAIN")
+                    "{authentication} requires --username and --password"
                 ))),
             }
         }
@@ -1304,9 +1331,13 @@ fn build_kafka_source(
         ClickPipePostKafkaSourceAuthentication,
     };
 
-    let authentication: ClickPipePostKafkaSourceAuthentication = match args.auth.as_deref() {
-        Some(authentication) => parse_enum(authentication)?,
-        None => ClickPipePostKafkaSourceAuthentication::default(),
+    // An explicit `--auth` wins; otherwise infer the mechanism from the
+    // credential flags, and send no authentication at all when none were given
+    // so brokers that require none are reachable.
+    let authentication: Option<ClickPipePostKafkaSourceAuthentication> = match args.auth.as_deref()
+    {
+        Some(authentication) => Some(parse_enum(authentication)?),
+        None => infer_kafka_authentication(args),
     };
 
     let mtls_cert_contents = match (
@@ -1314,15 +1345,17 @@ fn build_kafka_source(
         args.client_certificate.as_deref(),
         args.client_key.as_deref(),
     ) {
-        (ClickPipePostKafkaSourceAuthentication::MUTUAL_TLS, Some(cert_path), Some(key_path)) => {
-            Some((
-                std::fs::read_to_string(cert_path)?,
-                std::fs::read_to_string(key_path)?,
-            ))
-        }
+        (
+            Some(ClickPipePostKafkaSourceAuthentication::MUTUAL_TLS),
+            Some(cert_path),
+            Some(key_path),
+        ) => Some((
+            std::fs::read_to_string(cert_path)?,
+            std::fs::read_to_string(key_path)?,
+        )),
         _ => None,
     };
-    let credentials = build_kafka_credentials(&authentication, args, mtls_cert_contents)?;
+    let credentials = build_kafka_credentials(authentication.as_ref(), args, mtls_cert_contents)?;
 
     let schema_registry = args
         .schema_registry_url
@@ -3405,6 +3438,14 @@ mod tests {
         assert_eq!(args.kafka_type, "kafka");
         assert_eq!(args.offset, "from_beginning");
         assert_eq!(org_id.as_deref(), Some("org-kafka"));
+        // Auth flags are all optional for discovery too, and an unauthenticated
+        // broker builds a source with no authentication at all (issue #606).
+        assert_eq!(args.auth, None);
+        assert_eq!(args.username, None);
+        assert_eq!(args.password, None);
+        let discovery_source = build_kafka_source(&args).expect("no-auth discovery source builds");
+        assert_eq!(discovery_source.authentication, None);
+        assert!(discovery_source.credentials.is_null());
 
         let ClickPipeCommands::SchemaDiscover {
             service_id,
@@ -4848,6 +4889,147 @@ mod tests {
         }
     }
 
+    /// Wire value of the built source's authentication, or `None` when the
+    /// request omits authentication entirely (no-auth broker).
+    fn kafka_auth(
+        source: &clickhouse_cloud_api::models::ClickPipePostKafkaSource,
+    ) -> Option<String> {
+        source.authentication.as_ref().map(ToString::to_string)
+    }
+
+    #[test]
+    fn build_kafka_source_defaults_to_no_authentication() {
+        // No --auth and no credential flags: the request must omit
+        // authentication rather than inventing PLAIN, so brokers that require
+        // no authentication are reachable (issue #606).
+        let args = kafka_args().source;
+        let source = build_kafka_source(&args).unwrap();
+        assert_eq!(kafka_auth(&source), None);
+        assert!(
+            source.credentials.is_null(),
+            "no-auth source must not carry credentials: {}",
+            source.credentials
+        );
+        assert_eq!(source.iam_role, None);
+    }
+
+    #[test]
+    fn build_kafka_source_infers_plain_from_username_and_password() {
+        let mut args = kafka_args().source;
+        args.username = Some("user".into());
+        args.password = Some("password".into());
+        let source = build_kafka_source(&args).unwrap();
+        assert_eq!(kafka_auth(&source).as_deref(), Some("PLAIN"));
+        assert_eq!(source.credentials["username"], "user");
+        assert_eq!(source.credentials["password"], "password");
+    }
+
+    #[test]
+    fn build_kafka_source_infers_iam_user_from_access_keys() {
+        let mut args = kafka_args().source;
+        args.access_key_id = Some("AKIA".into());
+        args.secret_key = Some("secret".into());
+        let source = build_kafka_source(&args).unwrap();
+        assert_eq!(kafka_auth(&source).as_deref(), Some("IAM_USER"));
+        assert_eq!(source.credentials["accessKeyId"], "AKIA");
+        assert_eq!(source.credentials["secretKey"], "secret");
+    }
+
+    #[test]
+    fn build_kafka_source_infers_iam_role_from_role_arn() {
+        let mut args = kafka_args().source;
+        args.iam_role = Some("arn:aws:iam::123:role/Foo".into());
+        let source = build_kafka_source(&args).unwrap();
+        assert_eq!(kafka_auth(&source).as_deref(), Some("IAM_ROLE"));
+        assert!(source.credentials.is_null());
+        assert_eq!(
+            source.iam_role.as_deref(),
+            Some("arn:aws:iam::123:role/Foo")
+        );
+    }
+
+    #[test]
+    fn build_kafka_source_infers_mutual_tls_from_client_certificate_pair() {
+        let directory = tempfile::tempdir().unwrap();
+        let client_certificate = directory.path().join("client.pem");
+        let client_key = directory.path().join("client.key");
+        std::fs::write(&client_certificate, "CLIENT_CERT").unwrap();
+        std::fs::write(&client_key, "CLIENT_KEY").unwrap();
+
+        let mut args = kafka_args().source;
+        args.client_certificate = Some(client_certificate.to_string_lossy().into_owned());
+        args.client_key = Some(client_key.to_string_lossy().into_owned());
+
+        let source = build_kafka_source(&args).unwrap();
+        assert_eq!(kafka_auth(&source).as_deref(), Some("MUTUAL_TLS"));
+        assert_eq!(source.credentials["certificate"], "CLIENT_CERT");
+        assert_eq!(source.credentials["privateKey"], "CLIENT_KEY");
+    }
+
+    #[test]
+    fn build_kafka_source_errors_when_explicit_mechanism_lacks_credentials() {
+        // An explicitly selected mechanism still fails fast, and the message
+        // names the mechanism the user actually asked for.
+        for auth in ["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"] {
+            let mut args = kafka_args().source;
+            args.auth = Some(auth.into());
+            let error = build_kafka_source(&args).unwrap_err();
+            assert_eq!(
+                error.message,
+                format!("{auth} requires --username and --password")
+            );
+        }
+
+        let mut args = kafka_args().source;
+        args.auth = Some("IAM_USER".into());
+        let error = build_kafka_source(&args).unwrap_err();
+        assert!(error.message.contains("--access-key-id"));
+
+        let mut args = kafka_args().source;
+        args.auth = Some("MUTUAL_TLS".into());
+        let error = build_kafka_source(&args).unwrap_err();
+        assert!(error.message.contains("--client-certificate"));
+    }
+
+    #[test]
+    fn kafka_credentials_absent_authentication_is_null() {
+        let args = kafka_args();
+        let credentials = build_kafka_credentials(None, &args.source, None).unwrap();
+        assert!(credentials.is_null());
+    }
+
+    #[test]
+    fn infer_kafka_authentication_prefers_sasl_over_certificates() {
+        // Both SASL and client-certificate flags present: SASL wins, matching
+        // the credential body that gets built.
+        let mut args = kafka_args().source;
+        args.username = Some("user".into());
+        args.password = Some("password".into());
+        args.client_certificate = Some("cert-path".into());
+        args.client_key = Some("key-path".into());
+        assert_eq!(
+            infer_kafka_authentication(&args).map(|auth| auth.to_string()),
+            Some("PLAIN".to_string())
+        );
+    }
+
+    #[test]
+    fn infer_kafka_authentication_ignores_half_specified_credentials() {
+        // Half a credential pair is not enough to infer a mechanism; clap
+        // rejects these pairings, so absence keeps the fallback honest.
+        let mut args = kafka_args().source;
+        args.username = Some("user".into());
+        assert_eq!(infer_kafka_authentication(&args), None);
+
+        let mut args = kafka_args().source;
+        args.secret_key = Some("secret".into());
+        assert_eq!(infer_kafka_authentication(&args), None);
+
+        let mut args = kafka_args().source;
+        args.client_key = Some("key-path".into());
+        assert_eq!(infer_kafka_authentication(&args), None);
+    }
+
     #[test]
     fn build_kafka_source_supports_minimal_fields() {
         let mut args = kafka_args().source;
@@ -4860,7 +5042,7 @@ mod tests {
         assert_eq!(source.format.to_string(), "JSONEachRow");
         assert_eq!(source.brokers, "b:9092");
         assert_eq!(source.topics, "t");
-        assert_eq!(source.authentication.to_string(), "PLAIN");
+        assert_eq!(kafka_auth(&source).as_deref(), Some("PLAIN"));
         assert_eq!(source.credentials["username"], "user");
         assert_eq!(source.credentials["password"], "password");
         assert_eq!(source.consumer_group, None);
@@ -4915,7 +5097,7 @@ mod tests {
         assert_eq!(source.brokers, "broker-1:9092,broker-2:9092");
         assert_eq!(source.topics, "topic-1,topic-2");
         assert_eq!(source.consumer_group.as_deref(), Some("group"));
-        assert_eq!(source.authentication.to_string(), "MUTUAL_TLS");
+        assert_eq!(kafka_auth(&source).as_deref(), Some("MUTUAL_TLS"));
         assert_eq!(source.credentials["certificate"], "CLIENT_CERT");
         assert_eq!(source.credentials["privateKey"], "CLIENT_KEY");
         assert_eq!(source.iam_role.as_deref(), Some("arn:role"));
@@ -4999,7 +5181,7 @@ mod tests {
         args.source.auth = Some("PLAIN".into());
         args.source.username = Some("u".into());
         args.source.password = Some("p".into());
-        let credentials = build_kafka_credentials(&Auth::PLAIN, &args.source, None).unwrap();
+        let credentials = build_kafka_credentials(Some(&Auth::PLAIN), &args.source, None).unwrap();
         assert_eq!(credentials["username"], "u");
         assert_eq!(credentials["password"], "p");
     }
@@ -5011,7 +5193,8 @@ mod tests {
         args.source.auth = Some("IAM_USER".into());
         args.source.access_key_id = Some("AKIA".into());
         args.source.secret_key = Some("secret".into());
-        let credentials = build_kafka_credentials(&Auth::IAM_USER, &args.source, None).unwrap();
+        let credentials =
+            build_kafka_credentials(Some(&Auth::IAM_USER), &args.source, None).unwrap();
         // MskIamUser wire shape is {accessKeyId, secretKey} — NOT snake_case.
         assert_eq!(credentials["accessKeyId"], "AKIA");
         assert_eq!(credentials["secretKey"], "secret");
@@ -5026,7 +5209,8 @@ mod tests {
         args.source.iam_role = Some("arn:aws:iam::123:role/Foo".into());
         // IAM_ROLE sends credentials=null; the role ARN flows through the
         // top-level `iamRole` field on the Kafka source, not credentials.
-        let credentials = build_kafka_credentials(&Auth::IAM_ROLE, &args.source, None).unwrap();
+        let credentials =
+            build_kafka_credentials(Some(&Auth::IAM_ROLE), &args.source, None).unwrap();
         assert!(credentials.is_null());
     }
 
@@ -5036,7 +5220,7 @@ mod tests {
         let args = kafka_args();
         let contents = Some(("CERT_PEM".into(), "KEY_PEM".into()));
         let credentials =
-            build_kafka_credentials(&Auth::MUTUAL_TLS, &args.source, contents).unwrap();
+            build_kafka_credentials(Some(&Auth::MUTUAL_TLS), &args.source, contents).unwrap();
         assert_eq!(credentials["certificate"], "CERT_PEM");
         assert_eq!(credentials["privateKey"], "KEY_PEM");
     }
@@ -5045,7 +5229,7 @@ mod tests {
     fn kafka_credentials_iam_user_missing_args_errors() {
         use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
         let args = kafka_args();
-        let error = build_kafka_credentials(&Auth::IAM_USER, &args.source, None).unwrap_err();
+        let error = build_kafka_credentials(Some(&Auth::IAM_USER), &args.source, None).unwrap_err();
         assert!(error.message.contains("--access-key-id"));
     }
 
@@ -5054,7 +5238,7 @@ mod tests {
         use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
         let mut args = kafka_args();
         args.source.auth = Some("IAM_ROLE".into());
-        let error = build_kafka_credentials(&Auth::IAM_ROLE, &args.source, None).unwrap_err();
+        let error = build_kafka_credentials(Some(&Auth::IAM_ROLE), &args.source, None).unwrap_err();
         assert!(error.message.contains("--iam-role"));
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2466,7 +2466,8 @@ async fn mongodb_tls_host_absent_when_not_passed() {
 // plus all 4 SASL credential shapes (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512,
 // MUTUAL_TLS, IAM_ROLE).
 
-fn kafka_args_minimal() -> Vec<&'static str> {
+/// Kafka create args carrying no authentication flag of any kind.
+fn kafka_args_without_auth() -> Vec<&'static str> {
     vec![
         "clickpipe",
         "create",
@@ -2488,15 +2489,15 @@ fn kafka_args_minimal() -> Vec<&'static str> {
         "id:Int64",
         "--kafka-type",
         "kafka",
-        "--auth",
-        "PLAIN",
-        "--username",
-        "u",
-        "--password",
-        "p",
         "--org-id",
         "org",
     ]
+}
+
+fn kafka_args_minimal() -> Vec<&'static str> {
+    let mut args = kafka_args_without_auth();
+    args.extend(["--auth", "PLAIN", "--username", "u", "--password", "p"]);
+    args
 }
 
 #[tokio::test]
@@ -2529,6 +2530,76 @@ async fn kafka_plain_credentials_shape() {
     let creds = &body["source"]["kafka"]["credentials"];
     assert_eq!(creds["username"], "u");
     assert_eq!(creds["password"], "p");
+}
+
+#[tokio::test]
+async fn kafka_without_auth_flags_sends_no_authentication() {
+    // A broker that requires no authentication: the CLI must not invent PLAIN
+    // (which used to fail client-side with "PLAIN requires --username and
+    // --password"), and `authentication` must be absent from the wire body
+    // because the spec enum has no value for "none".
+    let mock = start_mock_clickpipes_api().await;
+    let body = invoke_cli_capture_body(&mock, &kafka_args_without_auth()).await;
+
+    let kafka = &body["source"]["kafka"];
+    assert!(
+        kafka.get("authentication").is_none(),
+        "authentication must be omitted for a no-auth broker: {kafka}",
+    );
+    assert!(
+        kafka["credentials"].is_null(),
+        "credentials must not carry a mechanism body: {kafka}",
+    );
+    assert_eq!(kafka["brokers"], "broker:9092");
+    assert_eq!(kafka["topics"], "topic");
+}
+
+#[tokio::test]
+async fn schema_discover_kafka_without_auth_flags_sends_no_authentication() {
+    let mock = start_mock_schema_discovery_api().await;
+    let body = invoke_cli_capture_body(
+        &mock,
+        &[
+            "clickpipe",
+            "schema-discover",
+            "svc-id",
+            "--org-id",
+            "org",
+            "kafka",
+            "--brokers",
+            "broker:9092",
+            "--topics",
+            "topic",
+            "--format",
+            "JSONEachRow",
+        ],
+    )
+    .await;
+
+    let kafka = &body["source"]["kafka"];
+    assert!(
+        kafka.get("authentication").is_none(),
+        "authentication must be omitted for a no-auth broker: {kafka}",
+    );
+    assert!(
+        kafka["credentials"].is_null(),
+        "credentials must not carry a mechanism body: {kafka}",
+    );
+}
+
+#[tokio::test]
+async fn kafka_infers_plain_from_username_and_password_without_auth_flag() {
+    // Credential flags without --auth still resolve to the matching mechanism,
+    // so omitting --auth is not a silent downgrade to no authentication.
+    let mock = start_mock_clickpipes_api().await;
+    let mut args = kafka_args_without_auth();
+    args.extend(["--username", "u", "--password", "p"]);
+    let body = invoke_cli_capture_body(&mock, &args).await;
+
+    let kafka = &body["source"]["kafka"];
+    assert_eq!(kafka["authentication"], "PLAIN");
+    assert_eq!(kafka["credentials"]["username"], "u");
+    assert_eq!(kafka["credentials"]["password"], "p");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

`clickpipe create kafka` and `clickpipe schema-discover kafka` implicitly defaulted the authentication mechanism to PLAIN whenever `--auth` was omitted. An invocation with no auth flags at all therefore failed client-side with `PLAIN requires --username and --password`, making a broker that requires no authentication unreachable.

Auth resolution is now:

1. an explicit `--auth` wins;
2. otherwise the mechanism is inferred from the credential flags that were passed — `--username`/`--password` → PLAIN, `--access-key-id`/`--secret-key` → IAM_USER, `--iam-role` → IAM_ROLE, `--client-certificate`/`--client-key` → MUTUAL_TLS; every credential pair must be given in full — `--client-certificate` and `--client-key` are now clap-paired like the other two pairs, so half a pair is a usage error (exit 2) rather than a silent no-auth request (review finding);
3. otherwise no authentication is sent.

An explicitly selected mechanism still fails fast when its credentials are missing, and the error now names the mechanism the user actually asked for rather than always saying PLAIN.

## Why this request shape

An unauthenticated Kafka source has no value in the spec enum (`PLAIN`..`MUTUAL_TLS`), and `ClickPipePostKafkaSource` carries no `required[]`, so absence of the key is the wire representation of "no auth":

- the object-storage source already works this way — its `authentication` is nullable and omitted for public buckets ("PUBLIC uses no authentication" in the spec description), and the CLI already omits it;
- the equivalent PATCH property (`ClickPipePatchKafkaSource.authentication`) is nullable upstream;
- the control plane's own field is `omitempty` (visible in the official Terraform provider's `internal/api/clickpipe_models.go`).

So `ClickPipePostKafkaSource.authentication` becomes `Option<T>` with `skip_serializing_if`, paired with a documented `optionality_exemptions` entry in the analyzer config. Presence and enum-value checking are unchanged; only the requiredness demand is exempted. `credentials` stays as-is and carries `null` for a no-auth source, exactly as it already does for IAM_ROLE.

## Tests

- Builder unit tests: no-auth default, each inference path (PLAIN / IAM_USER / IAM_ROLE / MUTUAL_TLS), explicit-mechanism error messages for PLAIN/SCRAM/IAM_USER/MUTUAL_TLS, `build_kafka_credentials(None, ..)` → null.
- Inference tests for half-specified credential pairs (no mechanism inferred).
- Clap coverage: `schema-discover kafka` parses with no auth flags and builds a source with no authentication.
- Wiremock subprocess tests: `create kafka` and `schema-discover kafka` with no auth flags omit `authentication` and send null `credentials`; `--username`/`--password` without `--auth` still sends PLAIN with the right credential body.
- Library test pinning that an absent mechanism is omitted rather than serialized as `null`.
- Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clickhousectl`, `cargo test -p clickhouse-cloud-api --test spec_coverage_test --test models_test --lib`, `cargo test -p clickhouse-openapi-analyzer`, `cargo check --workspace --all-features`. Cloud integration suites were not run (they need live credentials); the Kafka stages/smoke constructions were updated to the new `Option` field and compile under `--all-targets`.

README documents the optional `--auth` behaviour with a no-auth example for both commands.

Part of a stacked PR chain: this PR is based on `fix/605-clickpipe-scale-usage-error`, not `main`.

Fixes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
