### PR TITLE
Omit Kafka-only ClickPipe settings for non-Kafka pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,14 @@ clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
   --streaming-max-insert-wait-ms 10000
 ```
 
+`settings update` only sends the settings you name on the command line, and it
+first reads the pipe to find its source type: settings that the API supports for
+one source only — currently the Kafka `kafka_read_committed` setting, which the
+CLI preserves rather than exposing as a flag — are sent for Kafka pipes and
+omitted for every other source. Object-storage-, streaming- and
+ClickHouse-specific settings are validated by the API, so passing (for example)
+`--object-storage-max-file-count` to a Kafka pipe is rejected server-side.
+
 #### Creating ClickPipes
 
 Each source type has its own subcommand under `clickpipe create`:

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -3392,8 +3392,15 @@ pub struct ClickPipeSettingsPutRequest {
     pub clickhouse_parallel_distributed_insert_select: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_view_processing: Option<bool>,
-    #[serde(rename = "kafka_read_committed")]
-    pub kafka_read_committed: bool,
+    /// Kafka-only: the API rejects this key outright for any other source
+    /// ("Setting 'kafka_read_committed' is only supported for Kafka
+    /// ClickPipes"), so absence — not `false` — is how a non-Kafka settings
+    /// update expresses "this setting does not apply".
+    #[serde(
+        rename = "kafka_read_committed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub kafka_read_committed: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_concurrency: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1660,7 +1660,7 @@ async fn update_click_pipe_settings() {
         .await;
 
     let body = ClickPipeSettingsPutRequest {
-        kafka_read_committed: true,
+        kafka_read_committed: Some(true),
         ..Default::default()
     };
     let resp = c

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -3679,6 +3679,36 @@ fn click_pipe_post_kafka_source_omits_absent_authentication() {
     assert_eq!(v["credentials"]["username"], "u");
 }
 
+// `kafka_read_committed` is only supported for Kafka pipes, so a settings PUT
+// for any other source must leave the key off the wire entirely — not send
+// `false` and not send `null`.
+#[test]
+fn click_pipe_settings_put_request_omits_absent_kafka_read_committed() {
+    let non_kafka = ClickPipeSettingsPutRequest {
+        object_storage_max_file_count: Some(200),
+        kafka_read_committed: None,
+        ..Default::default()
+    };
+    let v = serde_json::to_value(&non_kafka).unwrap();
+    assert!(
+        v.get("kafka_read_committed").is_none(),
+        "absent kafka_read_committed must be omitted, got {v}"
+    );
+    assert_eq!(
+        v,
+        serde_json::json!({ "object_storage_max_file_count": 200 })
+    );
+
+    let kafka = ClickPipeSettingsPutRequest {
+        streaming_max_insert_wait_ms: Some(1000),
+        kafka_read_committed: Some(true),
+        ..Default::default()
+    };
+    let v = serde_json::to_value(&kafka).unwrap();
+    assert_eq!(v["kafka_read_committed"], true);
+    assert_eq!(v["streaming_max_insert_wait_ms"], 1000);
+}
+
 #[test]
 fn click_pipe_schema_discovery_request_supports_new_sources() {
     let object_storage = ClickPipeSchemaDiscoveryRequest {
@@ -3981,10 +4011,14 @@ fn shared_clickpipe_nested_types_stay_strict_on_the_request_side() {
         serde_json::from_str::<ClickPipePostgresPipeTableMappingResponse>("{}").unwrap(),
         ClickPipePostgresPipeTableMappingResponse::default()
     );
-    // The new non-nullable Kafka setting is required in requests while the
-    // response variant remains tolerant of a dropped key.
+    // The new non-nullable Kafka setting is required in the create-position
+    // settings object, while the settings PUT omits it for non-Kafka pipes and
+    // the response variant remains tolerant of a dropped key.
     assert!(serde_json::from_str::<ClickPipeSettings>("{}").is_err());
-    assert!(serde_json::from_str::<ClickPipeSettingsPutRequest>("{}").is_err());
+    assert_eq!(
+        serde_json::from_str::<ClickPipeSettingsPutRequest>("{}").unwrap(),
+        ClickPipeSettingsPutRequest::default()
+    );
     assert_eq!(
         serde_json::from_str::<ClickPipeSettingsResponse>("{}").unwrap(),
         ClickPipeSettingsResponse::default()

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -106,6 +106,13 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // field is `omitempty` and the equivalent PATCH property is nullable.
     // Keeping this `T` would force every request to claim an auth mechanism.
     ("ClickPipePostKafkaSource", "authentication"),
+    // `kafka_read_committed` is Kafka-only: the settings PUT is rejected with
+    // "Setting 'kafka_read_committed' is only supported for Kafka ClickPipes"
+    // for every other source, and the schema carries no `required[]`, so
+    // requiredness resolves from the description heuristic. Absence is the only
+    // way a non-Kafka settings update can express "does not apply"; keeping this
+    // `T` would put the key on every request and break all non-Kafka pipes.
+    ("ClickPipeSettingsPutRequest", "kafka_read_committed"),
     // Empty TLS/IAM strings fail validation for sources that do not use them.
     ("ClickPipeMutatePostgresSource", "caCertificate"),
     ("ClickPipeMutatePostgresSource", "iamRole"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1067,10 +1067,7 @@ pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -
                 clickhouse_parallel_view_processing,
                 org_id,
             } => {
-                clickpipe_settings_update(
-                    client,
-                    &service_id,
-                    &clickpipe_id,
+                let values = ClickPipeSettingsValues {
                     streaming_max_insert_wait_ms,
                     object_storage_concurrency,
                     object_storage_polling_interval_ms,
@@ -1080,6 +1077,12 @@ pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -
                     clickhouse_max_insert_threads,
                     object_storage_use_cluster_function,
                     clickhouse_parallel_view_processing,
+                };
+                clickpipe_settings_update(
+                    client,
+                    &service_id,
+                    &clickpipe_id,
+                    &values,
                     org_id.as_deref(),
                     json,
                 )
@@ -1711,11 +1714,15 @@ async fn clickpipe_settings_get(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn clickpipe_settings_update(
-    client: &CloudClient,
-    service_id: &str,
-    clickpipe_id: &str,
+/// The settings a `clickpipe settings update` invocation carries, decoupled from
+/// clap so the request builder can be unit-tested.
+///
+/// Every field is source-agnostic: each one is only sent when the user passed
+/// the matching flag, so the API validates applicability per source. Kafka-only
+/// settings are not here — they are resolved from the pipe itself (see
+/// [`build_clickpipe_settings_request`]).
+#[derive(Debug, Clone, Default, PartialEq)]
+struct ClickPipeSettingsValues {
     streaming_max_insert_wait_ms: Option<u32>,
     object_storage_concurrency: Option<u32>,
     object_storage_polling_interval_ms: Option<u32>,
@@ -1725,30 +1732,78 @@ async fn clickpipe_settings_update(
     clickhouse_max_insert_threads: Option<u32>,
     object_storage_use_cluster_function: Option<bool>,
     clickhouse_parallel_view_processing: Option<bool>,
-    org_id: Option<&str>,
-    json: bool,
-) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, org_id).await?;
-    let kafka_read_committed = client
-        .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
-        .await?
-        .kafka_read_committed
-        .unwrap_or(false);
-    let request = clickhouse_cloud_api::models::ClickPipeSettingsPutRequest {
-        streaming_max_insert_wait_ms: streaming_max_insert_wait_ms.map(i64::from),
-        object_storage_concurrency: object_storage_concurrency.map(i64::from),
-        object_storage_polling_interval_ms: object_storage_polling_interval_ms.map(i64::from),
-        object_storage_max_insert_bytes: object_storage_max_insert_bytes.map(|value| value as i64),
-        object_storage_max_file_count: object_storage_max_file_count.map(i64::from),
-        clickhouse_max_threads: clickhouse_max_threads.map(i64::from),
-        clickhouse_max_insert_threads: clickhouse_max_insert_threads.map(i64::from),
-        object_storage_use_cluster_function,
-        clickhouse_parallel_view_processing,
+}
+
+/// True when the fetched pipe reads from a Kafka (or Kafka-compatible) source.
+///
+/// A pipe whose `source` is absent from the response is treated as non-Kafka:
+/// Kafka-only settings are then omitted, which is the safe direction because
+/// sending one to a non-Kafka pipe fails the whole request.
+fn clickpipe_source_is_kafka(clickpipe: &clickhouse_cloud_api::models::ClickPipe) -> bool {
+    clickpipe
+        .source
+        .as_ref()
+        .is_some_and(|source| source.kafka.is_some())
+}
+
+/// Build the settings PUT body from the flags the user passed.
+///
+/// `kafka_read_committed` is Kafka-only: the API rejects the key for every other
+/// source, so callers pass `None` for a non-Kafka pipe and the pipe's current
+/// value for a Kafka pipe (the PUT would otherwise reset it).
+fn build_clickpipe_settings_request(
+    values: &ClickPipeSettingsValues,
+    kafka_read_committed: Option<bool>,
+) -> clickhouse_cloud_api::models::ClickPipeSettingsPutRequest {
+    clickhouse_cloud_api::models::ClickPipeSettingsPutRequest {
+        streaming_max_insert_wait_ms: values.streaming_max_insert_wait_ms.map(i64::from),
+        object_storage_concurrency: values.object_storage_concurrency.map(i64::from),
+        object_storage_polling_interval_ms: values
+            .object_storage_polling_interval_ms
+            .map(i64::from),
+        object_storage_max_insert_bytes: values
+            .object_storage_max_insert_bytes
+            .map(|value| value as i64),
+        object_storage_max_file_count: values.object_storage_max_file_count.map(i64::from),
+        clickhouse_max_threads: values.clickhouse_max_threads.map(i64::from),
+        clickhouse_max_insert_threads: values.clickhouse_max_insert_threads.map(i64::from),
+        object_storage_use_cluster_function: values.object_storage_use_cluster_function,
+        clickhouse_parallel_view_processing: values.clickhouse_parallel_view_processing,
         kafka_read_committed,
         clickhouse_max_download_threads: None,
         clickhouse_min_insert_block_size_bytes: None,
         clickhouse_parallel_distributed_insert_select: None,
+    }
+}
+
+async fn clickpipe_settings_update(
+    client: &CloudClient,
+    service_id: &str,
+    clickpipe_id: &str,
+    values: &ClickPipeSettingsValues,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    // The source decides which settings may appear in the body at all: sending
+    // `kafka_read_committed` for a non-Kafka pipe fails the entire request, so
+    // the pipe is fetched to classify it, and its current value is only read
+    // back (a PUT that omits it would reset it) for a Kafka pipe.
+    let clickpipe = client
+        .get_clickpipe(&org_id, service_id, clickpipe_id)
+        .await?;
+    let kafka_read_committed = if clickpipe_source_is_kafka(&clickpipe) {
+        Some(
+            client
+                .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
+                .await?
+                .kafka_read_committed
+                .unwrap_or(false),
+        )
+    } else {
+        None
     };
+    let request = build_clickpipe_settings_request(values, kafka_read_committed);
     let settings = client
         .update_clickpipe_settings(&org_id, service_id, clickpipe_id, &request)
         .await?;
@@ -3016,6 +3071,135 @@ mod tests {
         assert_eq!(object_storage_use_cluster_function, None);
         assert_eq!(clickhouse_parallel_view_processing, None);
         assert_eq!(org_id, None);
+    }
+
+    // A non-Kafka pipe must not carry `kafka_read_committed`: the API rejects
+    // the key for every other source, which broke every non-Kafka settings
+    // update (#602).
+    #[test]
+    fn builds_settings_request_without_kafka_only_settings_for_non_kafka_pipes() {
+        let values = ClickPipeSettingsValues {
+            object_storage_max_file_count: Some(200),
+            ..Default::default()
+        };
+        let request = build_clickpipe_settings_request(&values, None);
+        assert_eq!(request.kafka_read_committed, None);
+        assert_eq!(request.object_storage_max_file_count, Some(200));
+        assert_eq!(request.streaming_max_insert_wait_ms, None);
+        assert_eq!(request.object_storage_concurrency, None);
+        assert_eq!(request.object_storage_polling_interval_ms, None);
+        assert_eq!(request.object_storage_max_insert_bytes, None);
+        assert_eq!(request.clickhouse_max_threads, None);
+        assert_eq!(request.clickhouse_max_insert_threads, None);
+        assert_eq!(request.object_storage_use_cluster_function, None);
+        assert_eq!(request.clickhouse_parallel_view_processing, None);
+        assert_eq!(request.clickhouse_max_download_threads, None);
+        assert_eq!(request.clickhouse_min_insert_block_size_bytes, None);
+        assert_eq!(request.clickhouse_parallel_distributed_insert_select, None);
+        // Nothing at all was passed: the body stays empty rather than
+        // resetting settings the user did not name.
+        let empty = build_clickpipe_settings_request(&ClickPipeSettingsValues::default(), None);
+        assert_eq!(
+            serde_json::to_value(&empty).unwrap(),
+            serde_json::json!({}),
+            "a non-Kafka update with no flags must send an empty body"
+        );
+    }
+
+    #[test]
+    fn builds_settings_request_with_every_flag_and_kafka_read_committed() {
+        let values = ClickPipeSettingsValues {
+            streaming_max_insert_wait_ms: Some(1000),
+            object_storage_concurrency: Some(2),
+            object_storage_polling_interval_ms: Some(3000),
+            object_storage_max_insert_bytes: Some(4000),
+            object_storage_max_file_count: Some(5),
+            clickhouse_max_threads: Some(6),
+            clickhouse_max_insert_threads: Some(7),
+            object_storage_use_cluster_function: Some(true),
+            clickhouse_parallel_view_processing: Some(false),
+        };
+        let request = build_clickpipe_settings_request(&values, Some(true));
+        assert_eq!(request.streaming_max_insert_wait_ms, Some(1000));
+        assert_eq!(request.object_storage_concurrency, Some(2));
+        assert_eq!(request.object_storage_polling_interval_ms, Some(3000));
+        assert_eq!(request.object_storage_max_insert_bytes, Some(4000));
+        assert_eq!(request.object_storage_max_file_count, Some(5));
+        assert_eq!(request.clickhouse_max_threads, Some(6));
+        assert_eq!(request.clickhouse_max_insert_threads, Some(7));
+        assert_eq!(request.object_storage_use_cluster_function, Some(true));
+        assert_eq!(request.clickhouse_parallel_view_processing, Some(false));
+        assert_eq!(request.kafka_read_committed, Some(true));
+        // A Kafka pipe with the setting disabled still sends it explicitly, so
+        // the PUT does not silently flip it.
+        let request = build_clickpipe_settings_request(&values, Some(false));
+        assert_eq!(request.kafka_read_committed, Some(false));
+    }
+
+    #[test]
+    fn readme_documents_source_aware_settings_update() {
+        let readme = include_str!("../../../../README.md");
+        let clickpipes = readme
+            .split_once("### ClickPipes")
+            .expect("ClickPipes section")
+            .1
+            .split_once("#### Creating ClickPipes")
+            .expect("next ClickPipes section")
+            .0;
+
+        for expected in [
+            "only sends the settings you name on the command line",
+            "first reads the pipe to find its source type",
+            "`kafka_read_committed`",
+            "omitted for every other source",
+        ] {
+            assert!(
+                clickpipes.contains(expected),
+                "missing `{expected}`:\n{clickpipes}"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_clickpipe_source_as_kafka_only_for_kafka_pipes() {
+        use clickhouse_cloud_api::models::{
+            ClickPipe, ClickPipeKafkaSource, ClickPipeObjectStorageSource, ClickPipePostgresSource,
+            ClickPipeSource,
+        };
+
+        let kafka = ClickPipe {
+            source: Some(ClickPipeSource {
+                kafka: Some(ClickPipeKafkaSource::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(clickpipe_source_is_kafka(&kafka));
+
+        let object_storage = ClickPipe {
+            source: Some(ClickPipeSource {
+                object_storage: Some(ClickPipeObjectStorageSource::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!clickpipe_source_is_kafka(&object_storage));
+
+        let postgres = ClickPipe {
+            source: Some(ClickPipeSource {
+                postgres: Some(ClickPipePostgresSource::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!clickpipe_source_is_kafka(&postgres));
+
+        // An absent source (or an absent kafka arm) is treated as non-Kafka.
+        assert!(!clickpipe_source_is_kafka(&ClickPipe::default()));
+        assert!(!clickpipe_source_is_kafka(&ClickPipe {
+            source: Some(ClickPipeSource::default()),
+            ..Default::default()
+        }));
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -6439,40 +6439,156 @@ async fn mysql_server_id_absent_when_not_passed() {
     );
 }
 
-// ── ClickPipe settings updates preserve required values ─────────────────────
+// ── ClickPipe settings updates are source-aware (#602) ─────────────────────
+//
+// `kafka_read_committed` is only supported for Kafka pipes: the API fails the
+// whole PUT with "Setting 'kafka_read_committed' is only supported for Kafka
+// ClickPipes" for any other source. The handler therefore fetches the pipe to
+// classify its source, and only reads back and re-sends the Kafka-only setting
+// when the source is Kafka.
+
+const CLICKPIPE_PATH: &str = "/v1/organizations/org/services/svc-id/clickpipes/pipe-id";
+const CLICKPIPE_SETTINGS_PATH: &str =
+    "/v1/organizations/org/services/svc-id/clickpipes/pipe-id/settings";
+
+/// Stub the pipe GET with a source of the given shape, e.g.
+/// `json!({ "objectStorage": { "type": "s3" } })`.
+async fn mount_clickpipe_get(mock: &MockServer, source: Value) {
+    let stub_pipe = serde_json::json!({
+        "result": {
+            "id": "00000000-0000-0000-0000-0000000000aa",
+            "name": "test-pipe",
+            "state": "Running",
+            "source": source,
+        },
+        "status": 200,
+        "requestId": "stub-clickpipe-get",
+    });
+    Mock::given(method("GET"))
+        .and(path(CLICKPIPE_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(stub_pipe))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_clickpipe_settings_put(mock: &MockServer, result: Value) {
+    let updated_settings = serde_json::json!({
+        "result": result,
+        "status": 200,
+        "requestId": "stub-settings-update",
+    });
+    Mock::given(method("PUT"))
+        .and(path(CLICKPIPE_SETTINGS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(updated_settings))
+        .mount(mock)
+        .await;
+}
+
+/// The (method, path) pairs the mock saw, in order.
+async fn recorded_request_shape(mock: &MockServer) -> Vec<(String, String)> {
+    mock.received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|request| {
+            (
+                request.method.as_str().to_string(),
+                request.url.path().to_string(),
+            )
+        })
+        .collect()
+}
+
+async fn recorded_put_body(mock: &MockServer) -> Value {
+    let requests = mock.received_requests().await.unwrap();
+    let put = requests
+        .iter()
+        .find(|request| request.method == wiremock::http::Method::PUT)
+        .expect("no settings PUT request recorded by mock");
+    serde_json::from_slice::<Value>(&put.body).unwrap()
+}
+
+#[tokio::test]
+async fn clickpipe_settings_update_omits_kafka_only_settings_for_non_kafka_pipes() {
+    for source in [
+        serde_json::json!({ "objectStorage": { "type": "s3", "format": "JSONEachRow" } }),
+        serde_json::json!({ "postgres": { "host": "db.example.com" } }),
+        // A response that drops `source` entirely is treated as non-Kafka.
+        serde_json::json!({}),
+    ] {
+        let mock = MockServer::start().await;
+        mount_clickpipe_get(&mock, source.clone()).await;
+        mount_clickpipe_settings_put(
+            &mock,
+            serde_json::json!({ "object_storage_max_file_count": 200 }),
+        )
+        .await;
+
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "clickpipe",
+                "settings",
+                "update",
+                "svc-id",
+                "pipe-id",
+                "--object-storage-max-file-count",
+                "200",
+                "--org-id",
+                "org",
+            ],
+        );
+        assert_success(&output);
+
+        // No settings GET: nothing needs reading back when no Kafka-only
+        // setting is being re-sent.
+        assert_eq!(
+            recorded_request_shape(&mock).await,
+            vec![
+                ("GET".to_string(), CLICKPIPE_PATH.to_string()),
+                ("PUT".to_string(), CLICKPIPE_SETTINGS_PATH.to_string()),
+            ],
+            "unexpected requests for source {source}"
+        );
+        assert_eq!(
+            recorded_put_body(&mock).await,
+            serde_json::json!({ "object_storage_max_file_count": 200 }),
+            "kafka-only settings leaked for source {source}"
+        );
+    }
+}
 
 #[tokio::test]
 async fn clickpipe_settings_update_preserves_or_defaults_kafka_read_committed() {
-    let settings_path = "/v1/organizations/org/services/svc-id/clickpipes/pipe-id/settings";
     for (current_settings, expected) in [
         (serde_json::json!({ "kafka_read_committed": true }), true),
+        (serde_json::json!({ "kafka_read_committed": false }), false),
         (serde_json::json!({}), false),
     ] {
         let mock = MockServer::start().await;
+        mount_clickpipe_get(
+            &mock,
+            serde_json::json!({ "kafka": { "type": "kafka", "brokers": "b:9092" } }),
+        )
+        .await;
         let current_settings = serde_json::json!({
             "result": current_settings,
             "status": 200,
             "requestId": "stub-settings-get",
         });
-        let updated_settings = serde_json::json!({
-            "result": {
-                "streaming_max_insert_wait_ms": 1000,
-                "kafka_read_committed": expected,
-            },
-            "status": 200,
-            "requestId": "stub-settings-update",
-        });
-
         Mock::given(method("GET"))
-            .and(path(settings_path))
+            .and(path(CLICKPIPE_SETTINGS_PATH))
             .respond_with(ResponseTemplate::new(200).set_body_json(current_settings))
             .mount(&mock)
             .await;
-        Mock::given(method("PUT"))
-            .and(path(settings_path))
-            .respond_with(ResponseTemplate::new(200).set_body_json(updated_settings))
-            .mount(&mock)
-            .await;
+        mount_clickpipe_settings_put(
+            &mock,
+            serde_json::json!({
+                "streaming_max_insert_wait_ms": 1000,
+                "kafka_read_committed": expected,
+            }),
+        )
+        .await;
 
         let output = invoke_cli_with_cloud_credentials(
             &mock,
@@ -6490,30 +6606,16 @@ async fn clickpipe_settings_update_preserves_or_defaults_kafka_read_committed() 
         );
         assert_success(&output);
 
-        let requests = mock.received_requests().await.unwrap();
-        let request_shape = requests
-            .iter()
-            .map(|request| {
-                (
-                    request.method.as_str().to_string(),
-                    request.url.path().to_string(),
-                )
-            })
-            .collect::<Vec<_>>();
         assert_eq!(
-            request_shape,
+            recorded_request_shape(&mock).await,
             vec![
-                ("GET".to_string(), settings_path.to_string()),
-                ("PUT".to_string(), settings_path.to_string()),
+                ("GET".to_string(), CLICKPIPE_PATH.to_string()),
+                ("GET".to_string(), CLICKPIPE_SETTINGS_PATH.to_string()),
+                ("PUT".to_string(), CLICKPIPE_SETTINGS_PATH.to_string()),
             ]
         );
-
-        let put = requests
-            .iter()
-            .find(|request| request.method == wiremock::http::Method::PUT)
-            .expect("no settings PUT request recorded by mock");
         assert_eq!(
-            serde_json::from_slice::<Value>(&put.body).unwrap(),
+            recorded_put_body(&mock).await,
             serde_json::json!({
                 "streaming_max_insert_wait_ms": 1000,
                 "kafka_read_committed": expected,


### PR DESCRIPTION
## What

`clickhousectl cloud clickpipe settings update` failed for **every** non-Kafka pipe, whatever flags were passed:

```
$ chctl cloud clickpipe settings update <svc> <object-storage-pipe> --object-storage-max-file-count 200
Error: Setting 'kafka_read_committed' is only supported for Kafka ClickPipes
```

The handler unconditionally read the current settings and re-sent `kafka_read_committed` (defaulting to `false` when absent) in every PUT.

## Why the API library changed too

`kafka_read_committed` was a required `bool` on `ClickPipeSettingsPutRequest`, so the key could not be left off the wire at all. The spec schema carries no `required[]`, so requiredness resolved from the `"Optional"` description heuristic. The field is now `Option<bool>` with `skip_serializing_if`, plus a documented `optionality_exemptions` entry, so the drift analyzer keeps checking field presence and enum values without demanding the key on every request (same shape as the `ClickPipePostKafkaSource.authentication` exemption on the base branch).

## Behaviour after the fix

- The handler fetches the pipe first and classifies its source.
- **Kafka pipes**: unchanged — the current `kafka_read_committed` is read back from the settings endpoint and re-sent, so the PUT does not reset it.
- **Every other source** (object storage, Postgres, MySQL, MongoDB, Kinesis, BigQuery — and a response that drops `source` entirely): the key is omitted, and the settings GET is skipped.
- Audit of the other settings: they are all source-agnostic in the request and, as before, only appear on the wire when the user passed the matching flag, so the API validates applicability per source. Only `kafka_read_committed` was unconditional.
- Request construction moved into `build_clickpipe_settings_request` over a `ClickPipeSettingsValues` struct, replacing the twelve-argument handler.

## Tests

- Builder unit tests: non-Kafka omission (including an empty body when no flags are given), every flag set with a preserved Kafka value (`true` and `false`).
- Unit tests for the Kafka / object-storage / Postgres / absent-source classification.
- Wiremock subprocess tests (`tests/cli_request_shape_test.rs`): object-storage, Postgres and source-less pipe updates send no kafka field and issue only `GET pipe` + `PUT settings`; a Kafka pipe update still issues `GET pipe` + `GET settings` + `PUT settings` and preserves the value.
- Library tests: an absent `kafka_read_committed` is omitted rather than serialized as `null`; the settings PUT body is no longer strict while the create-position `ClickPipeSettings` still is.
- README note plus a README-pinning test.
- Verified: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clickhousectl`, `cargo test -p clickhouse-cloud-api --lib --test models_test --test client_test --test spec_coverage_test`, `cargo test -p clickhouse-openapi-analyzer`, `cargo check --workspace --all-features`.

## Stacking

Part of a stacked PR chain: based on `fix/606-kafka-no-auth`, not `main`.

Fixes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)