### PR TITLE
Correct the `--backup-start-time` help and check the stored backup period

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ clickhousectl cloud service delete <service-id>
 clickhousectl cloud service delete <service-id> --force
 ```
 
+`--backup-start-time` requires the backup period to be 24 or 48 hours. Nothing is defaulted when the period is omitted: the API validates the new start time against the period already stored on the service, so either pass `--backup-period-hours 24` or `--backup-period-hours 48` in the same call, or leave the stored period at one of those. When a start time is given without a period, the CLI reads the current configuration first and fails before sending the update if the stored period is something else.
+
 `--force` stops the service and then polls it until the stop completes, which takes minutes on a real service, printing each state change to stderr (stdout stays reserved for the result). Progress output is best-effort: if whatever was reading it goes away — a pager you quit, a supervising process that stopped reading — the lines are dropped and the deletion still runs to completion and exits 0.
 
 Use `clickhousectl cloud service create --help` for the complete option list. If omitted, `--provider` defaults to `aws`, `--region` defaults to `us-east-1`, and the IP allowlist defaults to `0.0.0.0/0`; production workflows should normally set all three explicitly. When the create response includes an initial password, it is shown only once.

--- a/crates/clickhousectl/src/cloud/backups.rs
+++ b/crates/clickhousectl/src/cloud/backups.rs
@@ -78,8 +78,9 @@ pub enum BackupConfigCommands {
         #[arg(long)]
         backup_retention_period_hours: Option<u32>,
 
-        /// Backup start time in UTC, exactly on the hour (HH:00). If the period
-        /// is omitted, the API sets it to 24 hours.
+        /// Backup start time in UTC, exactly on the hour (HH:00). Requires the
+        /// backup period to be 24 or 48 hours: pass --backup-period-hours 24|48
+        /// in the same call, or the stored period must already be one of those.
         #[arg(long, value_parser = parse_backup_start_time)]
         backup_start_time: Option<String>,
 
@@ -184,6 +185,21 @@ fn build_backup_config_update_request(
     })
 }
 
+/// A start time sent without a period is validated by the API against the
+/// *stored* period, which it keeps rather than defaulting. If that period is
+/// not 24 or 48 the PATCH fails with an opaque `BAD_REQUEST`, so check it
+/// first and name the flag that fixes it. An absent stored period is not a
+/// guess we get to make: proceed and let the API decide.
+fn check_stored_period_allows_start_time(stored_period_hours: Option<f64>) -> CloudResult<()> {
+    match stored_period_hours {
+        Some(period) if period != 24.0 && period != 48.0 => Err(CloudError::new(format!(
+            "the stored backup period is {period} hours, but --backup-start-time requires 24 or \
+             48. Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call."
+        ))),
+        _ => Ok(()),
+    }
+}
+
 async fn backup_list(
     client: &CloudClient,
     service_id: &str,
@@ -268,6 +284,12 @@ async fn backup_config_update(
 ) -> CloudResult<()> {
     let request = build_backup_config_update_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
+
+    if request.backup_start_time.is_some() && request.backup_period_in_hours.is_none() {
+        let stored = client.get_backup_config(&org_id, service_id).await?;
+        check_stored_period_allows_start_time(stored.backup_period_in_hours)?;
+    }
+
     let config = client
         .update_backup_config(&org_id, service_id, &request)
         .await?;
@@ -544,7 +566,12 @@ mod tests {
         let help = error.to_string();
         assert!(help.contains("exactly on the hour (HH:00)"));
         assert!(help.contains("must be 24 or 48 hours"));
-        assert!(help.contains("API sets it to 24 hours"));
+        assert!(help.contains("Requires the backup period to be 24 or 48 hours"));
+        assert!(help.contains("or the stored period must already be one of those"));
+        assert!(
+            !help.contains("API sets it to 24 hours"),
+            "help must not claim the API defaults an omitted period"
+        );
     }
 
     #[test]
@@ -656,6 +683,37 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "--backup-period-hours must be 24 or 48 when --backup-start-time is set"
+        );
+    }
+
+    #[test]
+    fn stored_period_check_accepts_compatible_periods() {
+        for stored in [24.0, 48.0] {
+            check_stored_period_allows_start_time(Some(stored)).unwrap();
+        }
+    }
+
+    #[test]
+    fn stored_period_check_proceeds_when_the_stored_period_is_absent() {
+        check_stored_period_allows_start_time(None).unwrap();
+    }
+
+    #[test]
+    fn stored_period_check_rejects_incompatible_periods_and_names_the_flag() {
+        let error = check_stored_period_allows_start_time(Some(12.0)).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "the stored backup period is 12 hours, but --backup-start-time requires 24 or 48. \
+             Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call."
+        );
+
+        let fractional = check_stored_period_allows_start_time(Some(12.5)).unwrap_err();
+        assert!(
+            fractional
+                .to_string()
+                .starts_with("the stored backup period is 12.5 hours,"),
+            "{fractional}"
         );
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -324,6 +324,123 @@ async fn backup_config_rejects_incompatible_period_before_any_request() {
     assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
+// ── Backup start time against the stored period (issue #642) ────────────────
+
+/// The API keeps the stored period when a start-time update omits one, and
+/// rejects the PATCH if that period is not 24 or 48. The CLI reads the
+/// configuration first so the user gets a message naming the flag to pass.
+const BACKUP_CONFIG_PATH: &str = "/v1/organizations/org-1/services/svc-1/backupConfiguration";
+
+async fn mount_stored_backup_config(mock: &MockServer, period_hours: f64) {
+    Mock::given(method("GET"))
+        .and(path(BACKUP_CONFIG_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "backupPeriodInHours": period_hours,
+                "backupRetentionPeriodInHours": 48.0,
+            },
+            "status": 200,
+            "requestId": "stub-backup-config-get",
+        })))
+        .mount(mock)
+        .await;
+}
+
+async fn mount_backup_config_patch(mock: &MockServer) {
+    Mock::given(method("PATCH"))
+        .and(path(BACKUP_CONFIG_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "backupPeriodInHours": 24.0,
+                "backupRetentionPeriodInHours": 48.0,
+                "backupStartTime": "02:00",
+            },
+            "status": 200,
+            "requestId": "stub-backup-config-patch",
+        })))
+        .mount(mock)
+        .await;
+}
+
+fn backup_config_update_args<'a>(extra: &[&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "service",
+        "backup-config",
+        "update",
+        "svc-1",
+        "--org-id",
+        "org-1",
+        "--backup-start-time",
+        "02:00",
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+#[tokio::test]
+async fn backup_config_start_time_refuses_an_incompatible_stored_period() {
+    let mock = MockServer::start().await;
+    mount_stored_backup_config(&mock, 12.0).await;
+
+    let output = invoke_cli_with_cloud_credentials(&mock, &backup_config_update_args(&[]));
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: the stored backup period is 12 hours, but --backup-start-time requires 24 or 48. \
+         Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call.\n"
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "expected only the configuration read");
+    assert_eq!(requests[0].method, wiremock::http::Method::GET);
+}
+
+#[tokio::test]
+async fn backup_config_start_time_patches_when_the_stored_period_is_compatible() {
+    let mock = MockServer::start().await;
+    mount_stored_backup_config(&mock, 24.0).await;
+    mount_backup_config_patch(&mock).await;
+
+    let output = invoke_cli_with_cloud_credentials(&mock, &backup_config_update_args(&[]));
+
+    assert_success(&output);
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method, wiremock::http::Method::GET);
+    assert_eq!(requests[1].method, wiremock::http::Method::PATCH);
+
+    let body: Value = serde_json::from_slice(&requests[1].body).expect("PATCH body wasn't JSON");
+    assert_eq!(body["backupStartTime"], "02:00");
+    assert!(
+        body.get("backupPeriodInHours").is_none(),
+        "the period must stay absent so the API keeps the stored one: {body}"
+    );
+
+    let printed: Value = serde_json::from_slice(&output.stdout).expect("stdout wasn't JSON");
+    assert_eq!(printed["backupStartTime"], "02:00");
+}
+
+#[tokio::test]
+async fn backup_config_start_time_with_an_explicit_period_skips_the_read() {
+    let mock = MockServer::start().await;
+    mount_backup_config_patch(&mock).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &backup_config_update_args(&["--backup-period-hours", "48"]),
+    );
+
+    assert_success(&output);
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "an explicit period needs no read");
+    assert_eq!(requests[0].method, wiremock::http::Method::PATCH);
+
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("PATCH body wasn't JSON");
+    assert_eq!(body["backupStartTime"], "02:00");
+    assert_eq!(body["backupPeriodInHours"], 48.0);
+}
+
 // ── Concrete Cloud error routing (issue #233) ──────────────────────────────
 
 async fn invoke_service_list_api_error(status: u16, message: &str) -> std::process::Output {


### PR DESCRIPTION
## What

- Fixes the doc comment on `backup_start_time` in the `backup-config update` command. It said "If the period is omitted, the API sets it to 24 hours", which is false. It now says the start time requires the backup period to be 24 or 48 hours, either passed in the same call or already stored on the service.
- Updates the pinned help-text test so it asserts the new wording and actively asserts the old claim is gone.
- Adds a client-side pre-check: when `--backup-start-time` is given without `--backup-period-hours`, the handler reads the current backup configuration through the existing `CloudClient::get_backup_config` wrapper and fails before the PATCH if the stored `backupPeriodInHours` is present and is neither 24 nor 48. The message names the numbers and the flag to pass, and nothing else. An absent stored period is not guessed at: the update proceeds and the API decides.
- Documents the 24/48 rule in the README backup-configuration section.

The existing client-side check for an explicitly supplied incompatible period (`--backup-period-hours 12 --backup-start-time 02:00`, issue #425) is unchanged and still fires before any request.

## Why

The API keeps the stored period when an update omits one, then validates the new start time against it. On a service whose period is 12 the documented invitation to pass a start time on its own produces `BAD_REQUEST: customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set` and no state change. The help text was inviting a request the API will not accept, and the resulting error names an internal field rather than a flag. Reading the configuration first turns that into an actionable local failure, and costs one GET only on the exact path that could fail this way.

## Behaviour after the fix

- Start time only, stored period 12: one GET, no PATCH, exit 1, `Error: the stored backup period is 12 hours, but --backup-start-time requires 24 or 48. Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call.`
- Start time only, stored period 24 or 48: GET then PATCH, whose body carries `backupStartTime` and no `backupPeriodInHours`, so the API keeps the stored period.
- Start time plus `--backup-period-hours 24|48`: no GET, a single PATCH with both fields.
- Start time plus any other period: exit 1 with no requests at all.
- Stored period absent from the response: no local refusal, the PATCH is sent.

`--json` output is unchanged on success, and the failure exit code stays 1.

## Tests

- New unit tests for `check_stored_period_allows_start_time` covering 24 and 48, an absent stored period, an exact message assertion for 12, and a fractional value.
- The pinned help-text test now requires the new wording and forbids the old sentence.
- New subprocess and wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs`: stored period 12 refuses with only the GET recorded, stored period 24 issues GET then a PATCH whose body omits `backupPeriodInHours`, and an explicit period 48 issues the PATCH with both fields and no read at all. The pre-existing test for an explicit period 12 already covers the no-request case.
- Verification commands, all clean: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`, `cargo test -p clickhousectl` (all binaries green, 868 unit tests plus every integration target). The API library was not touched.

## Stacking

Part of a stacked PR chain: based on `feat/450-telemetry-failure-classification`, not `main`.

Fixes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)
