### PR TITLE
Add --clear-backup-start-time so the backup start time is no longer a one-way door

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,11 @@ clickhousectl cloud service backup-config update <service-id> \
   --backup-retention-period-hours 720 \
   --backup-start-time 02:00
 
+# Remove the start time again, optionally changing the period in the same call
+clickhousectl cloud service backup-config update <service-id> \
+  --clear-backup-start-time \
+  --backup-period-hours 12
+
 # Service Prometheus configuration
 clickhousectl cloud service prometheus <service-id> --filtered-metrics true
 
@@ -638,6 +643,8 @@ clickhousectl cloud service delete <service-id> --force
 ```
 
 `--backup-start-time` requires the backup period to be 24 or 48 hours. Nothing is defaulted when the period is omitted: the API validates the new start time against the period already stored on the service, so either pass `--backup-period-hours 24` or `--backup-period-hours 48` in the same call, or leave the stored period at one of those. When a start time is given without a period, the CLI reads the current configuration first and fails before sending the update if the stored period is something else.
+
+`--clear-backup-start-time` removes a stored start time and lifts that restriction, so a service that has one can go back to any backup period. It sends an explicit `"backupStartTime": null`, which the API accepts even though the OpenAPI spec does not mark the field nullable, and it can be combined with `--backup-period-hours` to clear the start time and set an otherwise incompatible period in a single call. The two start-time flags conflict: pass one or the other.
 
 `--force` stops the service and then polls it until the stop completes, which takes minutes on a real service, printing each state change to stderr (stdout stays reserved for the result). Progress output is best-effort: if whatever was reading it goes away — a pager you quit, a supervising process that stopped reading — the lines are dropped and the deletion still runs to completion and exits 0.
 

--- a/crates/clickhouse-cloud-api/src/models/backups.rs
+++ b/crates/clickhouse-cloud-api/src/models/backups.rs
@@ -574,8 +574,18 @@ pub struct BackupConfigurationPatchRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub backup_retention_period_in_hours: Option<f64>,
+    /// Three states, because a PATCH that can only set a value cannot undo it:
+    /// `None` omits the key and leaves the stored start time alone,
+    /// `Some(None)` sends an explicit `null`, and `Some(Some(time))` sends the
+    /// time string. An explicit `null` is what clears a stored start time
+    /// (verified against api.clickhouse.cloud on 2026-09-01: the PATCH returns
+    /// 200 and the following GET no longer carries the field), which matters
+    /// because the API refuses any backup period other than 24 or 48 hours
+    /// while one is stored. The empty string is not an alternative: the API
+    /// answers it with `BAD_REQUEST: customBackupStartTime must be a valid
+    /// time (HH:00)`.
     #[serde(rename = "backupStartTime", skip_serializing_if = "Option::is_none")]
-    pub backup_start_time: Option<String>,
+    pub backup_start_time: Option<Option<String>>,
 }
 
 /// `GcpBackupBucket` from the ClickHouse Cloud API.

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1282,7 +1282,7 @@ async fn update_backup_configuration() {
     let body = BackupConfigurationPatchRequest {
         backup_period_in_hours: Some(12.0),
         backup_retention_period_in_hours: Some(336.0),
-        backup_start_time: Some("03:00".to_string()),
+        backup_start_time: Some(Some("03:00".to_string())),
     };
     let resp = client
         .backup_configuration_update("org-1", "svc-1", &body)

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -928,12 +928,40 @@ fn serialize_backup_configuration_patch_request() {
     let req = BackupConfigurationPatchRequest {
         backup_period_in_hours: Some(12.0),
         backup_retention_period_in_hours: Some(336.0),
-        backup_start_time: Some("03:00".to_string()),
+        backup_start_time: Some(Some("03:00".to_string())),
     };
     let json = serde_json::to_value(&req).unwrap();
     assert_eq!(json["backupPeriodInHours"], 12.0);
     assert_eq!(json["backupRetentionPeriodInHours"], 336.0);
     assert_eq!(json["backupStartTime"], "03:00");
+}
+
+/// The three states of `backupStartTime` are what let a caller both set and
+/// unset the start time: only an explicit `null` clears the stored value, and
+/// omitting the key must leave it untouched.
+#[test]
+fn serialize_backup_configuration_patch_request_omits_an_untouched_start_time() {
+    let req = BackupConfigurationPatchRequest {
+        backup_period_in_hours: Some(12.0),
+        backup_retention_period_in_hours: None,
+        backup_start_time: None,
+    };
+    let json = serde_json::to_value(&req).unwrap();
+    assert_eq!(json, serde_json::json!({ "backupPeriodInHours": 12.0 }));
+}
+
+#[test]
+fn serialize_backup_configuration_patch_request_clears_the_start_time_with_null() {
+    let req = BackupConfigurationPatchRequest {
+        backup_period_in_hours: Some(12.0),
+        backup_retention_period_in_hours: None,
+        backup_start_time: Some(None),
+    };
+    let json = serde_json::to_value(&req).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({ "backupPeriodInHours": 12.0, "backupStartTime": null })
+    );
 }
 
 #[test]

--- a/crates/clickhousectl/src/cloud/backups.rs
+++ b/crates/clickhousectl/src/cloud/backups.rs
@@ -81,8 +81,16 @@ pub enum BackupConfigCommands {
         /// Backup start time in UTC, exactly on the hour (HH:00). Requires the
         /// backup period to be 24 or 48 hours: pass --backup-period-hours 24|48
         /// in the same call, or the stored period must already be one of those.
+        /// Reversible with --clear-backup-start-time.
         #[arg(long, value_parser = parse_backup_start_time)]
         backup_start_time: Option<String>,
+
+        /// Remove the stored backup start time, lifting the 24/48 hour
+        /// restriction on the backup period. Can be combined with
+        /// --backup-period-hours to clear the start time and set any period in
+        /// one call. Conflicts with --backup-start-time.
+        #[arg(long, conflicts_with = "backup_start_time")]
+        clear_backup_start_time: bool,
 
         /// Organization ID (auto-detected if not specified)
         #[arg(long)]
@@ -126,12 +134,14 @@ pub async fn run_config(
             backup_period_hours,
             backup_retention_period_hours,
             backup_start_time,
+            clear_backup_start_time,
             org_id,
         } => {
             let options = BackupConfigUpdateOptions {
                 backup_period_hours,
                 backup_retention_period_hours,
                 backup_start_time,
+                clear_backup_start_time,
                 org_id,
             };
             backup_config_update(client, &service_id, options, json).await
@@ -144,6 +154,7 @@ struct BackupConfigUpdateOptions {
     backup_period_hours: Option<u32>,
     backup_retention_period_hours: Option<u32>,
     backup_start_time: Option<String>,
+    clear_backup_start_time: bool,
     org_id: Option<String>,
 }
 
@@ -170,6 +181,12 @@ fn parse_backup_start_time(value: &str) -> Result<String, String> {
 fn build_backup_config_update_request(
     options: &BackupConfigUpdateOptions,
 ) -> CloudResult<BackupConfigurationPatchRequest> {
+    if options.backup_start_time.is_some() && options.clear_backup_start_time {
+        return Err(CloudError::new(
+            "--backup-start-time and --clear-backup-start-time cannot be used together",
+        ));
+    }
+
     if options.backup_start_time.is_some()
         && matches!(options.backup_period_hours, Some(period) if period != 24 && period != 48)
     {
@@ -178,10 +195,19 @@ fn build_backup_config_update_request(
         ));
     }
 
+    // Clearing is the one way out of the 24/48 hour period restriction, so it
+    // travels as an explicit `null` and is deliberately compatible with any
+    // period in the same call: the API applies the clear first.
+    let backup_start_time = match (&options.backup_start_time, options.clear_backup_start_time) {
+        (Some(time), _) => Some(Some(time.clone())),
+        (None, true) => Some(None),
+        (None, false) => None,
+    };
+
     Ok(BackupConfigurationPatchRequest {
         backup_period_in_hours: options.backup_period_hours.map(f64::from),
         backup_retention_period_in_hours: options.backup_retention_period_hours.map(f64::from),
-        backup_start_time: options.backup_start_time.clone(),
+        backup_start_time,
     })
 }
 
@@ -285,7 +311,12 @@ async fn backup_config_update(
     let request = build_backup_config_update_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
 
-    if request.backup_start_time.is_some() && request.backup_period_in_hours.is_none() {
+    // Only a start time being *set* is measured against the stored period.
+    // Clearing one is exactly how a service escapes an incompatible period, so
+    // it must never be blocked by that check.
+    if matches!(request.backup_start_time, Some(Some(_)))
+        && request.backup_period_in_hours.is_none()
+    {
         let stored = client.get_backup_config(&org_id, service_id).await?;
         check_stored_period_allows_start_time(stored.backup_period_in_hours)?;
     }
@@ -454,6 +485,7 @@ mod tests {
             backup_period_hours,
             backup_retention_period_hours,
             backup_start_time,
+            clear_backup_start_time,
             org_id,
         } = command
         else {
@@ -463,6 +495,7 @@ mod tests {
         assert_eq!(backup_period_hours, Some(48));
         assert_eq!(backup_retention_period_hours, Some(336));
         assert_eq!(backup_start_time.as_deref(), Some("03:00"));
+        assert!(!clear_backup_start_time);
         assert!(org_id.is_none());
     }
 
@@ -491,6 +524,7 @@ mod tests {
             backup_period_hours,
             backup_retention_period_hours,
             backup_start_time,
+            clear_backup_start_time,
             org_id,
         } = command
         else {
@@ -500,6 +534,7 @@ mod tests {
         assert!(backup_period_hours.is_none());
         assert!(backup_retention_period_hours.is_none());
         assert!(backup_start_time.is_none());
+        assert!(!clear_backup_start_time);
         assert!(org_id.is_none());
     }
 
@@ -568,6 +603,9 @@ mod tests {
         assert!(help.contains("must be 24 or 48 hours"));
         assert!(help.contains("Requires the backup period to be 24 or 48 hours"));
         assert!(help.contains("or the stored period must already be one of those"));
+        assert!(help.contains("Reversible with --clear-backup-start-time"));
+        assert!(help.contains("Remove the stored backup start time"));
+        assert!(help.contains("lifting the 24/48 hour"));
         assert!(
             !help.contains("API sets it to 24 hours"),
             "help must not claim the API defaults an omitted period"
@@ -619,17 +657,23 @@ mod tests {
         assert!(minimal.backup_period_in_hours.is_none());
         assert!(minimal.backup_retention_period_in_hours.is_none());
         assert!(minimal.backup_start_time.is_none());
+        assert_eq!(
+            serde_json::to_value(&minimal).unwrap(),
+            serde_json::json!({}),
+            "an untouched start time must not appear in the PATCH body"
+        );
 
         let maximal = build_backup_config_update_request(&BackupConfigUpdateOptions {
             backup_period_hours: Some(48),
             backup_retention_period_hours: Some(336),
             backup_start_time: Some("03:00".to_string()),
+            clear_backup_start_time: false,
             org_id: None,
         })
         .unwrap();
         assert_eq!(maximal.backup_period_in_hours, Some(48.0));
         assert_eq!(maximal.backup_retention_period_in_hours, Some(336.0));
-        assert_eq!(maximal.backup_start_time.as_deref(), Some("03:00"));
+        assert_eq!(maximal.backup_start_time, Some(Some("03:00".to_string())));
     }
 
     #[test]
@@ -641,7 +685,7 @@ mod tests {
         .unwrap();
 
         assert!(request.backup_period_in_hours.is_none());
-        assert_eq!(request.backup_start_time.as_deref(), Some("03:00"));
+        assert_eq!(request.backup_start_time, Some(Some("03:00".to_string())));
     }
 
     #[test]
@@ -655,7 +699,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(request.backup_period_in_hours, Some(f64::from(period)));
-            assert_eq!(request.backup_start_time.as_deref(), Some("03:00"));
+            assert_eq!(request.backup_start_time, Some(Some("03:00".to_string())));
         }
     }
 
@@ -683,6 +727,106 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "--backup-period-hours must be 24 or 48 when --backup-start-time is set"
+        );
+    }
+
+    #[test]
+    fn parses_clear_backup_start_time() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+            "--clear-backup-start-time",
+            "--backup-period-hours",
+            "12",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Service { command } = args.command else {
+            panic!("expected service command");
+        };
+        let crate::cloud::cli::ServiceCommands::BackupConfig { command } = command else {
+            panic!("expected backup-config command");
+        };
+        let crate::cloud::cli::BackupConfigCommands::Update {
+            backup_period_hours,
+            backup_start_time,
+            clear_backup_start_time,
+            ..
+        } = command
+        else {
+            panic!("expected backup-config update");
+        };
+        assert_eq!(backup_period_hours, Some(12));
+        assert!(backup_start_time.is_none());
+        assert!(clear_backup_start_time);
+    }
+
+    #[test]
+    fn rejects_setting_and_clearing_the_start_time_together() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+            "--backup-start-time",
+            "02:00",
+            "--clear-backup-start-time",
+        ])
+        .err()
+        .expect("conflicting flags should be rejected");
+
+        assert!(error.to_string().contains("cannot be used with"), "{error}");
+    }
+
+    #[test]
+    fn build_backup_config_update_request_clears_the_start_time_with_an_explicit_null() {
+        let request = build_backup_config_update_request(&BackupConfigUpdateOptions {
+            clear_backup_start_time: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(request.backup_start_time, Some(None));
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            serde_json::json!({ "backupStartTime": null }),
+            "clearing must send an explicit null and nothing else"
+        );
+    }
+
+    #[test]
+    fn build_backup_config_update_request_clears_alongside_any_period() {
+        let request = build_backup_config_update_request(&BackupConfigUpdateOptions {
+            backup_period_hours: Some(12),
+            clear_backup_start_time: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(request.backup_period_in_hours, Some(12.0));
+        assert_eq!(request.backup_start_time, Some(None));
+    }
+
+    #[test]
+    fn build_backup_config_update_request_rejects_setting_and_clearing_together() {
+        let error = build_backup_config_update_request(&BackupConfigUpdateOptions {
+            backup_start_time: Some("03:00".to_string()),
+            clear_backup_start_time: true,
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "--backup-start-time and --clear-backup-start-time cannot be used together"
         );
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -441,6 +441,126 @@ async fn backup_config_start_time_with_an_explicit_period_skips_the_read() {
     assert_eq!(body["backupPeriodInHours"], 48.0);
 }
 
+// ── Clearing the backup start time (issue #564) ─────────────────────────────
+
+/// The Cloud API clears a stored start time only on an explicit JSON `null`
+/// (an empty string is rejected as an invalid time), and clearing is the only
+/// way back to a backup period other than 24 or 48 hours. The flag therefore
+/// has to put the key in the body with a null value, and must not be talked
+/// out of it by the stored-period read.
+async fn mount_cleared_backup_config_patch(mock: &MockServer) {
+    Mock::given(method("PATCH"))
+        .and(path(BACKUP_CONFIG_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "backupPeriodInHours": 12.0,
+                "backupRetentionPeriodInHours": 48.0,
+            },
+            "status": 200,
+            "requestId": "stub-backup-config-clear",
+        })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn backup_config_clear_start_time_sends_an_explicit_null() {
+    let mock = MockServer::start().await;
+    mount_cleared_backup_config_patch(&mock).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--clear-backup-start-time",
+        ],
+    );
+
+    assert_success(&output);
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "clearing needs no stored-period read");
+    assert_eq!(requests[0].method, wiremock::http::Method::PATCH);
+
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("PATCH body wasn't JSON");
+    assert_eq!(
+        body,
+        serde_json::json!({ "backupStartTime": null }),
+        "the key must be present and null, not omitted: {body}"
+    );
+}
+
+#[tokio::test]
+async fn backup_config_clear_start_time_travels_with_an_incompatible_period() {
+    let mock = MockServer::start().await;
+    mount_cleared_backup_config_patch(&mock).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--clear-backup-start-time",
+            "--backup-period-hours",
+            "12",
+            "--json",
+        ],
+    );
+
+    assert_success(&output);
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("PATCH body wasn't JSON");
+    assert_eq!(
+        body,
+        serde_json::json!({ "backupPeriodInHours": 12.0, "backupStartTime": null })
+    );
+
+    let printed: Value = serde_json::from_slice(&output.stdout).expect("stdout wasn't JSON");
+    assert_eq!(printed["backupPeriodInHours"], 12.0);
+    assert!(
+        printed.get("backupStartTime").is_none(),
+        "the cleared start time must be absent from the response: {printed}"
+    );
+}
+
+#[tokio::test]
+async fn backup_config_rejects_setting_and_clearing_the_start_time_together() {
+    let mock = MockServer::start().await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--backup-start-time",
+            "02:00",
+            "--clear-backup-start-time",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("cannot be used with"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
 // ── Concrete Cloud error routing (issue #233) ──────────────────────────────
 
 async fn invoke_service_list_api_error(status: u16, message: &str) -> std::process::Output {


### PR DESCRIPTION
## What

`cloud service backup-config update` gains `--clear-backup-start-time`, which removes a stored backup start time by sending an explicit `"backupStartTime": null`. It conflicts with `--backup-start-time` and can be combined with `--backup-period-hours`, so a service can be freed from the 24/48 hour restriction and given a new period in a single call.

The API library makes that expressible: `BackupConfigurationPatchRequest.backup_start_time` becomes `Option<Option<String>>`, so `None` omits the key, `Some(None)` serializes an explicit `null`, and `Some(Some(time))` sends the time string. The field keeps `skip_serializing_if`, stays free of `serde(default)`, and needed no analyzer exemption. For library consumers this is a type change on a request field: code that set `backup_start_time: Some(time)` must now write `Some(Some(time))`.

## Why the API library changed too

The field was `Option<String>` with `skip_serializing_if`, which has only two states: send a time, or say nothing. A PATCH that can only set a value cannot undo it, so no CLI flag could have cleared the start time without the library change first.

## Behaviour after the fix

Verified live against api.clickhouse.cloud on a disposable service created and deleted for this PR:

```
PATCH .../backupConfiguration  {"backupStartTime": null}
200 {"result":{"backupPeriodInHours":24,"backupRetentionPeriodInHours":24}}
GET  .../backupConfiguration
200 {"result":{"backupPeriodInHours":24,"backupRetentionPeriodInHours":24}}     # start time gone

PATCH .../backupConfiguration  {"backupStartTime": ""}
400 {"error":"BAD_REQUEST: customBackupStartTime must be a valid time (HH:00)"}  # so null it is

PATCH .../backupConfiguration  {"backupPeriodInHours": 12}                       # with 03:00 stored
400 {"error":"BAD_REQUEST: customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set"}

PATCH .../backupConfiguration  {"backupStartTime": null, "backupPeriodInHours": 12}
200 {"result":{"backupPeriodInHours":12,"backupRetentionPeriodInHours":24}}      # clear and reperiod together
```

Repeating the null on a configuration that has no start time returns 200 and changes nothing, so clearing is idempotent. The same three steps then ran through the built binary end to end: setting `02:00`, being refused a 12 hour period, and recovering with `--clear-backup-start-time --backup-period-hours 12`.

Note that the OpenAPI spec does not declare `backupStartTime` nullable. The runtime accepts the null anyway, which is what the rustdoc on the field and the README paragraph both record.

## Tests

- Library serialization unit tests in `crates/clickhouse-cloud-api/tests/models_test.rs`: untouched start time omits the key, clear emits `null`, set emits the string.
- Clap tests next to the command: `--clear-backup-start-time` parses with a period, and the conflict with `--backup-start-time` is rejected. The help test now pins both the clear flag's description and the cross-reference from `--backup-start-time`.
- Request builder tests: clear produces `Some(None)` and serializes to `{"backupStartTime": null}`, clear travels with an incompatible period, and setting plus clearing together is an error.
- Subprocess and wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs` asserting the exact PATCH body for the clear, the clear plus period 12 combination including the `--json` output, and that conflicting flags exit 2 without any request.
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (23 test binaries, all passing)
- `cargo test -p clickhouse-cloud-api --lib --test spec_coverage_test`
- `cargo test -p clickhouse-cloud-api --test models_test --test client_test`
- `cargo test -p clickhouse-openapi-analyzer`
- `cargo check --workspace --all-features`

## Stacking

Part of a stacked PR chain: based on `fix/642-backup-start-time-help`, not `main`.

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
