### PR TITLE
Observe local client launch failures instead of claiming a successful handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `invalid_config_name` | The config name is a path rather than a file in the configs dir |
 | `invalid_version` | The version selector is invalid |
 | `version_not_installed` | The requested or configured version is not installed locally |
+| `binary_not_launchable` | The version is installed but its binary cannot be launched (missing, not a regular file, or not executable) |
 | `version_selection_required` | A version must be chosen because no default is set or the choice is ambiguous |
 | `version_already_installed` | The requested version is already installed |
 | `version_unavailable` | The requested version could not be resolved or downloaded |
@@ -1216,6 +1217,8 @@ The privacy boundary for positional arguments is exactly the same one as for fla
 - only arguments you actually passed count, so a value clap filled in from a default (or from the environment), and a name the CLI generated for you, are absent — which is what makes "you named it" and "we picked one" distinguishable
 - arguments forwarded to another program are never recorded: everything after `--` for `local server start`, and the trailing arguments of `local client` and `local postgres client`, belong to `clickhouse-server`, `clickhouse-client`, and `psql`
 - when a command fails to parse, the unmatched token is still never recorded — only the slot it would have filled
+
+Exactly one event is recorded per invocation. Two commands are special: `local client` and `local postgres client` hand the process over to the native `clickhouse client` or to `psql` with `exec()`, which replaces clickhousectl's process image — same PID, same process group, same terminal, inherited stdin/stdout/stderr — so that Ctrl-C, job control and the program's own exit status or fatal signal reach your shell exactly as if you had run it directly. Because clickhousectl is gone at that point, its event is recorded just before the handover and is explicitly *censored*: the outcome is `exec_attempt` and its exit code is a fixed `0`, which means "the handoff was reached" and never "the native client succeeded". Failures clickhousectl can see for itself — a build that is missing, is not a regular file, or has no execute bit, or a `psql` that is not on `PATH` — are refused before the handover, so they are ordinary failures with the real exit code and a message telling you how to repair the install.
 
 Nothing is sent before you have seen the notice unless you explicitly enable telemetry with `clickhousectl telemetry enable`. The first run normally prints a one-time notice to stderr, records that it was shown in `~/.clickhouse/telemetry.json`, and sends nothing. Sending starts from the following run. Explicitly enabling telemetry starts it immediately and skips the notice. The send happens in a short-lived detached process, so command latency is unaffected even when the endpoint is unreachable.
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -495,9 +495,11 @@ pub enum Error {
     /// `exec()` handoff (#471). Also self-composed — see
     /// [`BinaryLaunchProblem`] — so it renders in full, unlike
     /// [`Error::Exec`], which reports what the OS said when a launch that
-    /// looked viable still failed.
+    /// looked viable still failed. The repair needs `--force`: install
+    /// treats any existing path at the binary location as "already
+    /// installed" and no-ops without it.
     #[error(
-        "ClickHouse build {version} cannot be launched: {problem} ({path})\nReinstall it with `clickhousectl local install {version}`"
+        "ClickHouse build {version} cannot be launched: {problem} ({path})\nReinstall it with `clickhousectl local install --force {version}`"
     )]
     BinaryNotLaunchable {
         version: String,

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -180,6 +180,26 @@ pub enum BinaryLaunchProblem {
     Unreadable,
 }
 
+impl BinaryLaunchProblem {
+    /// The shell command that repairs the build, which depends on what is at
+    /// the path. `local install --force` renames a fresh binary over whatever
+    /// is there, which works for a missing or non-executable *file* but fails
+    /// with EISDIR when the path is a directory — that case has to go through
+    /// `local remove` first.
+    pub fn repair_command(&self, version: &str) -> String {
+        match self {
+            Self::NotAFile => {
+                format!(
+                    "clickhousectl local remove {version} && clickhousectl local install {version}"
+                )
+            }
+            Self::Missing | Self::NotExecutable | Self::Unreadable => {
+                format!("clickhousectl local install --force {version}")
+            }
+        }
+    }
+}
+
 impl fmt::Display for BinaryLaunchProblem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -495,11 +515,11 @@ pub enum Error {
     /// `exec()` handoff (#471). Also self-composed — see
     /// [`BinaryLaunchProblem`] — so it renders in full, unlike
     /// [`Error::Exec`], which reports what the OS said when a launch that
-    /// looked viable still failed. The repair needs `--force`: install
-    /// treats any existing path at the binary location as "already
-    /// installed" and no-ops without it.
+    /// looked viable still failed. The repair is reason-specific — see
+    /// [`BinaryLaunchProblem::repair_command`].
     #[error(
-        "ClickHouse build {version} cannot be launched: {problem} ({path})\nReinstall it with `clickhousectl local install --force {version}`"
+        "ClickHouse build {version} cannot be launched: {problem} ({path})\nReinstall it with `{}`",
+        problem.repair_command(version)
     )]
     BinaryNotLaunchable {
         version: String,

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -160,6 +160,37 @@ impl fmt::Display for StartupKind {
     }
 }
 
+/// Why a selected native binary cannot be launched, decided *before* the
+/// `exec()` handoff so the failure is an ordinary error rather than a censored
+/// telemetry handoff attempt (#471).
+///
+/// A closed vocabulary, deliberately: the resulting message is this CLI's own
+/// text end to end (path plus one of these phrases plus remediation), which is
+/// what lets it render at parity in structured output instead of being redacted
+/// like [`Error::Exec`]'s foreign subprocess text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryLaunchProblem {
+    /// Nothing at the path (a build removed after version resolution).
+    Missing,
+    /// A directory, device or socket where the binary should be.
+    NotAFile,
+    /// A regular file with no execute bit for anyone.
+    NotExecutable,
+    /// The path could not be inspected at all (permissions on a parent, …).
+    Unreadable,
+}
+
+impl fmt::Display for BinaryLaunchProblem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Missing => "the file does not exist",
+            Self::NotAFile => "it is not a regular file",
+            Self::NotExecutable => "it is not executable",
+            Self::Unreadable => "its metadata could not be read",
+        })
+    }
+}
+
 #[derive(Debug)]
 pub enum ManagedClientErrorKind {
     ServerNotFound,
@@ -459,6 +490,20 @@ pub enum Error {
     /// summarized in structured output rather than rendered.
     #[error("{0}")]
     UnsupportedArgument(String),
+
+    /// The selected native binary cannot be launched, detected before the
+    /// `exec()` handoff (#471). Also self-composed — see
+    /// [`BinaryLaunchProblem`] — so it renders in full, unlike
+    /// [`Error::Exec`], which reports what the OS said when a launch that
+    /// looked viable still failed.
+    #[error(
+        "ClickHouse build {version} cannot be launched: {problem} ({path})\nReinstall it with `clickhousectl local install {version}`"
+    )]
+    BinaryNotLaunchable {
+        version: String,
+        problem: BinaryLaunchProblem,
+        path: String,
+    },
 
     #[error("{kind} port {port} is already in use{}", kind.human_guidance())]
     PortInUse { kind: PortKind, port: u16 },

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -10,12 +10,14 @@ pub mod symlink;
 use cli::{ClientVersionArg, InstallVersionArg, LocalCommands, ServerCommands, ServerVersionArg};
 
 use crate::error::{
-    Error, ManagedClientError, ManagedClientErrorKind, ManagedClientSelection,
+    BinaryLaunchProblem, Error, ManagedClientError, ManagedClientErrorKind, ManagedClientSelection,
     ProjectServerCommand, ProjectServerNotFound, ProjectServerStateMissing, Result,
 };
 use crate::{init, paths, version_manager};
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
+use std::path::Path;
 use std::process::Command;
 
 pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
@@ -375,6 +377,9 @@ fn run_client(
     };
 
     ensure_repeated_query_supported(&version, query.len())?;
+    // Before the telemetry pre-exec hook, so a binary that cannot be launched
+    // is an ordinary error event rather than a censored handoff attempt (#471).
+    ensure_launchable(&binary, &version)?;
 
     let mut cmd = Command::new(&binary);
     cmd.arg("client")
@@ -393,11 +398,50 @@ fn run_client(
 
     cmd.args(&args);
     // `exec()` replaces the process image on success, so `main`'s telemetry
-    // tail never runs for this invocation; record the event now (#320).
+    // tail never runs for this invocation; record the censored handoff attempt
+    // now (#320, #471). Everything checkable about the launch is checked above
+    // this line, so only a race can still fail below it — and the native
+    // client, once launched, owns the terminal outright: it inherits stdin,
+    // stdout and stderr unchanged, stays in clickhousectl's process group and
+    // session on the same controlling TTY, and keeps this PID, so Ctrl-C,
+    // Ctrl-Z, window resizes and its own exit status or fatal signal reach the
+    // shell exactly as if it had been invoked directly. Preserving that is why
+    // the handoff stays an `exec()` and the outcome is censored instead of
+    // becoming a spawn-and-wait wrapper that would have to relay all of it.
     #[cfg(feature = "telemetry")]
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
+}
+
+/// Reject a selected ClickHouse binary that `exec()` is certain to refuse,
+/// *before* the telemetry pre-exec hook runs (#471).
+///
+/// `exec()` returns only on failure, by which point the invocation has already
+/// been recorded as a censored `exec_attempt`; a launch failure must therefore
+/// be caught here to be observable as a failure at all. The deterministic ones
+/// are: nothing at the path, a path that is not a regular file (a directory,
+/// say), a path that cannot be stat-ed, and a regular file carrying no execute
+/// bit. A binary unlinked or chmod-ed between this check and `exec()`, or one
+/// with a bad executable format, is a race no pre-flight can close — the
+/// correct exit code and message still reach the shell.
+fn ensure_launchable(binary: &Path, version: &str) -> Result<()> {
+    let problem = match std::fs::metadata(binary) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => BinaryLaunchProblem::Missing,
+        Err(_) => BinaryLaunchProblem::Unreadable,
+        Ok(metadata) if !metadata.is_file() => BinaryLaunchProblem::NotAFile,
+        // "Can anyone execute this", not "can the owner": a build installed
+        // 0o711 or 0o111 is perfectly launchable.
+        Ok(metadata) if metadata.permissions().mode() & 0o111 == 0 => {
+            BinaryLaunchProblem::NotExecutable
+        }
+        Ok(_) => return Ok(()),
+    };
+    Err(Error::BinaryNotLaunchable {
+        version: version.to_string(),
+        problem,
+        path: binary.display().to_string(),
+    })
 }
 
 const REPEATED_QUERY_MIN_VERSION: &str = "23.9.1.1854";
@@ -1398,6 +1442,92 @@ mod tests {
         assert!(ensure_repeated_query_supported(REPEATED_QUERY_MIN_VERSION, 2).is_ok());
         assert!(ensure_repeated_query_supported("25.12.9.61", 3).is_ok());
         assert!(ensure_repeated_query_supported("26.8.1.1760", usize::MAX).is_ok());
+    }
+
+    /// Write `contents` at `path` with the given mode, creating parents.
+    fn write_with_mode(path: &Path, contents: &str, mode: u32) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(path, contents).expect("write file");
+        let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(mode);
+        std::fs::set_permissions(path, permissions).expect("set mode");
+    }
+
+    #[test]
+    fn launchable_binary_passes_the_pre_exec_check() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let binary = dir.path().join("versions/25.12.9.61/clickhouse");
+        write_with_mode(&binary, "#!/bin/sh\nexit 0\n", 0o755);
+        assert!(ensure_launchable(&binary, "25.12.9.61").is_ok());
+    }
+
+    /// The classified problem for a path the pre-flight rejects.
+    fn launch_problem(binary: &Path, version: &str) -> BinaryLaunchProblem {
+        match ensure_launchable(binary, version).expect_err("path must be rejected") {
+            Error::BinaryNotLaunchable { problem, .. } => problem,
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn unlaunchable_binaries_fail_before_the_pre_exec_hook() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // No execute bit: `exec()` would return EACCES *after* the handoff had
+        // already been recorded, so the check names the file and the repair.
+        let not_executable = dir.path().join("versions/25.12.9.61/clickhouse");
+        write_with_mode(&not_executable, "#!/bin/sh\nexit 0\n", 0o644);
+        assert_eq!(
+            launch_problem(&not_executable, "25.12.9.61"),
+            BinaryLaunchProblem::NotExecutable
+        );
+
+        // A directory in the binary's place: `exists()` is true, so resolution
+        // accepts it and only the pre-flight can reject it.
+        let directory = dir.path().join("versions/26.8.1.1760/clickhouse");
+        std::fs::create_dir_all(&directory).expect("create directory");
+        assert_eq!(
+            launch_problem(&directory, "26.8.1.1760"),
+            BinaryLaunchProblem::NotAFile
+        );
+
+        // Missing entirely: a build removed after version resolution.
+        let missing = dir.path().join("versions/27.1.2.3/clickhouse");
+        assert_eq!(
+            launch_problem(&missing, "27.1.2.3"),
+            BinaryLaunchProblem::Missing
+        );
+    }
+
+    #[test]
+    fn launch_failure_message_names_the_build_the_path_and_the_repair() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let binary = dir.path().join("versions/25.12.9.61/clickhouse");
+        write_with_mode(&binary, "#!/bin/sh\nexit 0\n", 0o644);
+        let message = ensure_launchable(&binary, "25.12.9.61")
+            .expect_err("a non-executable binary cannot be launched")
+            .to_string();
+        assert!(message.contains("not executable"), "{message}");
+        assert!(message.contains(&binary.display().to_string()), "{message}");
+        assert!(
+            message.contains("clickhousectl local install 25.12.9.61"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn group_and_other_execute_bits_count_as_launchable() {
+        // The check asks "can anyone execute this", not "can the owner": a
+        // build installed with 0o711 or 0o111 must not be refused.
+        let dir = tempfile::tempdir().expect("tempdir");
+        for mode in [0o711, 0o151, 0o111] {
+            let binary = dir.path().join(format!("mode-{mode:o}/clickhouse"));
+            write_with_mode(&binary, "#!/bin/sh\nexit 0\n", mode);
+            assert!(
+                ensure_launchable(&binary, "25.12.9.61").is_ok(),
+                "mode {mode:o} must be launchable"
+            );
+        }
     }
 
     fn server_info(name: &str, engine: server::Engine, version: &str) -> server::ServerInfo {

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1510,7 +1510,7 @@ mod tests {
         assert!(message.contains("not executable"), "{message}");
         assert!(message.contains(&binary.display().to_string()), "{message}");
         assert!(
-            message.contains("clickhousectl local install 25.12.9.61"),
+            message.contains("clickhousectl local install --force 25.12.9.61"),
             "{message}"
         );
     }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1515,6 +1515,27 @@ mod tests {
         );
     }
 
+    /// `install --force` renames a fresh binary over the path, which fails
+    /// with EISDIR when a directory sits there; that reason has to recommend
+    /// `local remove` first.
+    #[test]
+    fn directory_at_binary_path_recommends_remove_then_install() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let directory = dir.path().join("versions/26.8.1.1760/clickhouse");
+        std::fs::create_dir_all(&directory).expect("create directory");
+        let message = ensure_launchable(&directory, "26.8.1.1760")
+            .expect_err("a directory cannot be launched")
+            .to_string();
+        assert!(message.contains("not a regular file"), "{message}");
+        assert!(
+            message.contains(
+                "clickhousectl local remove 26.8.1.1760 && clickhousectl local install 26.8.1.1760"
+            ),
+            "{message}"
+        );
+        assert!(!message.contains("--force"), "{message}");
+    }
+
     #[test]
     fn group_and_other_execute_bits_count_as_launchable() {
         // The check asks "can anyone execute this", not "can the owner": a

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -35,6 +35,10 @@ enum LocalErrorCode {
     /// [`Self::VersionUnavailable`], which means it could not be resolved or
     /// downloaded: `local list --remote` is no help for a local miss.
     VersionNotInstalled,
+    /// The build is installed but cannot be launched: not a regular file, or
+    /// carrying no execute bit. Distinct from [`Self::VersionNotInstalled`],
+    /// which `local install` fixes by fetching a missing build.
+    BinaryNotLaunchable,
     VersionSelectionRequired,
     VersionAlreadyInstalled,
     VersionUnavailable,
@@ -318,6 +322,13 @@ impl LocalErrorOutput {
             }
             Error::ClientVersionNotInstalled(version) => {
                 Mapping::parity(LocalErrorCode::VersionNotInstalled)
+                    .command(format!("clickhousectl local install {version}"))
+            }
+            // Installed but unusable: the message is entirely self-composed
+            // (path plus a closed-vocabulary problem), so it renders at parity
+            // and names the repair (#471).
+            Error::BinaryNotLaunchable { version, .. } => {
+                Mapping::parity(LocalErrorCode::BinaryNotLaunchable)
                     .command(format!("clickhousectl local install {version}"))
             }
             Error::NoDefaultVersion | Error::AmbiguousClientVersion => {
@@ -1297,6 +1308,7 @@ pub fn print_output(output: &(impl Serialize + fmt::Display), json: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::BinaryLaunchProblem;
 
     fn error_json(error: &Error) -> serde_json::Value {
         serde_json::to_value(LocalErrorOutput::from_error(error)).unwrap()
@@ -1524,11 +1536,40 @@ mod tests {
                 "io_error",
             ),
             (Error::Exec("raw fallback details".into()), "local_error"),
+            (
+                Error::BinaryNotLaunchable {
+                    version: "25.12.9.61".into(),
+                    problem: BinaryLaunchProblem::NotExecutable,
+                    path: "/home/u/.clickhouse/versions/25.12.9.61/clickhouse".into(),
+                },
+                "binary_not_launchable",
+            ),
         ];
 
         for (error, expected) in cases {
             assert_eq!(error_json(&error)["error"]["code"], expected);
         }
+    }
+
+    /// An installed-but-unlaunchable build is a different failure from a
+    /// missing one, and its recovery is the reinstall of *that* version (#471).
+    #[test]
+    fn unlaunchable_binary_json_error_names_the_problem_and_the_reinstall() {
+        let json = error_json(&Error::BinaryNotLaunchable {
+            version: "25.12.9.61".into(),
+            problem: BinaryLaunchProblem::NotExecutable,
+            path: "/home/u/.clickhouse/versions/25.12.9.61/clickhouse".into(),
+        });
+        let message = json["error"]["message"].as_str().expect("message");
+        assert!(message.contains("not executable"), "{message}");
+        assert!(
+            message.contains("/home/u/.clickhouse/versions/25.12.9.61/clickhouse"),
+            "{message}"
+        );
+        assert_eq!(
+            json["error"]["command"],
+            "clickhousectl local install 25.12.9.61"
+        );
     }
 
     #[test]
@@ -1670,6 +1711,11 @@ mod tests {
             Error::AmbiguousClientVersion,
             Error::StaleDefaultVersion("25.12.9.61".into()),
             Error::ClientVersionNotInstalled("25.12.9.61".into()),
+            Error::BinaryNotLaunchable {
+                version: "25.12.9.61".into(),
+                problem: BinaryLaunchProblem::NotAFile,
+                path: "/home/u/.clickhouse/versions/25.12.9.61/clickhouse".into(),
+            },
             Error::RepeatedClientQueryUnsupported {
                 version: "24.1.1.1".into(),
                 minimum: "24.2",

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -326,10 +326,11 @@ impl LocalErrorOutput {
             }
             // Installed but unusable: the message is entirely self-composed
             // (path plus a closed-vocabulary problem), so it renders at parity
-            // and names the repair (#471).
+            // and names the repair (#471). `--force` because install counts
+            // any existing path at the binary location as already installed.
             Error::BinaryNotLaunchable { version, .. } => {
                 Mapping::parity(LocalErrorCode::BinaryNotLaunchable)
-                    .command(format!("clickhousectl local install {version}"))
+                    .command(format!("clickhousectl local install --force {version}"))
             }
             Error::NoDefaultVersion | Error::AmbiguousClientVersion => {
                 Mapping::parity(LocalErrorCode::VersionSelectionRequired)
@@ -1568,7 +1569,7 @@ mod tests {
         );
         assert_eq!(
             json["error"]["command"],
-            "clickhousectl local install 25.12.9.61"
+            "clickhousectl local install --force 25.12.9.61"
         );
     }
 

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -326,12 +326,12 @@ impl LocalErrorOutput {
             }
             // Installed but unusable: the message is entirely self-composed
             // (path plus a closed-vocabulary problem), so it renders at parity
-            // and names the repair (#471). `--force` because install counts
-            // any existing path at the binary location as already installed.
-            Error::BinaryNotLaunchable { version, .. } => {
-                Mapping::parity(LocalErrorCode::BinaryNotLaunchable)
-                    .command(format!("clickhousectl local install --force {version}"))
-            }
+            // and names the repair (#471), which depends on the problem: see
+            // `BinaryLaunchProblem::repair_command`.
+            Error::BinaryNotLaunchable {
+                version, problem, ..
+            } => Mapping::parity(LocalErrorCode::BinaryNotLaunchable)
+                .command(problem.repair_command(version)),
             Error::NoDefaultVersion | Error::AmbiguousClientVersion => {
                 Mapping::parity(LocalErrorCode::VersionSelectionRequired)
                     .command("clickhousectl local list")
@@ -1573,6 +1573,25 @@ mod tests {
         );
     }
 
+    /// A directory at the binary path cannot be fixed by `install --force`
+    /// (renaming over a directory fails with EISDIR), so the recovery command
+    /// goes through `local remove` first.
+    #[test]
+    fn directory_at_binary_path_json_error_recommends_remove_then_install() {
+        let json = error_json(&Error::BinaryNotLaunchable {
+            version: "25.12.9.61".into(),
+            problem: BinaryLaunchProblem::NotAFile,
+            path: "/home/u/.clickhouse/versions/25.12.9.61/clickhouse".into(),
+        });
+        let message = json["error"]["message"].as_str().expect("message");
+        assert!(message.contains("not a regular file"), "{message}");
+        assert!(!message.contains("--force"), "{message}");
+        assert_eq!(
+            json["error"]["command"],
+            "clickhousectl local remove 25.12.9.61 && clickhousectl local install 25.12.9.61"
+        );
+    }
+
     #[test]
     fn version_is_default_json_error_explains_both_the_refusal_and_the_way_forward() {
         let json = error_json(&Error::VersionIsDefault {
@@ -1750,6 +1769,12 @@ mod tests {
             Error::ContainerNameConflict("chctl-pg-dev-17".into()),
             Error::PostgresUsage(
                 "multiple postgres instances named 'dev' (17, 18); pass --version to select one"
+                    .into(),
+            ),
+            // The missing-`psql` pre-flight (#471): its text is composed by
+            // this CLI, so the install hint must survive into JSON.
+            Error::PostgresUsage(
+                "could not execute psql: not found on PATH (install the PostgreSQL client tools)"
                     .into(),
             ),
         ];

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -1040,7 +1040,16 @@ async fn client(
     extra_args: Vec<String>,
 ) -> Result<()> {
     if host.is_some() || port.is_some() {
-        // Direct connect — no server lookup; require host psql.
+        // Direct connect — no server lookup; require host psql. Probing before
+        // the handoff (the same probe the managed path already uses to choose
+        // between host psql and `docker exec`) keeps a missing `psql` an
+        // ordinary error event instead of a censored `exec_attempt` (#471).
+        if !host_has_psql() {
+            return Err(Error::Postgres(
+                "could not execute psql: not found on PATH (install the PostgreSQL client tools)"
+                    .to_string(),
+            ));
+        }
         let h = host.unwrap_or_else(|| "127.0.0.1".to_string());
         let p = port.unwrap_or(DEFAULT_PG_PORT);
         return exec_host_psql(
@@ -1167,7 +1176,12 @@ fn exec_host_psql(
     }
     cmd.args(&extra_args);
     // `exec()` replaces the process image on success, so `main`'s telemetry
-    // tail never runs for this invocation; record the event now (#320).
+    // tail never runs for this invocation; record the censored handoff attempt
+    // now (#320, #471). Both callers probe for `psql` first, so only a race
+    // (or a `PATH` entry that is not launchable) can fail below this line;
+    // `psql` itself then inherits this process's stdio, process group, session
+    // and controlling TTY unchanged, which is why the handoff stays an
+    // `exec()`.
     #[cfg(feature = "telemetry")]
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -1044,8 +1044,10 @@ async fn client(
         // the handoff (the same probe the managed path already uses to choose
         // between host psql and `docker exec`) keeps a missing `psql` an
         // ordinary error event instead of a censored `exec_attempt` (#471).
+        // `PostgresUsage`, not `Postgres`: this text is composed here, so it
+        // renders verbatim in `--json` and the repair hint reaches agents.
         if !host_has_psql() {
-            return Err(Error::Postgres(
+            return Err(Error::PostgresUsage(
                 "could not execute psql: not found on PATH (install the PostgreSQL client tools)"
                     .to_string(),
             ));

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -34,9 +34,20 @@
 //! (`local client`, host `psql`), replacing the process image so `main`'s
 //! tail never runs on success. Those call sites invoke
 //! [`finalize_before_exec`] immediately before `exec()`; it records the
-//! stashed invocation with outcome `"exec"` and shares an exactly-once
-//! guard with [`finalize`] so a *failed* `exec()` — where the error
-//! propagates back to `main` — never produces a second event.
+//! stashed invocation with outcome `"exec_attempt"` and shares an
+//! exactly-once guard with [`finalize`] so a *failed* `exec()` — where the
+//! error propagates back to `main` — never produces a second event.
+//!
+//! `"exec_attempt"` is a **censored** outcome (#471): it proves the handoff
+//! hook was reached, never that the process image was replaced and never
+//! anything about the handed-over program's status. The handoff call sites
+//! therefore validate what can be validated *before* the hook runs (the
+//! selected binary is a regular file with an execute bit; `psql` is on
+//! `PATH`), so the deterministic launch failures are ordinary
+//! `"error"`/exit-1 events. What is left — a binary unlinked or chmod-ed
+//! between validation and `exec()`, a bad executable format — is a race no
+//! pre-flight can close, and it lands on `"exec_attempt"` with the correct
+//! exit code and message still reaching the shell.
 //!
 //! Transport is a detached child process (`clickhousectl telemetry send`,
 //! hidden): the parent spawns it with all stdio nulled and never waits, so
@@ -209,9 +220,13 @@ struct Payload {
     /// invocations carry `"ok"`, `"error"` (including non-zero child exits),
     /// `"cancelled"`, or `"auth_required"`. Child exits are explicitly marked
     /// as `"error"`; the remaining dispatched outcomes are derived from the
-    /// exit code by [`dispatched_outcome`]. `"exec"` means the process image was
-    /// replaced by `exec()` — the handed-over program's exit status is
-    /// unknowable, so `exit_code` is a fixed 0 and not meaningful. Failed
+    /// exit code by [`dispatched_outcome`]. `"exec_attempt"` means the
+    /// invocation reached the `exec()` handoff — nothing more. It is a
+    /// *censored* observation: the process image may or may not have been
+    /// replaced, and the handed-over program's exit status is unknowable
+    /// either way, so `exit_code` is a fixed 0 and carries no information.
+    /// Consumers must never count it as a native-client success or read its
+    /// exit code as a status. Failed
     /// parses carry a direct mapping of clap's `ErrorKind` (`"help"`,
     /// `"version"`, `"invalid_subcommand"`, …).
     /// Literal strings only — this field can never carry user data.
@@ -238,7 +253,7 @@ struct Payload {
 /// marks a successful parse `"ok"` before the command has run; by finalize
 /// time the exit code says how dispatch actually ended, so only that
 /// placeholder is rewritten — the parse kinds from [`capture_lossy`] and
-/// `"exec"` from [`finalize_before_exec`] pass through untouched. The mapping
+/// `"exec_attempt"` from [`finalize_before_exec`] pass through untouched. The mapping
 /// mirrors `Error::exit_code()`, with arbitrary child exit codes classified as
 /// errors.
 fn dispatched_outcome(outcome: &'static str, exit_code: i32) -> &'static str {
@@ -768,11 +783,12 @@ pub fn stash_invocation(invocation: Invocation) {
 }
 
 /// Exactly-once guard shared by [`finalize`] and [`finalize_before_exec`]:
-/// whichever runs first claims it, the other is a no-op. When `exec()` fails,
-/// the pre-exec hook has already recorded the invocation as `"exec"` and the
-/// error propagating back to `main`'s tail is not recorded — losing the
-/// exec-failure detail is the accepted price for never emitting two events
-/// for one invocation.
+/// whichever runs first claims it, the other is a no-op. When `exec()` fails
+/// the pre-exec hook has already recorded the invocation as `"exec_attempt"`,
+/// and the error propagating back to `main`'s tail is not recorded a second
+/// time — which is why `"exec_attempt"` is defined as censored rather than as
+/// a successful handoff (#471). Launch failures that *can* be detected before
+/// the hook runs never reach it, so they are recorded as ordinary errors.
 static FINALIZED: AtomicBool = AtomicBool::new(false);
 
 /// `true` for exactly one caller per guard: swap semantics, first wins.
@@ -781,11 +797,11 @@ fn claim(guard: &AtomicBool) -> bool {
 }
 
 /// The event recorded when the process image is about to be replaced: the
-/// stashed parse result with its outcome rewritten to the `"exec"` literal
-/// (see [`Payload::outcome`]).
-fn exec_invocation(stashed: &Invocation) -> Invocation {
+/// stashed parse result with its outcome rewritten to the `"exec_attempt"`
+/// literal (see [`Payload::outcome`]).
+fn exec_attempt_invocation(stashed: &Invocation) -> Invocation {
     Invocation {
-        outcome: "exec",
+        outcome: "exec_attempt",
         ..stashed.clone()
     }
 }
@@ -804,10 +820,15 @@ pub fn finalize(invocation: Invocation, exit_code: i32, defer_first_run_notice: 
 
 /// The pre-exec hook, called by the `exec()` handoffs (`local client`, host
 /// `psql`) immediately before the process image is replaced and `main`'s tail
-/// becomes unreachable. On a first run this prints the notice to stderr just
+/// becomes unreachable. Records the censored `"exec_attempt"` outcome, exactly
+/// once per invocation. On a first run this prints the notice to stderr just
 /// before the handed-over program starts — acceptable and intended. The
 /// detached send child survives the `exec()` because it is a separate
 /// process.
+///
+/// Call it as late as possible: everything a handler can check about the
+/// launch belongs *before* this hook, so that failure is a real
+/// `"error"`/exit-1 event instead of a censored attempt (#471).
 pub fn finalize_before_exec() {
     let Some(stashed) = STASHED_INVOCATION.get() else {
         return;
@@ -815,7 +836,7 @@ pub fn finalize_before_exec() {
     if !claim(&FINALIZED) {
         return;
     }
-    finalize_inner(&exec_invocation(stashed), 0, false);
+    finalize_inner(&exec_attempt_invocation(stashed), 0, false);
 }
 
 fn finalize_inner(invocation: &Invocation, exit_code: i32, defer_first_run_notice: bool) {
@@ -1122,7 +1143,7 @@ mod tests {
             dispatched_outcome("unknown_argument", 2),
             "unknown_argument"
         );
-        assert_eq!(dispatched_outcome("exec", 0), "exec");
+        assert_eq!(dispatched_outcome("exec_attempt", 0), "exec_attempt");
     }
 
     /// The `outcome` field of the payload `decide` builds for the given
@@ -1231,7 +1252,7 @@ mod tests {
     }
 
     #[test]
-    fn exec_invocation_rewrites_only_the_outcome() {
+    fn exec_attempt_invocation_rewrites_only_the_outcome() {
         let stashed = Invocation {
             command: "local client".into(),
             flags: vec!["port".into()],
@@ -1239,8 +1260,8 @@ mod tests {
             outcome: "ok",
             suggestion: None,
         };
-        let inv = exec_invocation(&stashed);
-        assert_eq!(inv.outcome, "exec");
+        let inv = exec_attempt_invocation(&stashed);
+        assert_eq!(inv.outcome, "exec_attempt");
         assert_eq!(inv.command, "local client");
         assert_eq!(inv.flags, ["port"]);
         assert_eq!(inv.positionals, ["name"]);
@@ -1248,27 +1269,38 @@ mod tests {
     }
 
     #[test]
-    fn exec_outcome_sends_the_expected_payload() {
+    fn exec_attempt_outcome_sends_the_expected_payload() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("telemetry.json");
         save_state_to(&path, false).unwrap();
-        let inv = exec_invocation(&Invocation {
+        let inv = exec_attempt_invocation(&Invocation {
             command: "local client".into(),
             flags: vec!["query".into()],
             positionals: vec![],
             outcome: "ok",
             suggestion: None,
         });
-        // The hook always passes 0: the handed-over program's exit status is
-        // unknowable, and `outcome` marks the code as not meaningful.
+        // The hook always passes 0: the handoff is censored, so neither the
+        // launch nor the handed-over program's exit status is observable and
+        // `outcome` marks the code as carrying no information.
         let Action::Send(json) = decide(&path, &inv, 0, &env_of(&[])) else {
             panic!("expected Send");
         };
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(value["command"], "local client");
         assert_eq!(value["flags"], serde_json::json!(["query"]));
-        assert_eq!(value["outcome"], "exec");
+        assert_eq!(value["outcome"], "exec_attempt");
         assert_eq!(value["exit_code"], 0);
+    }
+
+    #[test]
+    fn exec_attempt_is_never_rewritten_to_a_dispatched_outcome() {
+        // A censored attempt must not be laundered into "ok" (or "error") by
+        // the exit-code mapping, whatever code the tail would have seen.
+        let inv = exec_attempt_invocation(&invocation());
+        for exit_code in [0, 1, 3, 4, 23] {
+            assert_eq!(decided_outcome(&inv, exit_code), "exec_attempt");
+        }
     }
 
     // -- capture: values are structurally unreachable ------------------------

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -465,6 +465,389 @@ async fn child_exit_code_reaches_the_telemetry_tail_unchanged() {
     assert_eq!(payloads[0]["outcome"], "error");
 }
 
+// ---------------------------------------------------------------------------
+// `exec()` handoffs (#471). `local client` replaces the process image, so its
+// event is emitted by the pre-exec hook and is *censored*: `exec_attempt`
+// proves the handoff was reached, never that the launch or the native client
+// succeeded. These tests pin both halves of that contract — the deterministic
+// launch failures are ordinary `error` events, the residual race is censored,
+// and either way exactly one event is emitted and the shell keeps the real
+// status.
+// ---------------------------------------------------------------------------
+
+const FAKE_VERSION: &str = "25.12.9.61";
+
+/// Install a fake native client at `~/.clickhouse/versions/<version>/clickhouse`
+/// in the sandboxed home, with the given contents and mode.
+#[cfg(unix)]
+fn install_fake_clickhouse(sandbox: &Sandbox, version: &str, contents: &str, mode: u32) -> PathBuf {
+    let binary = sandbox
+        .home
+        .path()
+        .join(".clickhouse/versions")
+        .join(version)
+        .join("clickhouse");
+    std::fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    std::fs::write(&binary, contents).unwrap();
+    let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+    permissions.set_mode(mode);
+    std::fs::set_permissions(&binary, permissions).unwrap();
+    binary
+}
+
+/// `local client` on the direct-connect path (no server metadata needed),
+/// selecting the fake binary by exact version.
+///
+/// The environment is cleared down to `HOME` and the ingest URL — as in
+/// `child_exit_code_reaches_the_telemetry_tail_unchanged` — so agent detection
+/// cannot flip the assertions from human text to the JSON envelope depending on
+/// where the suite runs.
+#[cfg(unix)]
+fn run_local_client(sandbox: &Sandbox, project: &std::path::Path) -> Output {
+    sandbox
+        .command(&[
+            "local",
+            "client",
+            "--version",
+            FAKE_VERSION,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9000",
+        ])
+        .env_clear()
+        .env("HOME", sandbox.home.path())
+        .env("CHCTL_TELEMETRY_URL", sandbox.telemetry_url())
+        .current_dir(project)
+        .output()
+        .expect("run clickhousectl")
+}
+
+/// Wait for the event, then give a hypothetical second one time to arrive and
+/// fail if it does: exactly one event per invocation is the contract, and the
+/// handoff hook shares its guard with `main`'s tail.
+async fn exactly_one_event(sandbox: &Sandbox) -> Value {
+    let payloads = sandbox.wait_for_requests(1).await;
+    tokio::time::sleep(Duration::from_millis(750)).await;
+    let requests = sandbox.received_requests().await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "expected exactly one telemetry event, saw {:?}",
+        requests
+            .iter()
+            .map(|r| String::from_utf8_lossy(&r.body).into_owned())
+            .collect::<Vec<_>>()
+    );
+    payloads.into_iter().next().unwrap()
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn successful_handoff_is_one_censored_exec_attempt() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    install_fake_clickhouse(
+        &sandbox,
+        FAKE_VERSION,
+        "#!/bin/sh\nprintf 'child ran\\n'\nexit 0\n",
+        0o755,
+    );
+
+    let output = run_local_client(&sandbox, project.path());
+
+    // The child inherited stdout and its status is the process status: the
+    // image really was replaced.
+    assert_eq!(output.status.code(), Some(0), "{}", stderr_of(&output));
+    assert!(stdout_of(&output).contains("child ran"), "{output:?}");
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "exec_attempt");
+    // Fixed 0: censored, not "the native client succeeded".
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn child_exit_status_is_preserved_and_the_event_stays_censored() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    install_fake_clickhouse(
+        &sandbox,
+        FAKE_VERSION,
+        "#!/bin/sh\nprintf 'child ran\\n'\nexit 23\n",
+        0o755,
+    );
+
+    let output = run_local_client(&sandbox, project.path());
+
+    // The shell sees the native client's own status, unmodified.
+    assert_eq!(output.status.code(), Some(23), "{}", stderr_of(&output));
+    assert!(stdout_of(&output).contains("child ran"), "{output:?}");
+
+    // And the event does not claim to know it: `exec_attempt` with a fixed 0
+    // is the documented censored reading, never `ok` and never the child's 23.
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "exec_attempt");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn the_native_client_keeps_this_process_and_its_stdio() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    // `$$` is the exec'd shell's PID. It equalling the PID the harness spawned
+    // is the whole reason the handoff stays an `exec()` and its telemetry stays
+    // censored: same process means same process group, same session and the
+    // same controlling TTY, so job control, Ctrl-C and window resizes reach the
+    // native client exactly as if the shell had launched it. Reading a line
+    // back off stdin pins that stdin/stdout are inherited, not rewired.
+    install_fake_clickhouse(
+        &sandbox,
+        FAKE_VERSION,
+        "#!/bin/sh\nread line\nprintf 'pid:%s\\nstdin:%s\\n' \"$$\" \"$line\"\nexit 0\n",
+        0o755,
+    );
+
+    let mut child = sandbox
+        .command(&[
+            "local",
+            "client",
+            "--version",
+            FAKE_VERSION,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9000",
+        ])
+        .env_clear()
+        .env("HOME", sandbox.home.path())
+        .env("CHCTL_TELEMETRY_URL", sandbox.telemetry_url())
+        .current_dir(project.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn clickhousectl");
+    let pid = child.id();
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin
+            .write_all(b"hello\n")
+            .expect("write to inherited stdin");
+    }
+    let output = child.wait_with_output().expect("wait for clickhousectl");
+
+    assert_eq!(output.status.code(), Some(0), "{}", stderr_of(&output));
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains(&format!("pid:{pid}")),
+        "the native client must run as this very process: {stdout}"
+    );
+    assert!(stdout.contains("stdin:hello"), "{stdout}");
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["outcome"], "exec_attempt");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn signal_terminated_child_reaches_the_shell_as_a_signal() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    install_fake_clickhouse(&sandbox, FAKE_VERSION, "#!/bin/sh\nkill -TERM $$\n", 0o755);
+
+    let output = run_local_client(&sandbox, project.path());
+
+    // Killed by a signal, so there is no exit code at all — the shell sees the
+    // native client's death, not a wrapper's translation of it.
+    assert_eq!(output.status.code(), None);
+    assert_eq!(output.status.signal(), Some(15));
+
+    // And telemetry says only that the handoff was reached.
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "exec_attempt");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn non_executable_binary_is_an_error_event_not_a_handoff() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    install_fake_clickhouse(&sandbox, FAKE_VERSION, "#!/bin/sh\nexit 0\n", 0o644);
+
+    let output = run_local_client(&sandbox, project.path());
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains("not executable"), "{stderr}");
+    assert!(
+        stderr.contains("clickhousectl local install"),
+        "the error should say how to repair the install: {stderr}"
+    );
+
+    // A launch that never happened is a failure, not an accepted handoff.
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "error");
+    assert_eq!(event["exit_code"], 1);
+    assert_eq!(event["exit_code"], output.status.code().unwrap());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn directory_in_place_of_the_binary_is_an_error_event() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    // A directory named `clickhouse` satisfies the `exists()` resolution
+    // checks, so this reaches the launch pre-flight.
+    let binary = sandbox
+        .home
+        .path()
+        .join(".clickhouse/versions")
+        .join(FAKE_VERSION)
+        .join("clickhouse");
+    std::fs::create_dir_all(&binary).unwrap();
+
+    let output = run_local_client(&sandbox, project.path());
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains("not a regular file"), "{stderr}");
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["outcome"], "error");
+    assert_eq!(event["exit_code"], 1);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn binary_removed_before_the_pre_flight_is_an_error_event() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    let binary = install_fake_clickhouse(&sandbox, FAKE_VERSION, "#!/bin/sh\nexit 0\n", 0o755);
+    // Version resolution lists the directory, but nothing is left to launch:
+    // removal is detected by the pre-flight, so it is an ordinary error.
+    std::fs::remove_file(&binary).unwrap();
+    std::fs::write(binary.parent().unwrap().join("clickhouse.bak"), "stub").unwrap();
+
+    let output = run_local_client(&sandbox, project.path());
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "error");
+    assert_eq!(event["exit_code"], 1);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn launch_failure_after_the_pre_flight_is_censored_never_successful() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    // A regular file with an execute bit — the pre-flight passes — whose
+    // shebang interpreter does not exist, so `execve` fails with the very
+    // ENOENT a binary unlinked between the pre-flight and the launch would
+    // produce. That race is not closable, so this is the deterministic stand-in
+    // for it: the residue lands on the censored outcome, never on `ok`.
+    install_fake_clickhouse(
+        &sandbox,
+        FAKE_VERSION,
+        "#!/no/such/interpreter\nexit 0\n",
+        0o755,
+    );
+
+    let output = run_local_client(&sandbox, project.path());
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains("Failed to execute ClickHouse"),
+        "the OS launch failure must still reach the shell: {stderr}"
+    );
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local client");
+    assert_eq!(event["outcome"], "exec_attempt");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn bad_executable_format_is_censored_never_successful() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    // Executable, but not an executable format. The pre-flight passes, and
+    // `execvp` gets ENOEXEC — which POSIX has it answer by re-execing the file
+    // through `/bin/sh`, so the image *is* replaced and the shell reports the
+    // failure with its own non-zero status. Either way clickhousectl is gone by
+    // then: the outcome the event can honestly carry is the censored attempt,
+    // and the status the user sees is not clickhousectl's to choose.
+    install_fake_clickhouse(&sandbox, FAKE_VERSION, "\u{0}\u{1}not a binary\n", 0o755);
+
+    let output = run_local_client(&sandbox, project.path());
+
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "a file that is not an executable format must fail: {stderr}"
+    );
+
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["outcome"], "exec_attempt");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn missing_psql_is_an_error_event_not_a_handoff() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    let empty_path = sandbox.home.path().join("empty-path");
+    std::fs::create_dir_all(&empty_path).unwrap();
+
+    let output = sandbox
+        .command(&["local", "postgres", "client", "--host", "127.0.0.1"])
+        .env_clear()
+        .env("HOME", sandbox.home.path())
+        .env("CHCTL_TELEMETRY_URL", sandbox.telemetry_url())
+        .env("PATH", &empty_path)
+        .current_dir(project.path())
+        .output()
+        .expect("run clickhousectl");
+
+    let stderr = stderr_of(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains("could not execute psql"), "{stderr}");
+
+    // The other `exec()` handoff: a program that cannot be launched is an
+    // error, not a censored attempt.
+    let event = exactly_one_event(&sandbox).await;
+    assert_eq!(event["command"], "local postgres client");
+    assert_eq!(event["outcome"], "error");
+    assert_eq!(event["exit_code"], 1);
+}
+
 #[tokio::test]
 async fn flag_names_sent_but_values_never_leak() {
     let sandbox = Sandbox::new().await;


### PR DESCRIPTION
Fixes #471

Stacked PR: this branch is based on `feat/480-telemetry-positionals`, not `main`. Review/merge that one first.

## What was wrong

`local client` finalized telemetry as `outcome=exec, exit_code=0` immediately *before* `exec()`. That claimed something the hook cannot observe:

* a selected binary with no execute bit emitted `exec/0`, then clickhousectl printed `Permission denied` and exited 1;
* an executable child exiting 23 emitted `exec/0` while the shell correctly got 23.

The docs said `exec` meant "the process image was replaced", which was not what the hook proved.

## What this changes

The handoff stays an `exec()` deliberately. The native client must keep this PID, process group, session and controlling TTY, with stdin/stdout/stderr inherited, so Ctrl-C, Ctrl-Z, window resizes, and its own exit status or fatal signal reach the shell exactly as if it had been launched directly. A spawn-and-wait wrapper would have to relay all of that (SIGINT/SIGTSTP disposition, 128+signal translation, orphaning on parent death) to break even, so instead the telemetry contract was made honest:

* **`exec` → `exec_attempt`**, documented as a *censored* outcome: it proves the handoff was reached and nothing else — not that the image was replaced, not the child's status. `exit_code` stays a fixed `0` and carries no information; dashboards must never count it as native-client success. Still exactly one event per invocation (unchanged shared guard).
* **Deterministic launch failures never reach the hook.** `ensure_launchable` runs before `finalize_before_exec` and classifies missing / not-a-regular-file / unreadable / no-execute-bit into the new `Error::BinaryNotLaunchable`, so those are ordinary `outcome=error, exit_code=1` events with the real message and exit code. The message is fully self-composed (closed-vocabulary problem + path + repair), so unlike `Error::Exec` it renders at parity in `--json` under the new stable code `binary_not_launchable`, with `clickhousectl local install <version>` as the recovery command.
* **`local postgres client --host/--port`** now probes for `psql` the way the managed path already does, so a missing `psql` is an error event rather than a censored attempt (the existing `could not execute psql:` wording is preserved).
* Residual, stated plainly in code and README: a binary unlinked or chmod-ed between the pre-flight and `exec()`, or a bad executable format, still lands on `exec_attempt` — the correct exit code and message reach the shell, and the outcome is censored rather than claiming success.

## Tests

`cargo test -p clickhousectl` (all suites), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all`, plus `cargo check -p clickhousectl --no-default-features` (telemetry compiled out).

New subprocess coverage in `crates/clickhousectl/tests/telemetry_test.rs`, each asserting *exactly one* event:

| case | shell status | event |
| ---- | ------------ | ----- |
| executable child exits 0 | 0 | `exec_attempt` / 0 |
| executable child exits 23 | 23 | `exec_attempt` / 0 |
| child killed by SIGTERM | signal 15, no code | `exec_attempt` / 0 |
| child prints `$$` and echoes stdin | 0, PID equals the spawned PID | `exec_attempt` / 0 |
| binary without execute bit | 1 | `error` / 1 |
| directory in the binary's place | 1 | `error` / 1 |
| binary removed before the pre-flight | 1 | `error` / 1 |
| launch fails after the pre-flight (bad shebang interpreter — the same ENOENT the unlink race produces, deterministically) | 1 | `exec_attempt` / 0 |
| bad executable format (`execvp` hands it to `/bin/sh` per POSIX) | non-zero | `exec_attempt` / 0 |
| `psql` not on `PATH` | 1 | `error` / 1 |

Unit tests cover the pre-flight classification and message, that group/other execute bits count as launchable, that `exec_attempt` is never rewritten by the exit-code mapping, and the new JSON error code and parity rendering.

## Docs and deploy caveat

README documents the handoff semantics (censored `exec_attempt`, exit code 0 meaningless, what is refused before the handover) and adds `binary_not_launchable` to the local error-code table.

**Ingest worker:** the outcome vocabulary gains `exec_attempt` and loses `exec`. As with #320/#322, the ingest worker and any dashboards need updating before the next CLI release — `exec_attempt` must be treated as censored (never native-client success), and existing `exec` rows keep their old, weaker meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)