### PR TITLE
Give local JSON errors the same detail and hints as human output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,8 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `network_error` | An HTTP request failed |
 | `docker_unavailable` | Docker could not be reached (the message names the cause and the platform fix) |
 | `docker_error` | A Docker operation failed |
+| `container_name_conflict` | The container name is held by a container clickhousectl does not manage |
+| `postgres_error` | A Postgres validation or state error; the message carries its recovery guidance |
 | `io_error` | A local filesystem, metadata, or serialization operation failed |
 | `local_error` | A redacted fallback for failures whose text cannot be rendered safely |
 

--- a/README.md
+++ b/README.md
@@ -1067,13 +1067,15 @@ Local runtime failures also use structured output when `local --json` is set or 
 }
 ```
 
-`error.code` and `error.message` are always present. General errors can include an optional top-level `error.command` safe recovery command. Project-local `server stop` and `server remove` not-found errors instead include `project_scope`, `server`, and ordered `guidance`; their top-level `command` field is absent. Messages are built from allowlisted fields and never serialize raw I/O errors, credentials, SQL, container logs, Docker diagnostics, or arbitrary fallback details. Human local errors retain the concise `Error: ...` format. Clap usage errors, Cloud errors, and child-process output are not wrapped in this local schema.
+`error.code` and `error.message` are always present. General errors can include an optional top-level `error.command` safe recovery command, which names the step that actually recovers the failure (for example `clickhousectl local server stop dev` when `server remove dev` is refused because that server is running). Project-local `server stop` and `server remove` not-found errors instead include `project_scope`, `server`, and ordered `guidance`; their top-level `command` field is absent.
+
+`error.message` carries the same detail as the human `Error: ...` line whenever clickhousectl composes that text itself — a missing `--config` name lists the configs directory and the available files in both modes. The exception is text that interpolates output clickhousectl does not control: subprocess stderr and log tails (`startup_exit`, `startup_timeout`), Docker daemon strings (`docker_error`), download bodies (`download_failed`), and OS or serialization sources (`io_error`, `local_error`) are summarized instead, so JSON never carries raw I/O errors, credentials, SQL, or container logs. Human local errors retain the concise `Error: ...` format. Clap usage errors, Cloud errors, and child-process output are not wrapped in this local schema.
 
 When `.clickhouse` is absent from the current directory, bare `server stop` includes the same `project_scope` and `guidance` in its successful no-op output, while bare `server remove` includes them in its `server_selection_required` error. This distinguishes a missing project root from an initialized project that has no matching ClickHouse server.
 
 Managed `local client` failures deliberately use dedicated `managed_client_*` codes rather than the general server codes. Their error object includes `project_scope.path` (the canonical directory inspected), `server.selection` and `server.name`, an optional `server.binary_version`, and ordered `guidance` entries with allowlisted messages and optional commands. No raw lock, metadata, or I/O error is included in JSON. The nested shape distinguishes this exact-project lookup contract from failures in other local commands without changing those commands' stable envelopes.
 
-The schema and meanings of existing codes are stable. New optional fields or codes may be added compatibly; unclassified local failures use the bounded `local_error` fallback.
+The schema and meanings of existing codes are stable. New optional fields or codes may be added compatibly; failures whose text cannot be rendered safely use the bounded `local_error` fallback.
 
 | Code | Meaning |
 | ---- | ------- |
@@ -1084,15 +1086,28 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `managed_client_project_state_unavailable` | Managed client lookup could not read or lock current-project server state |
 | `server_selection_required` | A server name is required because omission is ambiguous or unsafe |
 | `server_not_running` | The selected local server exists but is stopped |
-| `server_running` | The operation requires a stopped server |
+| `server_running` | The operation requires a stopped server, or a running server is using the version |
+| `invalid_server_name` | The server name contains path separators or `..` |
+| `unsupported_argument` | An argument was rejected because it would break the managed server lifecycle |
+| `config_not_found` | The named `server start --config` file does not exist, or the name is ambiguous |
+| `invalid_config_name` | The config name is a path rather than a file in the configs dir |
 | `invalid_version` | The version selector is invalid |
-| `version_unavailable` | The requested or configured version is unavailable |
+| `version_not_installed` | The requested or configured version is not installed locally |
+| `version_selection_required` | A version must be chosen because no default is set or the choice is ambiguous |
+| `version_already_installed` | The requested version is already installed |
+| `version_unavailable` | The requested version could not be resolved or downloaded |
+| `version_is_default` | The version is the current default and `--force` was not passed |
+| `unsupported_client_version` | The installed client does not support the requested operation |
+| `unsupported_platform` | No ClickHouse build exists for this OS and architecture |
 | `port_in_use` | A requested port is occupied or no managed port is available |
 | `startup_exit` | A managed server exited before it became ready |
 | `startup_timeout` | A managed server did not become ready before its deadline |
-| `download_failed` | An artifact or image download failed |
+| `download_failed` | An artifact or image download or extraction failed |
+| `network_error` | An HTTP request failed |
+| `docker_unavailable` | Docker could not be reached (the message names the cause and the platform fix) |
+| `docker_error` | A Docker operation failed |
 | `io_error` | A local filesystem, metadata, or serialization operation failed |
-| `local_error` | A redacted fallback for other local runtime failures |
+| `local_error` | A redacted fallback for failures whose text cannot be rendered safely |
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -1084,11 +1084,11 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `managed_client_server_not_running` | The managed client server exists in the current project but is stopped |
 | `managed_client_binary_not_found` | The client binary selected by managed server metadata is not installed |
 | `managed_client_project_state_unavailable` | Managed client lookup could not read or lock current-project server state |
-| `server_selection_required` | A server name is required because omission is ambiguous or unsafe |
+| `server_selection_required` | A server name (or, for `server stop --global`, a `--project`) is required because the selection is ambiguous or unsafe |
 | `server_not_running` | The selected local server exists but is stopped |
 | `server_running` | The operation requires a stopped server, or a running server is using the version |
 | `invalid_server_name` | The server name contains path separators or `..` |
-| `unsupported_argument` | An argument was rejected because it would break the managed server lifecycle |
+| `unsupported_argument` | An argument was rejected because it would break the managed server lifecycle (a pass-through `--config`, or `--http-port`/`--tcp-port` `0`) |
 | `config_not_found` | The named `server start --config` file does not exist, or the name is ambiguous |
 | `invalid_config_name` | The config name is a path rather than a file in the configs dir |
 | `invalid_version` | The version selector is invalid |

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -481,8 +481,16 @@ pub enum Error {
         details: String,
     },
 
+    /// Postgres failure text clickhousectl does not control (currently the OS
+    /// error from a failed `psql` exec). Summarized in structured output.
     #[error("Postgres error: {0}")]
     Postgres(String),
+
+    /// A Postgres validation or state error whose text clickhousectl composes
+    /// itself, including its recovery guidance. Kept separate from
+    /// [`Error::Postgres`] so structured output can render it verbatim.
+    #[error("Postgres error: {0}")]
+    PostgresUsage(String),
 
     /// A child process whose status must be returned unchanged. This is
     /// intentionally not printed as a clickhousectl error by `run_parsed`.
@@ -620,6 +628,15 @@ pub enum Error {
     #[error("Docker error: {0}")]
     #[allow(clippy::enum_variant_names)]
     DockerError(String),
+
+    /// A container name held by a container clickhousectl does not manage.
+    /// Kept separate from [`Error::DockerError`], whose payload is daemon text,
+    /// so structured output can render this self-composed guidance verbatim.
+    #[error(
+        "Docker error: container '{0}' already exists but is not managed by clickhousectl. \
+         Remove it manually or pick a different --name."
+    )]
+    ContainerNameConflict(String),
 
     #[error("{primary}\nPostgres startup rollback incomplete: {cleanup}")]
     PostgresStartupRollback {

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -454,6 +454,12 @@ pub enum Error {
     #[error("Failed to execute ClickHouse: {0}")]
     Exec(String),
 
+    /// A rejected argument, with self-composed guidance. Kept separate from
+    /// [`Error::Exec`], whose payload is subprocess or OS text and is therefore
+    /// summarized in structured output rather than rendered.
+    #[error("{0}")]
+    UnsupportedArgument(String),
+
     #[error("{kind} port {port} is already in use{}", kind.human_guidance())]
     PortInUse { kind: PortKind, port: u16 },
 
@@ -519,7 +525,7 @@ pub enum Error {
     ServerStopSelectionRequired { available: usize },
 
     #[error(
-        "No server name was provided and the default ClickHouse server does not exist (custom ClickHouse servers available: {available}). Inspect them with `clickhousectl local server list`; to remove one, pass its name with `clickhousectl local server remove <name>`."
+        "No server name was provided and the default ClickHouse server does not exist (custom ClickHouse servers available: {available}); no server was removed. Inspect them with `clickhousectl local server list`; to remove one, pass its name with `clickhousectl local server remove <name>`."
     )]
     ServerRemoveSelectionRequired { available: usize },
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -532,6 +532,15 @@ pub enum Error {
     )]
     ServerStopSelectionRequired { available: usize },
 
+    /// `server stop --global <name>` matched running servers in more than one
+    /// project, so `--project` is needed to pick one. Self-composed guidance
+    /// (the project roots come from process discovery, not foreign output), so
+    /// structured output renders it verbatim.
+    #[error(
+        "Server '{name}' exists in multiple projects: {projects}. Use --project to specify which one."
+    )]
+    ServerInMultipleProjects { name: String, projects: String },
+
     #[error(
         "No server name was provided and the default ClickHouse server does not exist (custom ClickHouse servers available: {available}); no server was removed. Inspect them with `clickhousectl local server list`; to remove one, pass its name with `clickhousectl local server remove <name>`."
     )]

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -449,10 +449,7 @@ pub async fn ensure_name_free(
                 })
                 .unwrap_or(false);
             if !labels_match {
-                return Err(Error::DockerError(format!(
-                    "container '{cname}' already exists but is not managed by clickhousectl. \
-                     Remove it manually or pick a different --name."
-                )));
+                return Err(Error::ContainerNameConflict(cname));
             }
             let id = info.id.unwrap_or(cname.clone());
             let _ = stop_container(docker, &id).await;

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1239,11 +1239,10 @@ fn stop_server_global(
 
     if matches.len() > 1 {
         let projects: Vec<_> = matches.iter().map(|e| e.project.as_str()).collect();
-        return Err(Error::Exec(format!(
-            "Server '{}' exists in multiple projects: {}. Use --project to specify which one.",
+        return Err(Error::ServerInMultipleProjects {
             name,
-            projects.join(", ")
-        )));
+            projects: projects.join(", "),
+        });
     }
 
     let entry = matches[0];

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -551,7 +551,7 @@ async fn start_server(
         .iter()
         .any(|a| a.starts_with("--config") || a.starts_with("-C"))
     {
-        return Err(Error::Exec(
+        return Err(Error::UnsupportedArgument(
             "--config / --config-file / -C cannot be passed through in trailing args. \
              Use `--config <NAME>` with a file in ~/.clickhouse/configs/ \
              (see `clickhousectl local server configs`). \

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -273,6 +273,12 @@ impl LocalErrorOutput {
                 Mapping::parity(LocalErrorCode::ServerSelectionRequired)
                     .command("clickhousectl local server list")
             }
+            // The same ambiguity across projects: the global list shows which
+            // project root to pass to `--project`.
+            Error::ServerInMultipleProjects { .. } => {
+                Mapping::parity(LocalErrorCode::ServerSelectionRequired)
+                    .command("clickhousectl local server list --global")
+            }
             // Deliberately the list, not a `start` command: this variant is
             // also raised for Postgres servers and for global PID lookups,
             // where the name is not a `server start` argument.
@@ -1367,6 +1373,13 @@ mod tests {
                 "server_selection_required",
             ),
             (
+                Error::ServerInMultipleProjects {
+                    name: "dev".into(),
+                    projects: "/a, /b".into(),
+                },
+                "server_selection_required",
+            ),
+            (
                 Error::ServerNotRunning("default".into()),
                 "server_not_running",
             ),
@@ -1450,6 +1463,12 @@ mod tests {
             ),
             (
                 Error::UnsupportedArgument("--config cannot be passed through".into()),
+                "unsupported_argument",
+            ),
+            (
+                Error::UnsupportedArgument(
+                    "--http-port 0 is not allowed; pick a specific port or omit the flag".into(),
+                ),
                 "unsupported_argument",
             ),
             (
@@ -1633,8 +1652,15 @@ mod tests {
             Error::ServerRunningCannotRemove("dev".into()),
             Error::ServerStopSelectionRequired { available: 2 },
             Error::ServerRemoveSelectionRequired { available: 1 },
+            Error::ServerInMultipleProjects {
+                name: "dev".into(),
+                projects: "/projects/a, /projects/b".into(),
+            },
             Error::InvalidServerName("../escape".into()),
             Error::UnsupportedArgument("--config cannot be passed through".into()),
+            Error::UnsupportedArgument(
+                "--tcp-port 0 is not allowed; pick a specific port or omit the flag".into(),
+            ),
             Error::ConfigNotFound("config 'x' not found in /configs (available: y.xml)".into()),
             Error::InvalidConfigName("../etc/passwd".into()),
             Error::VersionNotFound("25.12.9.61".into()),

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -26,13 +26,28 @@ enum LocalErrorCode {
     ServerSelectionRequired,
     ServerNotRunning,
     ServerRunning,
+    InvalidServerName,
+    UnsupportedArgument,
+    ConfigNotFound,
+    InvalidConfigName,
     InvalidVersion,
+    /// The version is not installed locally. Distinct from
+    /// [`Self::VersionUnavailable`], which means it could not be resolved or
+    /// downloaded: `local list --remote` is no help for a local miss.
+    VersionNotInstalled,
+    VersionSelectionRequired,
+    VersionAlreadyInstalled,
     VersionUnavailable,
     VersionIsDefault,
+    UnsupportedClientVersion,
+    UnsupportedPlatform,
     PortInUse,
     StartupExit,
     StartupTimeout,
     DownloadFailed,
+    NetworkError,
+    DockerUnavailable,
+    DockerError,
     IoError,
     LocalError,
 }
@@ -42,7 +57,55 @@ struct LocalErrorDetail {
     code: LocalErrorCode,
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    command: Option<&'static str>,
+    command: Option<String>,
+}
+
+/// How one [`Error`] variant renders into a [`LocalErrorDetail`].
+///
+/// Built with either [`Mapping::parity`] — the JSON message is the error's own
+/// human text, verbatim — or [`Mapping::redacted`], which substitutes a curated
+/// summary for errors that interpolate foreign text.
+struct Mapping {
+    code: LocalErrorCode,
+    command: Option<String>,
+    /// Curated replacement for the human text; `None` renders `Display`.
+    redacted: Option<String>,
+}
+
+impl Mapping {
+    /// The JSON message is the error's `Display` text, so machine output
+    /// carries exactly the detail and remediation human output prints.
+    fn parity(code: LocalErrorCode) -> Self {
+        Self {
+            code,
+            command: None,
+            redacted: None,
+        }
+    }
+
+    /// The JSON message is `message`, not the error's `Display` text. For
+    /// errors whose text interpolates foreign output.
+    fn redacted(code: LocalErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            command: None,
+            redacted: Some(message.into()),
+        }
+    }
+
+    /// A safe, runnable recovery command for this failure.
+    fn command(mut self, command: impl Into<String>) -> Self {
+        self.command = Some(command.into());
+        self
+    }
+
+    fn into_detail(self, error: &Error) -> LocalErrorDetail {
+        LocalErrorDetail {
+            code: self.code,
+            message: self.redacted.unwrap_or_else(|| error.to_string()),
+            command: self.command,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -148,138 +211,159 @@ struct LocalErrorOutput {
 }
 
 impl LocalErrorOutput {
+    /// Classify one local runtime failure.
+    ///
+    /// Two rules govern the `message` field, and every arm below picks one
+    /// deliberately:
+    ///
+    /// * **Parity** ([`Mapping::parity`]) — the error's own human text is
+    ///   rendered verbatim, so a JSON consumer gets exactly the detail and
+    ///   remediation human mode prints. This is the default: these messages are
+    ///   composed by this crate from its own fields.
+    /// * **Redaction** ([`Mapping::redacted`]) — a curated summary replaces
+    ///   text that interpolates foreign output (subprocess stderr, Docker
+    ///   daemon or OS/serde source strings, download bodies), which can carry
+    ///   paths, SQL or credentials and tells a machine consumer nothing.
+    ///
+    /// The match is exhaustive on purpose: a new [`Error`] variant must be
+    /// classified here rather than silently collapsing to
+    /// `local_error`/"Local command failed".
     fn from_error(error: &Error) -> Self {
-        if let Error::ManagedClient(error) = error {
-            return Self {
-                error: LocalErrorBody::ManagedClient(ManagedClientErrorDetail::from_error(error)),
-            };
-        }
-        if let Error::ProjectServerNotFound(error) = error {
-            return Self {
-                error: LocalErrorBody::ProjectServer(ProjectServerErrorDetail::from_error(error)),
-            };
-        }
-        if let Error::ProjectServerStateMissing(error) = error {
-            return Self {
-                error: LocalErrorBody::ProjectServerStateMissing(
-                    ProjectServerStateMissingDetail::from_error(error),
-                ),
-            };
-        }
-        let detail = match error {
-            Error::ServerNotFound(name) => LocalErrorDetail {
-                code: LocalErrorCode::ServerNotFound,
-                message: format!("Server '{name}' not found"),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::ServerStopSelectionRequired { available } => LocalErrorDetail {
-                code: LocalErrorCode::ServerSelectionRequired,
-                message: format!(
-                    "Multiple non-default ClickHouse servers exist (available: {available}); specify a name or use stop-all"
-                ),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::ServerRemoveSelectionRequired { available } => LocalErrorDetail {
-                code: LocalErrorCode::ServerSelectionRequired,
-                message: format!(
-                    "The default ClickHouse server does not exist (custom ClickHouse servers available: {available}); no server was removed"
-                ),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::ServerNotRunning(name) => LocalErrorDetail {
-                code: LocalErrorCode::ServerNotRunning,
-                message: format!("Server '{name}' is not running"),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::ServerAlreadyRunning(name) => LocalErrorDetail {
-                code: LocalErrorCode::ServerRunning,
-                message: format!("Server '{name}' is already running"),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::ServerRunningCannotRemove(name) => LocalErrorDetail {
-                code: LocalErrorCode::ServerRunning,
-                message: format!("Server '{name}' is running"),
-                command: Some("clickhousectl local server list"),
-            },
+        let mapping = match error {
+            // ── structured bodies (their own DTOs, not code/message/command) ─
+            Error::ManagedClient(managed) => {
+                return Self {
+                    error: LocalErrorBody::ManagedClient(ManagedClientErrorDetail::from_error(
+                        managed,
+                    )),
+                };
+            }
+            Error::ProjectServerNotFound(not_found) => {
+                return Self {
+                    error: LocalErrorBody::ProjectServer(ProjectServerErrorDetail::from_error(
+                        not_found,
+                    )),
+                };
+            }
+            Error::ProjectServerStateMissing(missing) => {
+                return Self {
+                    error: LocalErrorBody::ProjectServerStateMissing(
+                        ProjectServerStateMissingDetail::from_error(missing),
+                    ),
+                };
+            }
+            // The rollback note is a cleanup detail on top of the failure that
+            // actually stopped the command; classify by that primary failure.
+            Error::PostgresStartupRollback { primary, .. } => {
+                return Self::from_error(primary);
+            }
+
+            // ── servers ─────────────────────────────────────────────────────
+            Error::ServerNotFound(_) => Mapping::parity(LocalErrorCode::ServerNotFound)
+                .command("clickhousectl local server list"),
+            Error::ServerStopSelectionRequired { .. }
+            | Error::ServerRemoveSelectionRequired { .. } => {
+                Mapping::parity(LocalErrorCode::ServerSelectionRequired)
+                    .command("clickhousectl local server list")
+            }
+            // Deliberately the list, not a `start` command: this variant is
+            // also raised for Postgres servers and for global PID lookups,
+            // where the name is not a `server start` argument.
+            Error::ServerNotRunning(_) => Mapping::parity(LocalErrorCode::ServerNotRunning)
+                .command("clickhousectl local server list"),
+            Error::ServerAlreadyRunning(_) => Mapping::parity(LocalErrorCode::ServerRunning)
+                .command("clickhousectl local server list"),
+            // Stopping *this* server is the recovery; `server list` only
+            // restates what the error already says.
+            Error::ServerRunningCannotRemove(name) => {
+                Mapping::parity(LocalErrorCode::ServerRunning)
+                    .command(format!("clickhousectl local server stop {name}"))
+            }
+            Error::InvalidServerName(_) => Mapping::parity(LocalErrorCode::InvalidServerName)
+                .command("clickhousectl local server list"),
+            Error::UnsupportedArgument(_) => Mapping::parity(LocalErrorCode::UnsupportedArgument)
+                .command("clickhousectl local server start --help"),
+
+            // ── server configs ──────────────────────────────────────────────
+            Error::ConfigNotFound(_) => Mapping::parity(LocalErrorCode::ConfigNotFound)
+                .command("clickhousectl local server configs"),
+            Error::InvalidConfigName(_) => Mapping::parity(LocalErrorCode::InvalidConfigName)
+                .command("clickhousectl local server configs"),
+
+            // ── versions ────────────────────────────────────────────────────
+            Error::InvalidVersion(_) => Mapping::parity(LocalErrorCode::InvalidVersion)
+                .command("clickhousectl local install --help"),
+            // Not installed locally: the installed list, not the remote one, is
+            // what resolves these.
+            Error::VersionNotFound(_) | Error::StaleDefaultVersion(_) => {
+                Mapping::parity(LocalErrorCode::VersionNotInstalled)
+                    .command("clickhousectl local list")
+            }
+            Error::NoVersionsInstalled | Error::NoClientVersionInstalled => {
+                Mapping::parity(LocalErrorCode::VersionNotInstalled)
+                    .command("clickhousectl local install latest")
+            }
+            Error::ClientVersionNotInstalled(version) => {
+                Mapping::parity(LocalErrorCode::VersionNotInstalled)
+                    .command(format!("clickhousectl local install {version}"))
+            }
+            Error::NoDefaultVersion | Error::AmbiguousClientVersion => {
+                Mapping::parity(LocalErrorCode::VersionSelectionRequired)
+                    .command("clickhousectl local list")
+            }
+            Error::VersionAlreadyInstalled(_) => {
+                Mapping::parity(LocalErrorCode::VersionAlreadyInstalled)
+                    .command("clickhousectl local list")
+            }
+            Error::RepeatedClientQueryUnsupported { .. } => {
+                Mapping::parity(LocalErrorCode::UnsupportedClientVersion)
+            }
             // The blocking servers are named — including their project root —
             // because they may live outside the current project, where neither
             // `server list` nor the caller's own state can find them.
-            Error::VersionInUse { version, servers } => LocalErrorDetail {
-                code: LocalErrorCode::ServerRunning,
-                message: format!(
-                    "Version {version} is in use by running server(s), in this project or another: {servers}"
-                ),
-                command: Some("clickhousectl local server list --global"),
-            },
-            Error::VersionIsDefault { .. } => LocalErrorDetail {
-                code: LocalErrorCode::VersionIsDefault,
-                message:
-                    "This version is the current default (~/.clickhouse/default) and is linked as \
-                     ~/.local/bin/clickhouse; removing it would clear both, and the exact build may \
-                     not be re-downloadable. Switch the default first, or pass --force to remove it \
-                     and clear the default marker and the global symlink."
-                        .to_string(),
-                command: Some("clickhousectl local use latest"),
-            },
-            Error::InvalidVersion(_) => LocalErrorDetail {
-                code: LocalErrorCode::InvalidVersion,
-                message: "Invalid version".to_string(),
-                command: Some("clickhousectl local install --help"),
-            },
-            Error::VersionNotFound(_)
-            | Error::NoVersionsInstalled
-            | Error::NoDefaultVersion
-            | Error::NoClientVersionInstalled
-            | Error::AmbiguousClientVersion
-            | Error::StaleDefaultVersion(_)
-            | Error::ClientVersionNotInstalled(_)
-            | Error::RepeatedClientQueryUnsupported { .. }
-            | Error::NoMatchingVersion(_)
+            Error::VersionInUse { .. } => Mapping::parity(LocalErrorCode::ServerRunning)
+                .command("clickhousectl local server list --global"),
+            Error::VersionIsDefault { .. } => Mapping::parity(LocalErrorCode::VersionIsDefault)
+                .command("clickhousectl local use latest"),
+            // Could not be resolved or downloaded, so the remote list is the
+            // next step.
+            Error::NoMatchingVersion(_)
             | Error::ExactVersionUnavailable { .. }
             | Error::UnknownVersionChannel(_)
-            | Error::VersionResolutionFallback { .. } => LocalErrorDetail {
-                code: LocalErrorCode::VersionUnavailable,
-                message: "Requested version is unavailable".to_string(),
-                command: Some("clickhousectl local list --remote"),
-            },
-            Error::PortInUse { kind, port } => LocalErrorDetail {
-                code: LocalErrorCode::PortInUse,
-                message: format!("{kind} port {port} is already in use"),
-                command: Some(match kind {
+            | Error::VersionResolutionFallback { .. } => {
+                Mapping::parity(LocalErrorCode::VersionUnavailable)
+                    .command("clickhousectl local list --remote")
+            }
+            Error::UnsupportedPlatform { .. } => {
+                Mapping::parity(LocalErrorCode::UnsupportedPlatform)
+            }
+
+            // ── ports and startup ───────────────────────────────────────────
+            Error::PortInUse { kind, .. } | Error::PortUnavailable(kind) => {
+                Mapping::parity(LocalErrorCode::PortInUse).command(match kind {
                     PortKind::Postgres => "clickhousectl local postgres start --help",
                     PortKind::Http | PortKind::Tcp => "clickhousectl local server start --help",
-                }),
-            },
-            Error::PortUnavailable(kind) => LocalErrorDetail {
-                code: LocalErrorCode::PortInUse,
-                message: format!("No free {kind} port is available"),
-                command: Some(match kind {
-                    PortKind::Postgres => "clickhousectl local postgres start --help",
-                    PortKind::Http | PortKind::Tcp => "clickhousectl local server start --help",
-                }),
-            },
-            Error::StartupExit { kind, name, .. } => LocalErrorDetail {
-                code: LocalErrorCode::StartupExit,
-                message: format!("{kind} server '{name}' exited before becoming ready"),
-                command: Some("clickhousectl local server list"),
-            },
+                })
+            }
+            // `details` is the managed server's own stderr or log tail: kept in
+            // human output, summarized here.
+            Error::StartupExit { kind, name, .. } => Mapping::redacted(
+                LocalErrorCode::StartupExit,
+                format!("{kind} server '{name}' exited before becoming ready"),
+            )
+            .command("clickhousectl local server list"),
             Error::StartupTimeout {
                 kind,
                 name,
                 seconds,
                 ..
-            } => LocalErrorDetail {
-                code: LocalErrorCode::StartupTimeout,
-                message: format!(
-                    "{kind} server '{name}' did not become ready within {seconds} seconds"
-                ),
-                command: Some("clickhousectl local server list"),
-            },
-            Error::Download(_) | Error::Extract(_) => LocalErrorDetail {
-                code: LocalErrorCode::DownloadFailed,
-                message: "Download failed".to_string(),
-                command: None,
-            },
+            } => Mapping::redacted(
+                LocalErrorCode::StartupTimeout,
+                format!("{kind} server '{name}' did not become ready within {seconds} seconds"),
+            )
+            .command("clickhousectl local server list"),
+
+            // ── network, downloads and extraction ───────────────────────────
             Error::Network(failure)
                 if matches!(
                     failure.stage,
@@ -288,39 +372,60 @@ impl LocalErrorOutput {
                         | NetworkStage::Download
                 ) =>
             {
-                LocalErrorDetail {
-                    code: LocalErrorCode::DownloadFailed,
-                    message: "Download failed".to_string(),
-                    command: None,
-                }
+                Mapping::parity(LocalErrorCode::DownloadFailed)
             }
-            Error::Network(_) => LocalErrorDetail {
-                code: LocalErrorCode::VersionUnavailable,
-                message: "Requested version is unavailable".to_string(),
-                command: Some("clickhousectl local list --remote"),
-            },
+            // Version resolution probes: the remote list is the next step.
+            Error::Network(_) => Mapping::parity(LocalErrorCode::VersionUnavailable)
+                .command("clickhousectl local list --remote"),
+            Error::Http(_) => {
+                Mapping::redacted(LocalErrorCode::NetworkError, "HTTP request failed")
+            }
+            Error::Download(_) => {
+                Mapping::redacted(LocalErrorCode::DownloadFailed, "Download failed")
+            }
+            Error::Extract(_) | Error::ExtractArchive { .. } => {
+                Mapping::redacted(LocalErrorCode::DownloadFailed, "Extraction failed")
+            }
+
+            // ── Docker ──────────────────────────────────────────────────────
+            // The unavailability text is built from a classified failure kind
+            // and platform guidance; the daemon's own message is used for
+            // classification only and never rendered (see `local::docker`).
+            Error::DockerNotAvailable(_) => Mapping::parity(LocalErrorCode::DockerUnavailable),
+            Error::DockerError(_) => {
+                Mapping::redacted(LocalErrorCode::DockerError, "Docker operation failed")
+            }
+
+            // ── filesystem and metadata ─────────────────────────────────────
             Error::Io(_)
             | Error::Json(_)
             | Error::CreateDir { .. }
+            | Error::ServerMetadataPermission { .. }
             | Error::ServerMetadataRead { .. }
             | Error::ServerMetadataUtf8 { .. }
             | Error::ServerMetadataParse { .. }
-            | Error::ServerMetadataWrite { .. } => LocalErrorDetail {
-                code: LocalErrorCode::IoError,
-                message: "Local I/O operation failed".to_string(),
-                command: None,
-            },
-            Error::PostgresStartupRollback { primary, .. } => {
-                return Self::from_error(primary);
+            | Error::ServerMetadataWrite { .. }
+            | Error::ServerLock { .. } => {
+                Mapping::redacted(LocalErrorCode::IoError, "Local I/O operation failed")
             }
-            _ => LocalErrorDetail {
-                code: LocalErrorCode::LocalError,
-                message: "Local command failed".to_string(),
-                command: None,
-            },
+
+            // ── bounded fallback ────────────────────────────────────────────
+            // Subprocess and Postgres text is foreign output. `Cloud`,
+            // `AuthRequired` and `Skills` belong to other command surfaces and
+            // are never printed through this envelope; `ChildExit` passes the
+            // child's status through without an error object at all.
+            Error::Exec(_)
+            | Error::Postgres(_)
+            | Error::Cloud(_)
+            | Error::AuthRequired(_)
+            | Error::Skills(_)
+            | Error::ChildExit(_) => {
+                Mapping::redacted(LocalErrorCode::LocalError, "Local command failed")
+            }
+            Error::Cancelled => Mapping::parity(LocalErrorCode::LocalError),
         };
         Self {
-            error: LocalErrorBody::General(detail),
+            error: LocalErrorBody::General(mapping.into_detail(error)),
         }
     }
 }
@@ -1270,7 +1375,76 @@ mod tests {
             ),
             (
                 Error::VersionNotFound("25.12.9.61".into()),
+                "version_not_installed",
+            ),
+            (
+                Error::StaleDefaultVersion("25.12.9.61".into()),
+                "version_not_installed",
+            ),
+            (Error::NoVersionsInstalled, "version_not_installed"),
+            (
+                Error::ClientVersionNotInstalled("25.12.9.61".into()),
+                "version_not_installed",
+            ),
+            (Error::NoDefaultVersion, "version_selection_required"),
+            (Error::AmbiguousClientVersion, "version_selection_required"),
+            (
+                Error::VersionAlreadyInstalled("25.12.9.61".into()),
+                "version_already_installed",
+            ),
+            (
+                Error::RepeatedClientQueryUnsupported {
+                    version: "24.1.1.1".into(),
+                    minimum: "24.2",
+                },
+                "unsupported_client_version",
+            ),
+            (
+                Error::NoMatchingVersion("99.99".into()),
                 "version_unavailable",
+            ),
+            (
+                Error::ExactVersionUnavailable {
+                    version: "26.2.8.7".into(),
+                    series: "26.2".into(),
+                    available: "26.2.20.4".into(),
+                },
+                "version_unavailable",
+            ),
+            (
+                Error::UnsupportedPlatform {
+                    os: "plan9".into(),
+                    arch: "sparc".into(),
+                },
+                "unsupported_platform",
+            ),
+            (
+                Error::ConfigNotFound("config 'x' not found in /configs (available: none)".into()),
+                "config_not_found",
+            ),
+            (
+                Error::InvalidConfigName("../etc/passwd".into()),
+                "invalid_config_name",
+            ),
+            (
+                Error::InvalidServerName("../escape".into()),
+                "invalid_server_name",
+            ),
+            (
+                Error::UnsupportedArgument("--config cannot be passed through".into()),
+                "unsupported_argument",
+            ),
+            (
+                Error::DockerNotAvailable("Docker socket was not found.\nStart Docker.".into()),
+                "docker_unavailable",
+            ),
+            (
+                Error::DockerError("raw daemon details".into()),
+                "docker_error",
+            ),
+            (
+                Error::ServerRunningCannotRemove("dev".into()),
+                "server_running",
             ),
             (
                 Error::PortInUse {
@@ -1364,6 +1538,182 @@ mod tests {
             r#"{"error":{"code":"startup_exit","message":"Postgres server 'default' exited before becoming ready","command":"clickhousectl local server list"}}"#
         );
         assert!(!wrapped.contains("hunter2"));
+    }
+
+    #[test]
+    fn running_server_remove_json_error_points_at_stopping_that_server() {
+        assert_eq!(
+            serde_json::to_string(&LocalErrorOutput::from_error(
+                &Error::ServerRunningCannotRemove("dev".into())
+            ))
+            .unwrap(),
+            r#"{"error":{"code":"server_running","message":"Server 'dev' is running; stop it first with `clickhousectl local server stop dev`","command":"clickhousectl local server stop dev"}}"#
+        );
+    }
+
+    #[test]
+    fn missing_config_json_error_keeps_the_full_human_detail() {
+        let error = Error::ConfigNotFound(
+            "config 'does-not-exist' not found in /home/dev/.clickhouse/configs \
+             (available: analytics.xml)"
+                .to_string(),
+        );
+
+        assert_eq!(
+            serde_json::to_value(LocalErrorOutput::from_error(&error)).unwrap(),
+            serde_json::json!({
+                "error": {
+                    "code": "config_not_found",
+                    "message": "config 'does-not-exist' not found in /home/dev/.clickhouse/configs (available: analytics.xml)",
+                    "command": "clickhousectl local server configs"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn a_version_that_is_not_installed_is_not_reported_as_unavailable_for_download() {
+        assert_eq!(
+            serde_json::to_value(LocalErrorOutput::from_error(&Error::VersionNotFound(
+                "25.12.9.61".into()
+            )))
+            .unwrap(),
+            serde_json::json!({
+                "error": {
+                    "code": "version_not_installed",
+                    "message": "Version 25.12.9.61 not found",
+                    "command": "clickhousectl local list"
+                }
+            })
+        );
+
+        // A version that cannot be resolved remotely keeps the remote hint.
+        let unresolvable = error_json(&Error::NoMatchingVersion("99.99".into()));
+        assert_eq!(unresolvable["error"]["code"], "version_unavailable");
+        assert_eq!(
+            unresolvable["error"]["command"],
+            "clickhousectl local list --remote"
+        );
+    }
+
+    /// Errors this crate composes itself render their human text verbatim, so
+    /// `--json` never carries less than the `Error: ...` line does.
+    #[test]
+    fn self_composed_errors_serialize_their_human_message_verbatim() {
+        let cases = [
+            Error::ServerNotFound("dev".into()),
+            Error::ServerNotRunning("dev".into()),
+            Error::ServerAlreadyRunning("dev".into()),
+            Error::ServerRunningCannotRemove("dev".into()),
+            Error::ServerStopSelectionRequired { available: 2 },
+            Error::ServerRemoveSelectionRequired { available: 1 },
+            Error::InvalidServerName("../escape".into()),
+            Error::UnsupportedArgument("--config cannot be passed through".into()),
+            Error::ConfigNotFound("config 'x' not found in /configs (available: y.xml)".into()),
+            Error::InvalidConfigName("../etc/passwd".into()),
+            Error::VersionNotFound("25.12.9.61".into()),
+            Error::NoVersionsInstalled,
+            Error::NoDefaultVersion,
+            Error::NoClientVersionInstalled,
+            Error::AmbiguousClientVersion,
+            Error::StaleDefaultVersion("25.12.9.61".into()),
+            Error::ClientVersionNotInstalled("25.12.9.61".into()),
+            Error::RepeatedClientQueryUnsupported {
+                version: "24.1.1.1".into(),
+                minimum: "24.2",
+            },
+            Error::VersionAlreadyInstalled("25.12.9.61".into()),
+            Error::VersionInUse {
+                version: "25.12.9.61".into(),
+                servers: "dev (/project, pid 42)".into(),
+            },
+            Error::VersionIsDefault {
+                version: "25.12.9.61".into(),
+            },
+            Error::NoMatchingVersion("99.99".into()),
+            Error::ExactVersionUnavailable {
+                version: "26.2.8.7".into(),
+                series: "26.2".into(),
+                available: "26.2.20.4".into(),
+            },
+            Error::UnknownVersionChannel("26.2.8.7".into()),
+            Error::InvalidVersion("Invalid version 'nope'".into()),
+            Error::UnsupportedPlatform {
+                os: "plan9".into(),
+                arch: "sparc".into(),
+            },
+            Error::PortInUse {
+                kind: PortKind::Postgres,
+                port: 5432,
+            },
+            Error::PortUnavailable(PortKind::Http),
+            Error::DockerNotAvailable("Docker socket was not found.\nStart Docker Desktop.".into()),
+        ];
+
+        for error in cases {
+            let json = error_json(&error);
+            assert_eq!(
+                json["error"]["message"],
+                serde_json::Value::String(error.to_string()),
+                "JSON message must match human output for {error:?}"
+            );
+        }
+    }
+
+    /// The complement of the parity rule: text that interpolates foreign output
+    /// (subprocess, Docker daemon, OS/serde sources) stays summarized.
+    #[test]
+    fn errors_carrying_foreign_output_stay_summarized() {
+        let secret = "password=hunter2; /Users/al/secret-project";
+        let cases = [
+            (Error::Exec(secret.into()), "Local command failed"),
+            (Error::DockerError(secret.into()), "Docker operation failed"),
+            (Error::Postgres(secret.into()), "Local command failed"),
+            (Error::Download(secret.into()), "Download failed"),
+            (Error::Extract(secret.into()), "Extraction failed"),
+            (
+                Error::Io(std::io::Error::other(secret)),
+                "Local I/O operation failed",
+            ),
+            (
+                Error::ServerMetadataWrite {
+                    path: secret.into(),
+                    source: std::io::Error::other(secret),
+                },
+                "Local I/O operation failed",
+            ),
+            (
+                Error::ServerLock {
+                    operation: "open the server metadata lock file",
+                    path: secret.into(),
+                    remediation: "Check access, then retry.",
+                    source: std::io::Error::other(secret),
+                },
+                "Local I/O operation failed",
+            ),
+            (
+                Error::StartupTimeout {
+                    kind: crate::error::StartupKind::ClickHouse,
+                    name: "default".into(),
+                    seconds: 30,
+                    details: secret.into(),
+                },
+                "ClickHouse server 'default' did not become ready within 30 seconds",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let serialized = serde_json::to_string(&LocalErrorOutput::from_error(&error)).unwrap();
+            assert_eq!(
+                error_json(&error)["error"]["message"],
+                expected,
+                "unexpected summary for {error:?}"
+            );
+            assert!(
+                !serialized.contains("hunter2") && !serialized.contains("secret-project"),
+                "leaked foreign output: {serialized}"
+            );
+        }
     }
 
     // ── JSON serialization tests ────────────────────────────────────────

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -48,6 +48,13 @@ enum LocalErrorCode {
     NetworkError,
     DockerUnavailable,
     DockerError,
+    /// The container name is held by a container clickhousectl does not
+    /// manage. Distinct from [`Self::DockerError`], which covers daemon
+    /// failures whose text is not rendered.
+    ContainerNameConflict,
+    /// A Postgres validation or state error whose text (and recovery
+    /// guidance) clickhousectl composes itself, rendered verbatim.
+    PostgresError,
     IoError,
     LocalError,
 }
@@ -395,6 +402,11 @@ impl LocalErrorOutput {
             Error::DockerError(_) => {
                 Mapping::redacted(LocalErrorCode::DockerError, "Docker operation failed")
             }
+            // Self-composed name-conflict guidance, unlike the daemon text
+            // above.
+            Error::ContainerNameConflict(_) => {
+                Mapping::parity(LocalErrorCode::ContainerNameConflict)
+            }
 
             // ── filesystem and metadata ─────────────────────────────────────
             Error::Io(_)
@@ -409,11 +421,17 @@ impl LocalErrorOutput {
                 Mapping::redacted(LocalErrorCode::IoError, "Local I/O operation failed")
             }
 
+            // ── postgres ────────────────────────────────────────────────────
+            // Self-composed validation and state guidance; the foreign-text
+            // sibling `Error::Postgres` stays in the fallback below.
+            Error::PostgresUsage(_) => Mapping::parity(LocalErrorCode::PostgresError),
+
             // ── bounded fallback ────────────────────────────────────────────
-            // Subprocess and Postgres text is foreign output. `Cloud`,
-            // `AuthRequired` and `Skills` belong to other command surfaces and
-            // are never printed through this envelope; `ChildExit` passes the
-            // child's status through without an error object at all.
+            // Subprocess text and `Postgres` (OS text from a failed psql
+            // exec) are foreign output. `Cloud`, `AuthRequired` and `Skills`
+            // belong to other command surfaces and are never printed through
+            // this envelope; `ChildExit` passes the child's status through
+            // without an error object at all.
             Error::Exec(_)
             | Error::Postgres(_)
             | Error::Cloud(_)
@@ -1443,6 +1461,14 @@ mod tests {
                 "docker_error",
             ),
             (
+                Error::ContainerNameConflict("chctl-pg-dev-17".into()),
+                "container_name_conflict",
+            ),
+            (
+                Error::PostgresUsage("--port 0 is not allowed".into()),
+                "postgres_error",
+            ),
+            (
                 Error::ServerRunningCannotRemove("dev".into()),
                 "server_running",
             ),
@@ -1648,6 +1674,11 @@ mod tests {
             },
             Error::PortUnavailable(PortKind::Http),
             Error::DockerNotAvailable("Docker socket was not found.\nStart Docker Desktop.".into()),
+            Error::ContainerNameConflict("chctl-pg-dev-17".into()),
+            Error::PostgresUsage(
+                "multiple postgres instances named 'dev' (17, 18); pass --version to select one"
+                    .into(),
+            ),
         ];
 
         for error in cases {

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -60,7 +60,7 @@ pub(crate) fn validate_pg_tag(tag: &str) -> Result<()> {
     };
 
     if !valid {
-        return Err(Error::Postgres(format!(
+        return Err(Error::PostgresUsage(format!(
             "invalid or unsupported postgres version '{}'. Use 17 or 18, optionally followed \
              by .<minor> and -<variant> (for example: 17, 17-alpine, 18.1, 18-bookworm).",
             tag
@@ -160,7 +160,7 @@ fn validate_start_options(
         validate_pg_tag(version)?;
     }
 
-    validate_pg_start_env_args(password, &extra_env).map_err(Error::Postgres)?;
+    validate_pg_start_env_args(password, &extra_env).map_err(Error::PostgresUsage)?;
     let password_from_env = extra_env.iter().find_map(|assignment| {
         assignment
             .strip_prefix("POSTGRES_PASSWORD=")
@@ -297,7 +297,7 @@ async fn start(
                 docker.inspect_container(cid, None).await.ok()
             };
             let Some(inspected) = inspected else {
-                return Err(Error::Postgres(format!(
+                return Err(Error::PostgresUsage(format!(
                     "server '{}' (postgres:{}) has metadata but the container is gone. \
                      Run `clickhousectl local postgres remove {}` to clear the data dir \
                      and start fresh.",
@@ -568,7 +568,7 @@ fn resolve_pg_start_version_locked(
         }
         _ => {
             let versions: Vec<&str> = existing.iter().map(|info| info.version.as_str()).collect();
-            Err(Error::Postgres(format!(
+            Err(Error::PostgresUsage(format!(
                 "multiple postgres instances named '{}' ({}); pass --version to select one",
                 user_name,
                 versions.join(", ")
@@ -599,7 +599,7 @@ fn resolve_pg_target_locked(
         1 => Ok(instances.into_iter().next().unwrap()),
         _ => {
             let versions: Vec<String> = instances.iter().map(|i| i.version.clone()).collect();
-            Err(Error::Postgres(format!(
+            Err(Error::PostgresUsage(format!(
                 "multiple postgres instances named '{}' ({}); pass --version to select one",
                 user_name,
                 versions.join(", ")
@@ -924,7 +924,7 @@ fn format_postgres_readiness_error(
 fn resolve_port(explicit: Option<u16>) -> Result<u16> {
     match explicit {
         Some(0) => {
-            return Err(Error::Postgres(
+            return Err(Error::PostgresUsage(
                 "--port 0 is not allowed; pick a specific port or omit the flag".into(),
             ));
         }
@@ -1454,7 +1454,7 @@ mod tests {
     #[test]
     fn resolve_port_rejects_zero_for_non_clap_callers() {
         let err = resolve_port(Some(0)).unwrap_err();
-        assert!(matches!(err, Error::Postgres(msg) if msg.contains("--port 0")));
+        assert!(matches!(err, Error::PostgresUsage(msg) if msg.contains("--port 0")));
     }
 
     #[test]
@@ -1623,7 +1623,10 @@ mod tests {
             )
             .err()
             .expect("malformed environment variable should fail");
-            assert!(matches!(error, Error::Postgres(_)), "{assignment}: {error}");
+            assert!(
+                matches!(error, Error::PostgresUsage(_)),
+                "{assignment}: {error}"
+            );
         }
     }
 
@@ -1640,7 +1643,7 @@ mod tests {
         .expect("duplicate environment variable should fail");
 
         assert!(
-            matches!(error, Error::Postgres(msg) if msg.contains("APP_MODE") && msg.contains("more than once"))
+            matches!(error, Error::PostgresUsage(msg) if msg.contains("APP_MODE") && msg.contains("more than once"))
         );
     }
 
@@ -1661,7 +1664,7 @@ mod tests {
             .err()
             .expect("reserved environment variable should fail");
             assert!(
-                matches!(error, Error::Postgres(msg) if msg.contains("managed by clickhousectl"))
+                matches!(error, Error::PostgresUsage(msg) if msg.contains("managed by clickhousectl"))
             );
         }
     }
@@ -1677,7 +1680,9 @@ mod tests {
         )
         .err()
         .expect("password sources should conflict");
-        assert!(matches!(error, Error::Postgres(msg) if msg.contains("both --password and --env")));
+        assert!(
+            matches!(error, Error::PostgresUsage(msg) if msg.contains("both --password and --env"))
+        );
 
         let error = validate_start_options(
             Some("dev"),
@@ -1692,7 +1697,7 @@ mod tests {
         .err()
         .expect("duplicate password should fail");
         assert!(
-            matches!(error, Error::Postgres(msg) if msg.contains("POSTGRES_PASSWORD") && msg.contains("more than once"))
+            matches!(error, Error::PostgresUsage(msg) if msg.contains("POSTGRES_PASSWORD") && msg.contains("more than once"))
         );
     }
 }

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -881,7 +881,7 @@ fn find_free_port(start: u16) -> Option<u16> {
 pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u16, u16, bool)> {
     let http = match http_port {
         Some(0) => {
-            return Err(Error::Exec(
+            return Err(Error::UnsupportedArgument(
                 "--http-port 0 is not allowed; pick a specific port or omit the flag".into(),
             ));
         }
@@ -904,7 +904,7 @@ pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u
 
     let tcp = match tcp_port {
         Some(0) => {
-            return Err(Error::Exec(
+            return Err(Error::UnsupportedArgument(
                 "--tcp-port 0 is not allowed; pick a specific port or omit the flag".into(),
             ));
         }
@@ -1513,10 +1513,14 @@ mod tests {
     #[test]
     fn explicit_ports_reject_zero() {
         let http_error = resolve_ports(Some(0), None).unwrap_err();
-        assert!(matches!(http_error, Error::Exec(msg) if msg.contains("--http-port 0")));
+        assert!(
+            matches!(http_error, Error::UnsupportedArgument(msg) if msg.contains("--http-port 0"))
+        );
 
         let tcp_error = resolve_ports(None, Some(0)).unwrap_err();
-        assert!(matches!(tcp_error, Error::Exec(msg) if msg.contains("--tcp-port 0")));
+        assert!(
+            matches!(tcp_error, Error::UnsupportedArgument(msg) if msg.contains("--tcp-port 0"))
+        );
     }
 
     // ── ensure_stopped_by_pid (issue #600) ─────────────────────────────

--- a/crates/clickhousectl/tests/local_postgres_readiness_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_readiness_test.rs
@@ -1013,7 +1013,8 @@ fn create_success_start_failure_rolls_back_exact_container_and_fresh_data() {
 
     assert_eq!(output.status.code(), Some(1));
     let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
-    assert_eq!(error["error"]["code"], "local_error");
+    assert_eq!(error["error"]["code"], "docker_error");
+    assert_eq!(error["error"]["message"], "Docker operation failed");
     assert!(!String::from_utf8_lossy(&output.stderr).contains("start failed by test"));
     let create = request_index(&requests, "POST", "/containers/create?");
     let start = request_index(&requests, "POST", "/containers/pg-id/start");
@@ -1209,7 +1210,8 @@ fn cleanup_failure_preserves_rollback_behavior_but_redacts_json_diagnostics() {
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&output.stderr);
     let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
-    assert_eq!(error["error"]["code"], "local_error");
+    assert_eq!(error["error"]["code"], "docker_error");
+    assert_eq!(error["error"]["message"], "Docker operation failed");
     assert!(!stderr.contains("start failed by test"));
     assert!(!stderr.contains("Postgres startup rollback incomplete"));
     assert!(!stderr.contains("remove failed by test"));

--- a/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
@@ -259,7 +259,10 @@ fn bound_explicit_port_fails_locally_without_docker_or_project_state() {
     assert_eq!(error["error"]["code"], "port_in_use");
     assert_eq!(
         error["error"]["message"],
-        format!("Postgres port {port} is already in use")
+        format!(
+            "Postgres port {port} is already in use; choose another --port or omit --port to \
+             auto-select a free port"
+        )
     );
     assert_eq!(
         error["error"]["command"],

--- a/crates/clickhousectl/tests/local_server_selection_test.rs
+++ b/crates/clickhousectl/tests/local_server_selection_test.rs
@@ -330,7 +330,7 @@ fn omitted_stop_requires_a_name_or_stop_all_for_many_non_default_servers() {
         json!({
             "error": {
                 "code": "server_selection_required",
-                "message": "Multiple non-default ClickHouse servers exist (available: 2); specify a name or use stop-all",
+                "message": "No server name was provided and multiple non-default ClickHouse servers exist (available: 2). Pass a name with `clickhousectl local server stop <name>`, or stop every server with `clickhousectl local server stop-all`.",
                 "command": "clickhousectl local server list"
             }
         })
@@ -384,7 +384,10 @@ fn omitted_remove_never_selects_custom_servers() {
         assert_eq!(
             error["error"]["message"],
             format!(
-                "The default ClickHouse server does not exist (custom ClickHouse servers available: {}); no server was removed",
+                "No server name was provided and the default ClickHouse server does not exist \
+                 (custom ClickHouse servers available: {}); no server was removed. Inspect them \
+                 with `clickhousectl local server list`; to remove one, pass its name with \
+                 `clickhousectl local server remove <name>`.",
                 names.len()
             )
         );

--- a/crates/clickhousectl/tests/local_server_state_machine_test.rs
+++ b/crates/clickhousectl/tests/local_server_state_machine_test.rs
@@ -698,7 +698,10 @@ fn fresh_project(fixture: &Fixture) {
             args: strings(&["local", "--json", "server", "remove"]),
             expected: ExpectedOutput::JsonFailure(error(
                 "server_selection_required",
-                "The default ClickHouse server does not exist (custom ClickHouse servers available: 0); no server was removed",
+                "No server name was provided and the default ClickHouse server does not exist \
+                 (custom ClickHouse servers available: 0); no server was removed. Inspect them with \
+                 `clickhousectl local server list`; to remove one, pass its name with \
+                 `clickhousectl local server remove <name>`.",
                 Some("clickhousectl local server list"),
             )),
         },
@@ -880,7 +883,10 @@ fn custom_name_lifecycle(fixture: &Fixture) {
             args: strings(&["local", "--json", "server", "remove"]),
             expected: ExpectedOutput::JsonFailure(error(
                 "server_selection_required",
-                "The default ClickHouse server does not exist (custom ClickHouse servers available: 1); no server was removed",
+                "No server name was provided and the default ClickHouse server does not exist \
+                 (custom ClickHouse servers available: 1); no server was removed. Inspect them with \
+                 `clickhousectl local server list`; to remove one, pass its name with \
+                 `clickhousectl local server remove <name>`.",
                 Some("clickhousectl local server list"),
             )),
         },
@@ -890,8 +896,8 @@ fn custom_name_lifecycle(fixture: &Fixture) {
             args: strings(&["local", "--json", "server", "remove", "dev"]),
             expected: ExpectedOutput::JsonFailure(error(
                 "server_running",
-                "Server 'dev' is running",
-                Some("clickhousectl local server list"),
+                "Server 'dev' is running; stop it first with `clickhousectl local server stop dev`",
+                Some("clickhousectl local server stop dev"),
             )),
         },
         CommandCase {
@@ -988,7 +994,9 @@ fn omitted_and_explicit_selection(fixture: &Fixture) {
 
     let ambiguous_stop = error(
         "server_selection_required",
-        "Multiple non-default ClickHouse servers exist (available: 2); specify a name or use stop-all",
+        "No server name was provided and multiple non-default ClickHouse servers exist \
+         (available: 2). Pass a name with `clickhousectl local server stop <name>`, or stop every \
+         server with `clickhousectl local server stop-all`.",
         Some("clickhousectl local server list"),
     );
     fixture.run_cases(&[
@@ -1004,7 +1012,10 @@ fn omitted_and_explicit_selection(fixture: &Fixture) {
             args: strings(&["local", "--json", "server", "remove"]),
             expected: ExpectedOutput::JsonFailure(error(
                 "server_selection_required",
-                "The default ClickHouse server does not exist (custom ClickHouse servers available: 2); no server was removed",
+                "No server name was provided and the default ClickHouse server does not exist \
+                 (custom ClickHouse servers available: 2); no server was removed. Inspect them with \
+                 `clickhousectl local server list`; to remove one, pass its name with \
+                 `clickhousectl local server remove <name>`.",
                 Some("clickhousectl local server list"),
             )),
         },

--- a/crates/clickhousectl/tests/local_structured_errors_test.rs
+++ b/crates/clickhousectl/tests/local_structured_errors_test.rs
@@ -428,6 +428,31 @@ fn config_and_argument_failures_carry_their_full_human_detail_in_json() {
             Some("clickhousectl local server start --help"),
         ),
     );
+
+    // Port 0 would hand the choice to the OS, which managed metadata cannot
+    // track; the refusal is self-composed guidance, not a redacted fallback.
+    let zero_port = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            VERSION,
+            "--http-port",
+            "0",
+        ],
+    );
+    assert_structured_failure(
+        &zero_port,
+        &expected_error(
+            "unsupported_argument",
+            "--http-port 0 is not allowed; pick a specific port or omit the flag",
+            Some("clickhousectl local server start --help"),
+        ),
+    );
 }
 
 #[test]

--- a/crates/clickhousectl/tests/local_structured_errors_test.rs
+++ b/crates/clickhousectl/tests/local_structured_errors_test.rs
@@ -195,17 +195,19 @@ fn version_port_and_startup_failures_have_typed_safe_shapes() {
     let project = tempfile::tempdir().expect("create project");
     let home = tempfile::tempdir().expect("create home");
 
-    let unavailable = run(
+    // A version that is not installed is a local miss, not an unresolvable
+    // download: the code and the hint both stay local.
+    let not_installed = run(
         project.path(),
         home.path(),
         &["local", "--json", "remove", "99.99.1.1"],
     );
     assert_structured_failure(
-        &unavailable,
+        &not_installed,
         &expected_error(
-            "version_unavailable",
-            "Requested version is unavailable",
-            Some("clickhousectl local list --remote"),
+            "version_not_installed",
+            "Version 99.99.1.1 not found",
+            Some("clickhousectl local list"),
         ),
     );
 
@@ -267,7 +269,7 @@ fn version_port_and_startup_failures_have_typed_safe_shapes() {
 }
 
 #[test]
-fn io_and_fallback_errors_redact_paths_docker_details_and_secrets() {
+fn io_and_docker_errors_redact_paths_daemon_details_and_secrets() {
     let root = tempfile::tempdir().expect("create root");
     let project = root.path().join("project-private-token");
     let home = root.path().join("home-private-token");
@@ -286,18 +288,25 @@ fn io_and_fallback_errors_redact_paths_docker_details_and_secrets() {
     );
     std::fs::remove_file(project.join(".clickhouse/servers/default.json")).unwrap();
 
+    // Docker unavailability is classified and described by clickhousectl
+    // itself, so JSON carries the full human diagnostic — but never the
+    // daemon's own text or the socket path it was pointed at.
     let docker_secret = home.join("docker-secret-token.sock");
-    let fallback = command(&project, &home)
+    let unavailable = command(&project, &home)
         .env("DOCKER_HOST", format!("unix://{}", docker_secret.display()))
         .args(["local", "--json", "postgres", "start"])
         .output()
-        .expect("run Docker fallback failure");
-    assert_structured_failure(
-        &fallback,
-        &expected_error("local_error", "Local command failed", None),
-    );
+        .expect("run Docker unavailable failure");
+    assert_eq!(unavailable.status.code(), Some(1));
+    assert!(unavailable.stdout.is_empty());
+    let error: serde_json::Value =
+        serde_json::from_slice(&unavailable.stderr).expect("one JSON error object");
+    assert_eq!(error["error"]["code"], "docker_unavailable");
+    let message = error["error"]["message"].as_str().expect("message");
+    assert!(message.contains("Docker is not available"), "{message}");
+    assert!(message.contains("was not found"), "{message}");
 
-    for output in [&io_error, &fallback] {
+    for output in [&io_error, &unavailable] {
         let stderr = String::from_utf8_lossy(&output.stderr);
         for sensitive in [
             "project-private-token",
@@ -305,11 +314,120 @@ fn io_and_fallback_errors_redact_paths_docker_details_and_secrets() {
             "docker-secret-token",
             "hunter2",
             "private SQL",
-            "DOCKER_HOST",
         ] {
             assert!(!stderr.contains(sensitive), "leaked {sensitive}: {stderr}");
         }
     }
+}
+
+/// Issue #608: the message an agent gets in JSON must not be thinner than the
+/// human `Error: ...` line for a self-composed local failure.
+#[test]
+fn config_and_argument_failures_carry_their_full_human_detail_in_json() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    install_fake_clickhouse(home.path(), "#!/bin/sh\nexit 7\n");
+    let configs = home.path().join(".clickhouse/configs");
+    std::fs::create_dir_all(&configs).expect("create configs dir");
+    std::fs::write(configs.join("analytics.xml"), b"<clickhouse/>").expect("write config");
+
+    let missing_config = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            VERSION,
+            "--config",
+            "does-not-exist",
+        ],
+    );
+    assert_structured_failure(
+        &missing_config,
+        &expected_error(
+            "config_not_found",
+            &format!(
+                "config 'does-not-exist' not found in {} (available: analytics.xml)",
+                configs.display()
+            ),
+            Some("clickhousectl local server configs"),
+        ),
+    );
+
+    let human = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "server",
+            "start",
+            "--version",
+            VERSION,
+            "--config",
+            "does-not-exist",
+        ],
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&human.stderr),
+        format!(
+            "Error: config 'does-not-exist' not found in {} (available: analytics.xml)\n",
+            configs.display()
+        ),
+        "JSON and human mode must carry the same detail"
+    );
+
+    let escaping_config = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            VERSION,
+            "--config",
+            "../outside.xml",
+        ],
+    );
+    assert_structured_failure(
+        &escaping_config,
+        &expected_error(
+            "invalid_config_name",
+            "Invalid config name '../outside.xml': must be a file in the configs dir, not a path \
+             (no '/', '\\', or '..')",
+            Some("clickhousectl local server configs"),
+        ),
+    );
+
+    let passthrough = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            VERSION,
+            "--",
+            "--config-file=/tmp/elsewhere.xml",
+        ],
+    );
+    assert_structured_failure(
+        &passthrough,
+        &expected_error(
+            "unsupported_argument",
+            "--config / --config-file / -C cannot be passed through in trailing args. \
+             Use `--config <NAME>` with a file in ~/.clickhouse/configs/ \
+             (see `clickhousectl local server configs`). \
+             Individual --setting=value flags are supported.",
+            Some("clickhousectl local server start --help"),
+        ),
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

`local --json` errors were consistently thinner than the human `Error: ...` line they replace, which is backwards: JSON is the surface coding agents read. Issue #608 reported three cases; this fixes them and the rest of the mapping they were symptoms of.

## What

- **Wrong hint.** `local server remove <running>` suggested `clickhousectl local server list`; it now suggests `clickhousectl local server stop <name>` — the step that actually recovers — and carries the human message's `stop it first with ...` clause.
- **Lost detail.** Errors whose text clickhousectl composes itself are now rendered verbatim, so `local server start --config does-not-exist` reports `config 'does-not-exist' not found in <dir> (available: analytics.xml)` in JSON instead of `{"code":"local_error","message":"Local command failed"}`.
- **Conflated code.** `local remove <not-installed-version>` now reports a new `version_not_installed` code with a `clickhousectl local list` hint, instead of `version_unavailable` / `clickhousectl local list --remote`, which described an unresolvable download.

The mapping became an exhaustive match over `Error`. Every variant picks one of two documented rules: **parity** (render the error's own `Display`) or **redaction** (a curated summary). A new `Error` variant now has to be classified rather than silently collapsing into the fallback. Only text interpolating output we do not control stays summarized — subprocess stderr and log tails (`startup_exit`, `startup_timeout`), Docker daemon strings (`docker_error`), download bodies (`download_failed`), OS/serde sources (`io_error`, `local_error`).

New codes replace the fallback where it was hiding real classifications: `version_not_installed`, `version_selection_required`, `version_already_installed`, `unsupported_client_version`, `unsupported_platform`, `config_not_found`, `invalid_config_name`, `invalid_server_name`, `unsupported_argument`, `docker_unavailable`, `docker_error`, `network_error`. Docker unavailability is built by `local::docker` from a classified failure kind and platform guidance and never renders the daemon's own text, so it now reaches JSON in full.

Two small adjacent fixes the audit turned up:

- The `--config` passthrough guard used `Error::Exec`, whose payload is subprocess text and therefore redacted, so a pure usage mistake produced an opaque `local_error`. It now uses a dedicated `Error::UnsupportedArgument`.
- The bare `server remove` selection error gained "no server was removed" in **human** mode, which JSON already stated.

`error.command` is now `Option<String>` so a hint can name the concrete server or version.

## Tests

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clickhousectl` (all green), plus `cargo check --workspace --all-features`.

- Inline exact-payload tests for the three reported cases.
- `self_composed_errors_serialize_their_human_message_verbatim` asserts `message == error.to_string()` across every parity-classified error, so the two surfaces cannot drift again.
- `errors_carrying_foreign_output_stay_summarized` asserts the complement, including that no injected secret or path is serialized.
- Subprocess coverage in `local_structured_errors_test.rs` for missing config, escaping config name, passthrough argument, the not-installed version, and the Docker diagnostic (still asserting the socket path and metadata contents never leak).
- Existing exact-JSON expectations updated in the postgres readiness/validation, server selection and server state-machine suites.

README documents the two message rules and the extended error-code table.

## Stacking

Part of a stacked chain: based on `fix/600-local-remove-global-guard`, not `main`. Keeps JSON parity with the `local remove` guards added there (`version_is_default`, `server_running` for `VersionInUse`).

Fixes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)