### PR TITLE
Guard `local remove` against running servers in any project

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ clickhousectl local list --remote           # Available for download
 
 # Remove a version
 clickhousectl local remove 26.8.1.1760
-clickhousectl local remove 26.8.1.1760 --force   # Stop running servers on this version, and remove it even if it is the default
+clickhousectl local remove 26.8.1.1760 --force   # Stop running servers on this version (in any project), and remove it even if it is the default
 ```
 
 `local use` also creates a symlink at `~/.local/bin/clickhouse` pointing to the selected version's binary, so the plain `clickhouse` command (e.g. `clickhouse local`, `clickhouse client`) is on PATH. Pass `--no-global` to skip. If a regular file already exists at that path it is left alone with a warning.
 
-`local remove` refuses to delete a version while a local server is running on it (it would leave the server pointing at a deleted binary), failing with the running server names. Stop the server first, or pass `--force` to stop the running server(s) and then remove the version.
+`local remove` refuses to delete a version while a local server is running on it (it would leave the server pointing at a deleted binary), failing with exit `1` and JSON error code `server_running`. Because versions are shared between projects, the check spans **every** project, not just the current directory: the error names each blocking server with the project root it was started from and its PID, so a server found by `clickhousectl local server list --global` is identifiable. Stop those servers first (`clickhousectl local server stop --global <name>`), or pass `--force` to stop them — in whichever project they run — and then remove the version.
 
 `local remove` also refuses to delete the **current default version** (exit `1`, JSON error code `version_is_default`): removing it clears the `~/.clickhouse/default` marker and the global `~/.local/bin/clickhouse` symlink, and the exact build is not always re-downloadable — `builds.clickhouse.com` does not serve every exact build, which can leave a master-channel build unrecoverable. Switch the default first with `clickhousectl local use <other-version>`, or pass `--force` to remove it anyway. A forced removal stops any running servers on the version, warns on stderr before the version itself is deleted, then reports `was_default: true` in its output and clears both the default marker and the global symlink; set a new default with `clickhousectl local use latest`.
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -390,8 +390,13 @@ pub enum Error {
     #[error("Version {0} is already installed")]
     VersionAlreadyInstalled(String),
 
+    /// `local remove` was asked to delete a version that a running server was
+    /// started from. The blocking servers are named with their project root
+    /// because the check spans every project, not just the current directory:
+    /// deleting the binary breaks a server started elsewhere just as badly.
     #[error(
-        "Version {version} is in use by running server(s): {servers}. Stop them first, or pass --force."
+        "Version {version} is in use by running server(s), in this project or another: {servers}. \
+         Stop them first (`clickhousectl local server stop --global <name>`), or pass --force to stop them and remove the version."
     )]
     VersionInUse { version: String, servers: String },
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -207,8 +207,10 @@ CONTEXT FOR AGENTS:
   Removes an installed ClickHouse version from ~/.clickhouse/versions/.
   Takes an exact version string as shown by `clickhousectl local list` (e.g., \"25.12.5.44\").
   Does NOT accept keywords like \"stable\" — use the exact version number.
-  Fails if a local server is currently running on this version; stop it first, or pass
-  --force to stop the running server(s) before removing.
+  Fails if a local server is currently running on this version, in ANY project (versions are
+  shared, so a server started from another directory is checked too — see
+  `clickhousectl local server list --global`). The error names each blocking server with its
+  project root and PID; stop them first, or pass --force to stop them before removing.
   Fails if the version is the current default (removing it clears ~/.clickhouse/default and
   the global ~/.local/bin/clickhouse symlink, and the exact build may not be
   re-downloadable). Switch the default with `clickhousectl local use <other-version>` first,
@@ -219,7 +221,7 @@ CONTEXT FOR AGENTS:
         // Keep this opaque: removal matches an installed directory name instead of resolving a version spec.
         version: String,
 
-        /// Stop any running servers using this version, and remove it even when it is the default (clearing ~/.clickhouse/default and the global symlink)
+        /// Stop any running servers using this version, in any project, and remove it even when it is the default (clearing ~/.clickhouse/default and the global symlink)
         #[arg(long)]
         force: bool,
     },

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -214,26 +214,29 @@ fn remove(version: &str, force: bool, json: bool) -> Result<()> {
         });
     }
 
-    // Recover orphaned servers so we detect a running process even when its
-    // metadata file is missing, then refuse to pull the binary out from under
-    // a server running on this version.
-    server::recover_current_project_servers()?;
-    let in_use: Vec<String> = server::list_running_servers()?
-        .into_iter()
-        .filter(|i| i.version == version)
-        .map(|i| i.name)
-        .collect();
+    // Refuse to pull the binary out from under a server running on this
+    // version. The lookup spans every project, not just this one: a server
+    // started from another directory is invisible to project-scoped metadata,
+    // but deleting its binary breaks `local client` there just the same.
+    let in_use = server::servers_using_version(version)?;
     if !in_use.is_empty() {
         if !force {
             return Err(Error::VersionInUse {
                 version: version.to_string(),
-                servers: in_use.join(", "),
+                servers: server::describe_version_users(&in_use),
             });
         }
-        for name in &in_use {
-            server::kill_server(name)?;
+        for user in &in_use {
+            // Servers in this project are stopped through their metadata so it
+            // stays consistent; servers elsewhere can only be stopped by PID,
+            // exactly like `server stop --global`.
+            if user.current_project {
+                server::kill_server(&user.name)?;
+            } else {
+                server::kill_server_by_pid(user.pid)?;
+            }
             if !json {
-                println!("Stopped server '{}'", name);
+                println!("Stopped server '{}' in {}", user.name, user.project);
             }
         }
     }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -229,11 +229,12 @@ fn remove(version: &str, force: bool, json: bool) -> Result<()> {
         for user in &in_use {
             // Servers in this project are stopped through their metadata so it
             // stays consistent; servers elsewhere can only be stopped by PID,
-            // exactly like `server stop --global`.
+            // like `server stop --global`, except that a blocker which exited
+            // on its own since discovery is already what --force wants.
             if user.current_project {
                 server::kill_server(&user.name)?;
             } else {
-                server::kill_server_by_pid(user.pid)?;
+                server::ensure_stopped_by_pid(user.pid)?;
             }
             if !json {
                 println!("Stopped server '{}' in {}", user.name, user.project);

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -201,10 +201,15 @@ impl LocalErrorOutput {
                 message: format!("Server '{name}' is running"),
                 command: Some("clickhousectl local server list"),
             },
-            Error::VersionInUse { .. } => LocalErrorDetail {
+            // The blocking servers are named — including their project root —
+            // because they may live outside the current project, where neither
+            // `server list` nor the caller's own state can find them.
+            Error::VersionInUse { version, servers } => LocalErrorDetail {
                 code: LocalErrorCode::ServerRunning,
-                message: "A running server is using this version".to_string(),
-                command: Some("clickhousectl local server list"),
+                message: format!(
+                    "Version {version} is in use by running server(s), in this project or another: {servers}"
+                ),
+                command: Some("clickhousectl local server list --global"),
             },
             Error::VersionIsDefault { .. } => LocalErrorDetail {
                 code: LocalErrorCode::VersionIsDefault,

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -1151,6 +1151,21 @@ pub fn kill_server_by_pid(pid: u32) -> Result<()> {
     kill_process(pid)
 }
 
+/// Make sure the server discovered at `pid` is no longer running, for
+/// `local remove --force` stopping a blocker in another project.
+///
+/// Unlike [`kill_server_by_pid`], a process that has already exited is not an
+/// error: the discovery scan and this call are separated by other blockers
+/// being stopped, and a server that went away on its own is exactly the state
+/// the removal is after. `server stop --global` keeps the strict variant, where
+/// a PID that vanished since the listing is worth telling the user about.
+pub fn ensure_stopped_by_pid(pid: u32) -> Result<()> {
+    match kill_server_by_pid(pid) {
+        Err(Error::ServerNotRunning(_)) => Ok(()),
+        other => other,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1502,6 +1517,32 @@ mod tests {
 
         let tcp_error = resolve_ports(None, Some(0)).unwrap_err();
         assert!(matches!(tcp_error, Error::Exec(msg) if msg.contains("--tcp-port 0")));
+    }
+
+    // ── ensure_stopped_by_pid (issue #600) ─────────────────────────────
+
+    /// A PID that certainly belonged to a process and certainly has exited:
+    /// the fake server `local remove` discovered but which quit before
+    /// `--force` reached it.
+    fn exited_pid() -> u32 {
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn short-lived process");
+        child.wait().expect("reap short-lived process");
+        child.id()
+    }
+
+    #[test]
+    fn a_blocker_that_exited_since_discovery_counts_as_stopped() {
+        let pid = exited_pid();
+
+        assert!(
+            matches!(kill_server_by_pid(pid), Err(Error::ServerNotRunning(_))),
+            "`server stop --global` keeps reporting a vanished PID"
+        );
+        ensure_stopped_by_pid(pid).expect("an already-exited blocker must not abort the removal");
     }
 
     // ── select_version_users / describe_version_users (issue #600) ──────

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -958,12 +958,20 @@ pub fn recover_current_project_servers() -> Result<()> {
 }
 
 pub(crate) fn recover_current_project_servers_locked(lock: &MetadataLock) -> Result<()> {
+    recover_from_discovered_locked(&discovery::discover_clickhouse_processes(), lock)
+}
+
+/// Recovery over an already-completed process scan, so a caller that also needs
+/// the global view pays for `pgrep`/`lsof` once.
+fn recover_from_discovered_locked(
+    processes: &[discovery::DiscoveredProcess],
+    lock: &MetadataLock,
+) -> Result<()> {
     let current_dir = std::env::current_dir()?
         .canonicalize()?
         .display()
         .to_string();
 
-    let processes = discovery::discover_clickhouse_processes();
     for proc in processes {
         // Canonicalize the discovered project root for comparison
         let discovered_root = match std::path::Path::new(&proc.project_root).canonicalize() {
@@ -977,9 +985,12 @@ pub(crate) fn recover_current_project_servers_locked(lock: &MetadataLock) -> Res
 
         validate_server_name(&proc.server_name)?;
         let info = ServerInfo {
-            name: proc.server_name,
+            name: proc.server_name.clone(),
             pid: proc.pid,
-            version: proc.version.unwrap_or_else(|| "unknown".to_string()),
+            version: proc
+                .version
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
             http_port: proc.http_port.unwrap_or(0),
             tcp_port: proc.tcp_port.unwrap_or(0),
             started_at: "recovered".to_string(),
@@ -1019,20 +1030,115 @@ pub struct GlobalServerEntry {
 /// (Postgres containers are not currently merged in — a future change will add
 /// `docker ps` based discovery here as well.)
 pub fn list_all_servers_global() -> Vec<GlobalServerEntry> {
-    let processes = discovery::discover_clickhouse_processes();
+    global_entries(&discovery::discover_clickhouse_processes())
+}
+
+fn global_entries(processes: &[discovery::DiscoveredProcess]) -> Vec<GlobalServerEntry> {
     processes
-        .into_iter()
+        .iter()
         .map(|p| GlobalServerEntry {
-            name: p.server_name,
+            name: p.server_name.clone(),
             pid: p.pid,
-            project: p.project_root,
+            project: p.project_root.clone(),
             http_port: p.http_port,
             tcp_port: p.tcp_port,
-            version: p.version,
+            version: p.version.clone(),
             engine: Engine::Clickhouse,
             container_id: None,
         })
         .collect()
+}
+
+/// A running server that occupies an installed ClickHouse version, wherever it
+/// was started from. Produced by [`servers_using_version`] for `local remove`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionUser {
+    pub name: String,
+    /// Project root the server was started from.
+    pub project: String,
+    pub pid: u32,
+    /// True when the server belongs to the current project, so its metadata is
+    /// reachable and [`kill_server`] can keep it consistent. Servers in other
+    /// projects can only be stopped by PID, like `server stop --global`.
+    pub current_project: bool,
+}
+
+/// Every running server — in this project and in every other project — that is
+/// running `version`.
+///
+/// `local remove` deletes a binary that running servers hold open, so the guard
+/// has to see past the current project's metadata (issue #600).
+pub fn servers_using_version(version: &str) -> Result<Vec<VersionUser>> {
+    // One process scan feeds both sources: discovery shells out to
+    // `pgrep`/`lsof`/`ps`, so scanning twice would double the cost of the guard.
+    let processes = discovery::discover_clickhouse_processes();
+    let project_servers = {
+        let lock = lock_metadata()?;
+        // Recover orphans first so a server whose metadata file is missing is
+        // still counted.
+        recover_from_discovered_locked(&processes, &lock)?;
+        list_running_servers_locked(&lock)?
+    };
+    Ok(select_version_users(
+        &project_servers,
+        &global_entries(&processes),
+        version,
+    ))
+}
+
+/// Merge project-scoped metadata with global process discovery and select the
+/// servers running `version`.
+///
+/// Both sources are consulted because each covers a gap in the other: metadata
+/// is project-scoped but survives a failed process scan, while discovery spans
+/// projects but depends on `pgrep`/`lsof`/`/proc`. The same server appears in
+/// both, so entries are de-duplicated by PID — metadata for a running server
+/// always carries the live PID of the discovered process.
+pub(crate) fn select_version_users(
+    project_servers: &[ServerInfo],
+    global: &[GlobalServerEntry],
+    version: &str,
+) -> Vec<VersionUser> {
+    let mut users: Vec<VersionUser> = project_servers
+        .iter()
+        .filter(|info| info.version == version)
+        .map(|info| VersionUser {
+            name: info.name.clone(),
+            project: info.cwd.clone(),
+            pid: info.pid,
+            current_project: true,
+        })
+        .collect();
+
+    for entry in global {
+        // A process whose version could not be read is treated as non-matching:
+        // blocking every removal on an unreadable command line would be
+        // unfixable by the user.
+        if entry.version.as_deref() != Some(version) {
+            continue;
+        }
+        if users.iter().any(|user| user.pid == entry.pid) {
+            continue;
+        }
+        users.push(VersionUser {
+            name: entry.name.clone(),
+            project: entry.project.clone(),
+            pid: entry.pid,
+            current_project: false,
+        });
+    }
+
+    users
+}
+
+/// Name the blocking servers for the `VersionInUse` error, so a server in
+/// another project is identifiable from the message alone.
+pub(crate) fn describe_version_users(users: &[VersionUser]) -> String {
+    users
+        .iter()
+        .map(|user| format!("'{}' in {} (PID {})", user.name, user.project, user.pid))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Kill a server found via global process discovery.
@@ -1396,5 +1502,147 @@ mod tests {
 
         let tcp_error = resolve_ports(None, Some(0)).unwrap_err();
         assert!(matches!(tcp_error, Error::Exec(msg) if msg.contains("--tcp-port 0")));
+    }
+
+    // ── select_version_users / describe_version_users (issue #600) ──────
+
+    fn named_info(name: &str, pid: u32, version: &str, project: &str) -> ServerInfo {
+        ServerInfo {
+            name: name.into(),
+            cwd: project.into(),
+            ..test_info(pid, version)
+        }
+    }
+
+    fn global_entry(
+        name: &str,
+        pid: u32,
+        version: Option<&str>,
+        project: &str,
+    ) -> GlobalServerEntry {
+        GlobalServerEntry {
+            name: name.into(),
+            pid,
+            project: project.into(),
+            http_port: Some(8123),
+            tcp_port: Some(9000),
+            version: version.map(str::to_string),
+            engine: Engine::Clickhouse,
+            container_id: None,
+        }
+    }
+
+    #[test]
+    fn no_running_server_on_the_version_leaves_it_free_to_remove() {
+        let users = select_version_users(
+            &[named_info("default", 10, "25.12.9.61", "/a")],
+            &[global_entry("dev", 20, Some("25.12.9.61"), "/b")],
+            "26.9.1.217",
+        );
+
+        assert!(users.is_empty());
+    }
+
+    #[test]
+    fn a_server_in_another_project_blocks_the_version() {
+        let users = select_version_users(
+            &[],
+            &[global_entry("dev", 4242, Some("26.9.1.217"), "/other")],
+            "26.9.1.217",
+        );
+
+        assert_eq!(
+            users,
+            vec![VersionUser {
+                name: "dev".into(),
+                project: "/other".into(),
+                pid: 4242,
+                current_project: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn the_same_server_seen_in_metadata_and_discovery_is_reported_once() {
+        let users = select_version_users(
+            &[named_info("default", 777, "26.9.1.217", "/here")],
+            &[global_entry("default", 777, Some("26.9.1.217"), "/here")],
+            "26.9.1.217",
+        );
+
+        assert_eq!(
+            users,
+            vec![VersionUser {
+                name: "default".into(),
+                project: "/here".into(),
+                pid: 777,
+                current_project: true,
+            }],
+            "the current project's metadata entry wins, so --force can stop it by name"
+        );
+    }
+
+    #[test]
+    fn servers_from_both_sources_are_merged() {
+        let users = select_version_users(
+            &[named_info("default", 1, "26.9.1.217", "/here")],
+            &[
+                global_entry("default", 1, Some("26.9.1.217"), "/here"),
+                global_entry("dev", 2, Some("26.9.1.217"), "/there"),
+                global_entry("old", 3, Some("25.12.9.61"), "/there"),
+            ],
+            "26.9.1.217",
+        );
+
+        assert_eq!(
+            users
+                .iter()
+                .map(|user| (user.name.as_str(), user.pid, user.current_project))
+                .collect::<Vec<_>>(),
+            vec![("default", 1, true), ("dev", 2, false)]
+        );
+    }
+
+    #[test]
+    fn a_discovered_process_with_an_unreadable_version_does_not_block() {
+        let users =
+            select_version_users(&[], &[global_entry("dev", 9, None, "/other")], "26.9.1.217");
+
+        assert!(
+            users.is_empty(),
+            "an unknown version must not make removal impossible"
+        );
+    }
+
+    #[test]
+    fn a_postgres_container_never_matches_a_clickhouse_version() {
+        let mut postgres = named_info("pg", 0, "postgres:17", "/here");
+        postgres.engine = Engine::Postgres;
+        postgres.container_id = Some("abc123".into());
+
+        assert!(select_version_users(&[postgres], &[], "26.9.1.217").is_empty());
+    }
+
+    #[test]
+    fn described_users_name_the_server_the_project_and_the_pid() {
+        let described = describe_version_users(&[
+            VersionUser {
+                name: "default".into(),
+                project: "/here".into(),
+                pid: 1,
+                current_project: true,
+            },
+            VersionUser {
+                name: "dev".into(),
+                project: "/there".into(),
+                pid: 2,
+                current_project: false,
+            },
+        ]);
+
+        assert_eq!(
+            described,
+            "'default' in /here (PID 1), 'dev' in /there (PID 2)"
+        );
     }
 }

--- a/crates/clickhousectl/tests/local_remove_global_guard_test.rs
+++ b/crates/clickhousectl/tests/local_remove_global_guard_test.rs
@@ -1,0 +1,407 @@
+//! Subprocess coverage for the cross-project `local remove` running-server
+//! guard (issue #600).
+//!
+//! Strategy: an isolated `HOME` with three fake installed versions, two project
+//! directories, and deterministic `pgrep`/`lsof`/`ps` stand-ins on `PATH` (the
+//! same technique as `local_server_state_machine_test.rs`) so process discovery
+//! only ever sees this fixture's fake servers. A server is started in project B
+//! and `local remove` is then run from project A, where the server is invisible
+//! to project-scoped metadata.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// The version the fake server in the other project runs on.
+const RUNNING_VERSION: &str = "26.9.1.217";
+/// The default version, so the issue-599 default guard never masks this one.
+const DEFAULT_VERSION: &str = "25.12.9.61";
+/// Installed and used by nothing.
+const UNUSED_VERSION: &str = "24.8.1.1";
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+struct ProcessGuard {
+    pid_file: PathBuf,
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        let Ok(contents) = std::fs::read_to_string(&self.pid_file) else {
+            return;
+        };
+        for pid in contents
+            .lines()
+            .filter_map(|line| line.split('|').next()?.parse::<i32>().ok())
+        {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+struct Fixture {
+    // Drop the process guard before removing directories used as process CWDs.
+    _processes: ProcessGuard,
+    _root: tempfile::TempDir,
+    home: PathBuf,
+    project_a: PathBuf,
+    project_b: PathBuf,
+    pid_file: PathBuf,
+    path: String,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let root = tempfile::Builder::new()
+            .prefix(&format!("clickhousectl-remove-global-{label}-"))
+            .tempdir()
+            .expect("create isolated test root");
+        let home = root.path().join("home");
+        let project_a = root.path().join("project-a");
+        let project_b = root.path().join("project-b");
+        let pid_file = root.path().join("fake-clickhouse-pids");
+        let tools = root.path().join("fake-tools");
+
+        std::fs::create_dir_all(home.join(".clickhouse")).expect("create isolated HOME");
+        std::fs::create_dir_all(&project_a).expect("create project A");
+        std::fs::create_dir_all(&project_b).expect("create project B");
+        std::fs::create_dir_all(&tools).expect("create fake process tools directory");
+
+        for version in [RUNNING_VERSION, DEFAULT_VERSION, UNUSED_VERSION] {
+            let binary = version_binary(&home, version);
+            std::fs::create_dir_all(binary.parent().expect("fake binary parent"))
+                .expect("create fake version directory");
+            // Records `<pid>|<cwd>|<version>` for the fake process tools, then
+            // blocks so the server stays "running" for the whole test.
+            write_executable(
+                &binary,
+                &format!(
+                    "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$$\" \"$PWD\" '{version}' >> \"$FAKE_CLICKHOUSE_PID_FILE\"\nexec /bin/sleep 300\n"
+                ),
+            );
+        }
+
+        std::fs::write(home.join(".clickhouse/default"), DEFAULT_VERSION)
+            .expect("write default marker");
+        seed_update_cache(&home);
+
+        // Deterministic stand-ins: they expose only this fixture's live fake
+        // processes, so the global scan cannot see (or kill) anything else on
+        // the machine, and does not depend on platform process names.
+        write_executable(
+            &tools.join("pgrep"),
+            "#!/bin/sh\n[ -f \"$FAKE_CLICKHOUSE_PID_FILE\" ] || exit 1\nfound=1\nwhile IFS='|' read -r pid cwd version; do\n  if kill -0 \"$pid\" 2>/dev/null; then\n    printf '%s\\n' \"$pid\"\n    found=0\n  fi\ndone < \"$FAKE_CLICKHOUSE_PID_FILE\"\nexit \"$found\"\n",
+        );
+        write_executable(
+            &tools.join("lsof"),
+            "#!/bin/sh\n[ -f \"$FAKE_CLICKHOUSE_PID_FILE\" ] || exit 1\nwhile IFS='|' read -r pid cwd version; do\n  if kill -0 \"$pid\" 2>/dev/null; then\n    printf 'p%s\\nfcwd\\nn%s\\n' \"$pid\" \"$cwd\"\n  fi\ndone < \"$FAKE_CLICKHOUSE_PID_FILE\"\n",
+        );
+        // `ps -o args= -p <pid>`: the version is what the guard matches on, so
+        // it has to come from the requested PID's own record.
+        write_executable(
+            &tools.join("ps"),
+            "#!/bin/sh\nfor arg in \"$@\"; do target=\"$arg\"; done\n[ -f \"$FAKE_CLICKHOUSE_PID_FILE\" ] || exit 1\nwhile IFS='|' read -r pid cwd version; do\n  if [ \"$pid\" = \"$target\" ]; then\n    printf '%s\\n' \"$HOME/.clickhouse/versions/$version/clickhouse server --http_port=8123 --tcp_port=9000\"\n    exit 0\n  fi\ndone < \"$FAKE_CLICKHOUSE_PID_FILE\"\nexit 1\n",
+        );
+        let path = format!("{}:/usr/bin:/bin:/usr/sbin:/sbin", tools.display());
+
+        Self {
+            _processes: ProcessGuard {
+                pid_file: pid_file.clone(),
+            },
+            _root: root,
+            home,
+            project_a,
+            project_b,
+            pid_file,
+            path,
+        }
+    }
+
+    fn run(&self, cwd: &Path, args: &[&str]) -> Output {
+        Command::new(clickhousectl_binary())
+            // `env_clear` keeps coding-agent detection from switching the
+            // subprocess to JSON, so human-output assertions stay meaningful.
+            .env_clear()
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", &self.home)
+            .env("PATH", &self.path)
+            .env("FAKE_CLICKHOUSE_PID_FILE", &self.pid_file)
+            .current_dir(cwd)
+            .args(args)
+            .output()
+            .expect("run shipped clickhousectl binary")
+    }
+
+    /// Start a fake server on `RUNNING_VERSION` in `project`, returning its PID.
+    fn start_server(&self, project: &Path, name: &str) -> u32 {
+        let output = self.run(
+            project,
+            &[
+                "local",
+                "--json",
+                "server",
+                "start",
+                name,
+                "-v",
+                RUNNING_VERSION,
+                "--no-wait",
+            ],
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "start stderr: {}",
+            stderr_of(&output)
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("parse start JSON");
+        assert_eq!(body["version"], RUNNING_VERSION);
+        let pid = body["pid"].as_u64().expect("start PID") as u32;
+        // The guard reads the process's own command line, so wait until the
+        // fake binary has recorded itself for the stand-in tools.
+        wait_for_pid_record(&self.pid_file, pid);
+        assert!(process_is_alive(pid));
+        pid
+    }
+
+    fn version_dir(&self, version: &str) -> PathBuf {
+        self.home.join(".clickhouse/versions").join(version)
+    }
+}
+
+fn version_binary(home: &Path, version: &str) -> PathBuf {
+    home.join(".clickhouse/versions")
+        .join(version)
+        .join("clickhouse")
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    std::fs::write(path, contents).expect("write fake executable");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake executable executable");
+}
+
+fn seed_update_cache(home: &Path) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_secs();
+    std::fs::write(
+        home.join(".clickhouse/last_update_check"),
+        format!("{now}\n{}", env!("CARGO_PKG_VERSION")),
+    )
+    .expect("seed fresh update cache");
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    i32::try_from(pid).is_ok_and(|pid| unsafe { libc::kill(pid, 0) == 0 })
+}
+
+fn wait_for_process_exit(pid: u32) {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    while process_is_alive(pid) {
+        assert!(Instant::now() < deadline, "PID {pid} did not exit");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_pid_record(pid_file: &Path, pid: u32) {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let recorded = std::fs::read_to_string(pid_file).unwrap_or_default();
+        if recorded
+            .lines()
+            .any(|line| line.split('|').next() == Some(&pid.to_string()))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "fake ClickHouse {pid} never recorded itself: {recorded}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn canonical(path: &Path) -> String {
+    path.canonicalize()
+        .expect("canonicalize project path")
+        .display()
+        .to_string()
+}
+
+#[test]
+fn removing_a_version_a_server_in_another_project_runs_is_refused() {
+    let fixture = Fixture::new("other-project");
+    let pid = fixture.start_server(&fixture.project_b, "dev");
+
+    let output = fixture.run(&fixture.project_a, &["local", "remove", RUNNING_VERSION]);
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    for required in [
+        RUNNING_VERSION,
+        "'dev'",
+        &canonical(&fixture.project_b),
+        &format!("PID {pid}"),
+        "--force",
+    ] {
+        assert!(stderr.contains(required), "missing {required:?}: {stderr}");
+    }
+    assert!(
+        fixture.version_dir(RUNNING_VERSION).exists(),
+        "a refused removal must not delete the version directory"
+    );
+    assert!(
+        process_is_alive(pid),
+        "a refused removal must not stop the server"
+    );
+}
+
+#[test]
+fn the_structured_refusal_names_the_blocking_project_and_the_global_list() {
+    let fixture = Fixture::new("other-project-json");
+    let pid = fixture.start_server(&fixture.project_b, "dev");
+
+    let output = fixture.run(
+        &fixture.project_a,
+        &["local", "--json", "remove", RUNNING_VERSION],
+    );
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(
+        output.stdout.is_empty(),
+        "runtime errors belong on stderr, got: {}",
+        stdout_of(&output)
+    );
+    let error: serde_json::Value =
+        serde_json::from_str(&stderr).expect("one JSON error object on stderr");
+    assert_eq!(error["error"]["code"], "server_running");
+    let message = error["error"]["message"].as_str().expect("message");
+    for required in [RUNNING_VERSION, "'dev'", &canonical(&fixture.project_b)] {
+        assert!(
+            message.contains(required),
+            "missing {required:?}: {message}"
+        );
+    }
+    assert_eq!(
+        error["error"]["command"],
+        "clickhousectl local server list --global"
+    );
+    assert!(fixture.version_dir(RUNNING_VERSION).exists());
+    assert!(process_is_alive(pid));
+}
+
+#[test]
+fn force_stops_the_other_projects_server_before_removing_the_version() {
+    let fixture = Fixture::new("other-project-force");
+    let pid = fixture.start_server(&fixture.project_b, "dev");
+
+    let output = fixture.run(
+        &fixture.project_a,
+        &["local", "remove", RUNNING_VERSION, "--force"],
+    );
+
+    let stderr = stderr_of(&output);
+    let stdout = stdout_of(&output);
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("Stopped server 'dev' in")
+            && stdout.contains(&canonical(&fixture.project_b)),
+        "--force must report which project's server it stopped: {stdout}"
+    );
+    wait_for_process_exit(pid);
+    assert!(
+        !fixture.version_dir(RUNNING_VERSION).exists(),
+        "--force must remove the version directory"
+    );
+}
+
+#[test]
+fn the_same_project_guard_still_refuses_and_keeps_metadata_consistent() {
+    let fixture = Fixture::new("same-project");
+    let pid = fixture.start_server(&fixture.project_a, "dev");
+
+    let refused = fixture.run(&fixture.project_a, &["local", "remove", RUNNING_VERSION]);
+    assert_eq!(
+        refused.status.code(),
+        Some(1),
+        "stderr: {}",
+        stderr_of(&refused)
+    );
+    assert!(stderr_of(&refused).contains("'dev'"));
+    assert!(process_is_alive(pid));
+
+    let forced = fixture.run(
+        &fixture.project_a,
+        &["local", "remove", RUNNING_VERSION, "--force"],
+    );
+    assert!(
+        forced.status.success(),
+        "expected success, got {:?}\nstderr: {}",
+        forced.status,
+        stderr_of(&forced)
+    );
+    wait_for_process_exit(pid);
+    assert!(!fixture.version_dir(RUNNING_VERSION).exists());
+
+    // Stopping through this project's metadata keeps the recorded server
+    // stopped rather than leaving a stale live PID behind.
+    let metadata: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(fixture.project_a.join(".clickhouse/servers/dev.json"))
+            .expect("read server metadata"),
+    )
+    .expect("parse server metadata");
+    assert_eq!(metadata["pid"], 0);
+    assert_eq!(metadata["version"], "");
+}
+
+#[test]
+fn a_version_nothing_runs_is_removed_while_another_projects_server_keeps_running() {
+    let fixture = Fixture::new("unused-version");
+    let pid = fixture.start_server(&fixture.project_b, "dev");
+
+    let output = fixture.run(
+        &fixture.project_a,
+        &["local", "--json", "remove", UNUSED_VERSION],
+    );
+
+    let stdout = stdout_of(&output);
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}\nstderr: {}",
+        output.status,
+        stderr_of(&output)
+    );
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("one JSON object");
+    assert_eq!(value["version"], UNUSED_VERSION);
+    assert!(!fixture.version_dir(UNUSED_VERSION).exists());
+    assert!(
+        fixture.version_dir(RUNNING_VERSION).exists(),
+        "the in-use version must be untouched"
+    );
+    assert!(
+        process_is_alive(pid),
+        "removing an unrelated version must not stop anything"
+    );
+}

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -58,6 +58,7 @@ NON_INSTALL_EXACT_PATHS = frozenset(
         "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
         "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
         "crates/clickhousectl/tests/local_remove_default_test.rs",
+        "crates/clickhousectl/tests/local_remove_global_guard_test.rs",
         "crates/clickhousectl/tests/local_server_metadata_test.rs",
         "crates/clickhousectl/tests/local_server_name_compatibility_test.rs",
         "crates/clickhousectl/tests/local_server_project_scope_errors_test.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -131,6 +131,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
                     "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
                     "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
                     "crates/clickhousectl/tests/local_remove_default_test.rs",
+                    "crates/clickhousectl/tests/local_remove_global_guard_test.rs",
                     "crates/clickhousectl/tests/local_server_metadata_test.rs",
                     "crates/clickhousectl/tests/local_server_name_compatibility_test.rs",
                     "crates/clickhousectl/tests/local_server_project_scope_errors_test.rs",


### PR DESCRIPTION
## What

`local remove`'s running-server guard was project-scoped: it called `recover_current_project_servers()` and filtered `list_running_servers()`, both of which only see `.clickhouse/servers/` under the current working directory. A server started from another project directory was invisible, so `local remove <its-version>` exited 0 and deleted the binary from under it — the server kept running on its open fd, but `local client -n <name>` in that project then failed with `managed_client_binary_not_found` (issue #600).

The guard now enumerates running servers across **every** project using the same process-discovery machinery behind `local server list --global`, merged with this project's metadata and de-duplicated by PID:

- Both sources are consulted because each covers a gap in the other: metadata is project-scoped but survives a failed process scan, while discovery spans projects but depends on `pgrep`/`lsof`/`/proc`.
- A single discovery pass feeds both orphan recovery and the global view, so the guard does not shell out to `pgrep`/`lsof` twice (`recover_from_discovered_locked` / `global_entries`).
- A discovered process whose version cannot be read is treated as non-matching — blocking every removal on an unreadable command line would be unfixable by the user.

## Why the error and `--force` changed shape

- Refusal is still exit `1` / JSON `server_running`, but the message now names each blocking server as `'<name>' in <project-root> (PID <pid>)`, in both the human error and the structured one, and points at `clickhousectl local server list --global`. Without the project root, a blocker outside the current directory is unactionable.
- `--force` stops blockers wherever they run: through metadata in this project (so the recorded state stays consistent) and by PID elsewhere, exactly like `server stop --global`. Its confirmation line now names the project.

## Tests

- `src/local/server.rs` unit tests for the pure helpers `select_version_users` (no match, other-project match, same server via both sources reported once, merge of both sources, unreadable version, Postgres container never matching a ClickHouse version) and `describe_version_users`.
- New subprocess suite `crates/clickhousectl/tests/local_remove_global_guard_test.rs`: isolated `HOME`, three fake installed versions, two project dirs, and deterministic `pgrep`/`lsof`/`ps` stand-ins on `PATH` (same technique as `local_server_state_machine_test.rs`, so the scan can never see or kill anything else on the machine). Covers the refusal, the structured error and its `command`, `--force` stopping the other project's server before removal, the unchanged same-project path (including metadata left at `pid: 0`), and an unrelated version still removing cleanly while the other project keeps running.
- All four cross-project tests fail against the previous guard (verified by stashing the handler change).
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clickhousectl` all clean.

## Docs

`README.md` and the `local remove` agent help now state that the check spans every project and that the error names the project root and PID.

## Stacked PR

Part of a stacked chain: this PR is based on `fix/599-local-remove-default-guard` (the default-version guard in the same function), not `main`.

Fixes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)