### PR TITLE
Refuse `cloud service query --query` when data is waiting on stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,10 @@ clickhousectl cloud service query --name my-service --queries-file query.sql   #
 clickhousectl cloud service query --name my-service --database mydb --query "SHOW TABLES"
 echo "SELECT 1+1" | clickhousectl cloud service query --name my-service
 
+# Load a CSV: the statement and its data travel together on stdin
+printf 'INSERT INTO trips FORMAT CSV\n' | cat - data.csv | \
+  clickhousectl cloud service query --id <service-id>
+
 # Replace a stale clickhousectl-owned Query API key for exactly one service
 clickhousectl cloud service repair-query-key <service-id> --org-id <org-id>
 
@@ -651,6 +655,15 @@ clickhousectl cloud service delete <service-id> --force
 Use `clickhousectl cloud service create --help` for the complete option list. If omitted, `--provider` defaults to `aws`, `--region` defaults to `us-east-1`, and the IP allowlist defaults to `0.0.0.0/0`; production workflows should normally set all three explicitly. When the create response includes an initial password, it is shown only once.
 
 `--query` and `--queries-file` are mutually exclusive. If neither is supplied, `cloud service query` reads SQL from stdin; `--queries-file -` also reads stdin explicitly.
+
+`--query` never reads stdin, so `--query "INSERT INTO trips FORMAT CSV" < data.csv` is refused (exit code `1`) before any request is sent rather than silently inserting nothing. The Query API takes a single request body, so a statement and a separate data stream cannot both be sent; pipe them together instead:
+
+```bash
+printf 'INSERT INTO trips FORMAT CSV\n' | cat - data.csv | \
+  clickhousectl cloud service query --id <service-id>
+```
+
+Only real input counts as a conflict. A redirected file, a closed pipe, `/dev/null` and a pipe that already holds data are all answered immediately, and a pipe that is open but silent is given 250 ms to produce its first byte before the CLI treats stdin as empty and runs the query. So an empty non-terminal stdin, which is what CI runners and coding agents normally have, leaves `--query` working as before, a pipe nobody writes to can never hang the command, and a producer that is merely slow to start still gets caught. The residual is narrow and deliberate: a producer that has written nothing within those 250 ms is indistinguishable from no input at all.
 
 Whatever the source, the SQL must be a single statement. The Query API runs exactly one statement per request, so a multi-statement `.sql` script is rejected by ClickHouse (error 62, `Multi-statements are not allowed`). Run statements one invocation at a time, or put a real client on PATH with `clickhousectl local use latest` and run the script through `clickhouse client` connected to the service.
 

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -445,9 +445,14 @@ CONTEXT FOR AGENTS:
   puts the standard `clickhouse` binary on PATH; use `clickhouse client` to connect
   to the service instead.
   SQL sources: --query and --queries-file are mutually exclusive. When neither
-  is supplied, SQL is read from stdin. Default format: PrettyCompact on a TTY,
-  TabSeparated when piped. --json selects JSONEachRow and cannot be combined
-  with --format; an explicit --format takes precedence over agent auto-JSON.
+  is supplied, SQL is read from stdin. --query never reads stdin, so data
+  redirected or piped alongside it is an error rather than a silent no-op:
+  send the statement and its data together instead, e.g.
+  printf 'INSERT INTO t FORMAT CSV\\n' | cat - data.csv | clickhousectl cloud
+  service query --id <id>.
+  Default format: PrettyCompact on a TTY, TabSeparated when piped. --json
+  selects JSONEachRow and cannot be combined with --format; an explicit
+  --format takes precedence over agent auto-JSON.
   The Query API runs exactly one statement per request, so multi-statement SQL
   (a typical ';'-separated .sql script) is rejected by the server. Run
   statements one invocation at a time, or connect with `clickhouse client`
@@ -463,7 +468,8 @@ CONTEXT FOR AGENTS:
         id: Option<String>,
 
         /// Execute a SQL query (a single statement; the Query API does not
-        /// accept multi-statement SQL)
+        /// accept multi-statement SQL). Does not read stdin: pipe a statement
+        /// and its data together instead of redirecting a data file here
         #[arg(long, short, conflicts_with = "queries_file")]
         query: Option<String>,
 
@@ -2413,12 +2419,106 @@ fn convert_query_error(
     }
 }
 
+/// What stdin holds when `--query` is validated (#641). Derived from the file
+/// descriptor only, never from anything the user typed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StdinInput {
+    /// An interactive terminal: nothing was piped or redirected in, and stdin
+    /// must not be read at all — a read would block on the human.
+    Terminal,
+    /// Not a terminal, and no byte arrived within
+    /// [`STDIN_FIRST_BYTE_TIMEOUT_MS`]: `< /dev/null`, a closed pipe, or a CI
+    /// runner or coding agent that has no tty and piped nothing.
+    Empty,
+    /// Not a terminal and at least one byte is available to read.
+    Pending,
+}
+
+/// The message for `--query` plus data on stdin. The Query API takes a single
+/// request body, so a statement and a separate data stream can never both be
+/// sent; the message therefore leads with what does work.
+const INLINE_QUERY_WITH_STDIN_ERROR: &str = "--query cannot be combined with SQL or data on stdin. \
+     The Query API sends one request body, so redirected data is never read. Pipe the statement \
+     and its data together on stdin instead: \
+     printf 'INSERT INTO t FORMAT CSV\\n' | cat - data.csv | clickhousectl cloud service query \
+     --id <id>. Or read a whole statement from stdin with --queries-file -.";
+
+/// Whether `--query` conflicts with what is on stdin. Pure, so the decision is
+/// unit-tested without a real file descriptor. Only bytes that are actually
+/// waiting count: a non-terminal but empty stdin is the normal shape for CI
+/// and for coding agents, so it must stay a valid way to run `--query`.
+fn inline_query_conflicts_with_stdin(inline: Option<&str>, stdin: StdinInput) -> bool {
+    inline.is_some() && matches!(stdin, StdinInput::Pending)
+}
+
+/// How long to wait for the first byte before deciding stdin carries nothing.
+///
+/// A zero timeout would reintroduce #641 as a race: in `cat data.csv |
+/// clickhousectl ... --query ...` the shell starts both processes at once, so
+/// the CLI can reach `poll` before `cat` has written anything and would go on
+/// to send the empty INSERT. A bounded wait closes that window. Nothing that
+/// already knows its answer pays it: a regular file, `/dev/null`, a closed
+/// pipe (`POLLHUP`) and a pipe that already holds data all make `poll` return
+/// at once. The only invocation that waits is `--query` whose stdin is an open
+/// pipe with nothing written yet — the harness case that must never hang — and
+/// it waits this long rather than forever.
+const STDIN_FIRST_BYTE_TIMEOUT_MS: libc::c_int = 250;
+
+/// Classify stdin without consuming it and without blocking indefinitely.
+///
+/// `poll` answers "would a read block?" without reading; only once it says a
+/// read is ready do we `fill_buf`, which performs one syscall and leaves the
+/// bytes in the shared stdin buffer, so the other SQL sources are unaffected.
+/// A hangup without readable data (`POLLHUP` alone) is an empty stdin, not
+/// input. The deliberate residual is now narrow: a producer that has not
+/// written its first byte within [`STDIN_FIRST_BYTE_TIMEOUT_MS`] still reads
+/// as no input, which is the price of never hanging on a pipe nobody is
+/// writing to.
+fn stdin_input() -> StdinInput {
+    use std::io::BufRead as _;
+
+    if std::io::stdin().is_terminal() {
+        return StdinInput::Terminal;
+    }
+
+    if !fd_becomes_readable(libc::STDIN_FILENO, STDIN_FIRST_BYTE_TIMEOUT_MS) {
+        return StdinInput::Empty;
+    }
+
+    match std::io::stdin().lock().fill_buf() {
+        Ok(buffered) if !buffered.is_empty() => StdinInput::Pending,
+        _ => StdinInput::Empty,
+    }
+}
+
+/// Whether a read on `fd` would find something within `timeout_ms`. A hangup
+/// with nothing readable (`POLLHUP` alone, a closed pipe) reports `false`, and
+/// so does a `poll` that is interrupted or errors: the CLI fails open to "no
+/// input" rather than refusing a run it cannot justify refusing. Split out
+/// from [`stdin_input`] so the timeout is testable against a real pipe without
+/// touching the process's own stdin.
+fn fd_becomes_readable(fd: libc::c_int, timeout_ms: libc::c_int) -> bool {
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: a single initialized `pollfd` is passed with a matching length,
+    // and the bounded timeout keeps the call from borrowing anything beyond
+    // its own return.
+    let ready = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+    ready > 0 && poll_fd.revents & libc::POLLIN != 0
+}
+
 fn read_query_sql(inline: Option<&str>, queries_file: Option<&str>) -> CloudResult<String> {
     use std::io::Read as _;
 
     if let Some(query) = inline {
         if query.trim().is_empty() {
             return Err(CloudError::new("--query was empty"));
+        }
+        if inline_query_conflicts_with_stdin(inline, stdin_input()) {
+            return Err(CloudError::new(INLINE_QUERY_WITH_STDIN_ERROR));
         }
         return Ok(query.to_string());
     }
@@ -5417,5 +5517,138 @@ mod tests {
 
         assert_eq!(start.command, Some(ServiceStatePatchRequestCommand::Start));
         assert_eq!(stop.command, Some(ServiceStatePatchRequestCommand::Stop));
+    }
+
+    #[test]
+    fn inline_query_only_conflicts_with_bytes_waiting_on_stdin() {
+        // The whole matrix of stdin states crossed with --query being present
+        // (#641). Only "not a terminal and data is already waiting" conflicts:
+        // a terminal must never be read, and a non-terminal empty stdin is the
+        // normal shape for CI and for coding agents.
+        assert!(!inline_query_conflicts_with_stdin(
+            Some("SELECT 1"),
+            StdinInput::Terminal
+        ));
+        assert!(!inline_query_conflicts_with_stdin(
+            Some("SELECT 1"),
+            StdinInput::Empty
+        ));
+        assert!(inline_query_conflicts_with_stdin(
+            Some("SELECT 1"),
+            StdinInput::Pending
+        ));
+
+        assert!(!inline_query_conflicts_with_stdin(
+            None,
+            StdinInput::Terminal
+        ));
+        assert!(!inline_query_conflicts_with_stdin(None, StdinInput::Empty));
+        // Without --query, piped bytes are the SQL itself, not a conflict.
+        assert!(!inline_query_conflicts_with_stdin(
+            None,
+            StdinInput::Pending
+        ));
+    }
+
+    /// A real unnamed pipe as `(read_fd, write_fd)`.
+    fn test_pipe() -> (libc::c_int, libc::c_int) {
+        let mut fds = [0 as libc::c_int; 2];
+        // SAFETY: `fds` is a two-element array, which is what `pipe` writes.
+        let created = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(created, 0, "pipe() failed");
+        (fds[0], fds[1])
+    }
+
+    fn write_byte(fd: libc::c_int) {
+        // SAFETY: one byte is written from a live local buffer.
+        let written = unsafe { libc::write(fd, b"x".as_ptr().cast(), 1) };
+        assert_eq!(written, 1, "write() failed");
+    }
+
+    fn close_fd(fd: libc::c_int) {
+        // SAFETY: each fd is closed exactly once by its owning test.
+        unsafe { libc::close(fd) };
+    }
+
+    #[test]
+    fn readiness_waits_for_a_producer_that_has_not_written_its_first_byte() {
+        // The #641 race: `cat data.csv | clickhousectl ... --query ...` starts
+        // both processes at once, so the CLI can look at stdin before the
+        // producer has written. A zero timeout calls that "no input" and sends
+        // the empty INSERT, which is the whole bug; the bounded wait sees the
+        // byte. This is asserted on a real pipe rather than through a
+        // subprocess so the interleaving is not left to process startup.
+        let (read_fd, write_fd) = test_pipe();
+        assert!(
+            !fd_becomes_readable(read_fd, 0),
+            "nothing has been written yet"
+        );
+
+        let producer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            write_byte(write_fd);
+            close_fd(write_fd);
+        });
+
+        let started = std::time::Instant::now();
+        assert!(fd_becomes_readable(read_fd, STDIN_FIRST_BYTE_TIMEOUT_MS));
+        assert!(
+            started.elapsed() < Duration::from_millis(STDIN_FIRST_BYTE_TIMEOUT_MS as u64 + 500),
+            "the wait must stay bounded"
+        );
+
+        producer.join().unwrap();
+        close_fd(read_fd);
+    }
+
+    #[test]
+    fn readiness_gives_up_on_a_pipe_nobody_writes_to() {
+        // A harness that wired up stdin and produced nothing must not hang the
+        // command: the wait expires and the run continues.
+        let (read_fd, write_fd) = test_pipe();
+
+        let started = std::time::Instant::now();
+        assert!(!fd_becomes_readable(read_fd, STDIN_FIRST_BYTE_TIMEOUT_MS));
+        let waited = started.elapsed();
+        assert!(
+            waited < Duration::from_millis(STDIN_FIRST_BYTE_TIMEOUT_MS as u64 + 500),
+            "waited {waited:?}"
+        );
+
+        close_fd(write_fd);
+        close_fd(read_fd);
+    }
+
+    #[test]
+    fn readiness_is_immediate_for_data_that_is_already_waiting() {
+        let (read_fd, write_fd) = test_pipe();
+        write_byte(write_fd);
+
+        assert!(fd_becomes_readable(read_fd, 0));
+
+        close_fd(write_fd);
+        close_fd(read_fd);
+    }
+
+    #[test]
+    fn the_stdin_conflict_message_says_what_does_work() {
+        assert!(
+            INLINE_QUERY_WITH_STDIN_ERROR
+                .starts_with("--query cannot be combined with SQL or data on stdin.")
+        );
+        assert!(INLINE_QUERY_WITH_STDIN_ERROR.contains("cat - data.csv"));
+        assert!(INLINE_QUERY_WITH_STDIN_ERROR.contains("--queries-file -"));
+    }
+
+    #[test]
+    fn service_query_help_documents_that_query_ignores_stdin() {
+        let error = Cli::try_parse_from(["clickhousectl", "cloud", "service", "query", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        let help = error.to_string();
+
+        assert!(help.contains("--query never reads stdin"), "{help}");
+        assert!(help.contains("cat - data.csv"), "{help}");
+        assert!(help.contains("Does not read stdin"), "{help}");
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3758,10 +3758,224 @@ async fn invoke_oauth_service_query_response(
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        // Pin stdin: `--query` now refuses to run when bytes are waiting on a
+        // non-terminal stdin (#641), so these tests must not inherit whatever
+        // the test runner happens to have there.
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
 
     (output, query_host)
+}
+
+// ── `--query` versus stdin (issue #641) ────────────────────────────────────
+//
+// `--query` sends one request body, so a redirected data file can never be
+// part of it. Rather than discard it silently, the CLI refuses before any
+// network call. An empty non-terminal stdin (`</dev/null`, CI, an agent
+// harness) is not data and must keep working, including when the writer is
+// held open and never writes.
+
+/// How a test drives the child's stdin.
+enum StdinPlan<'a> {
+    /// Closed immediately, the `< /dev/null` shape.
+    Null,
+    /// A regular file with content already in it, the `< data.csv` shape.
+    File(std::fs::File),
+    /// Written and closed as soon as the child is spawned.
+    Write(&'a [u8]),
+    /// A pipe whose writer waits before producing, the `producer |
+    /// clickhousectl` race: the shell starts both at once, so the data can
+    /// arrive after the CLI has already looked at stdin.
+    WriteAfter(&'a [u8], std::time::Duration),
+    /// A pipe that is held open and never written to: a harness that wired up
+    /// stdin and produced nothing. The CLI must not hang on it.
+    IdleOpen,
+}
+
+/// Run `cloud service query` over OAuth with a caller-chosen stdin. Returns
+/// the process output plus both mocks so a test can assert that nothing was
+/// requested at all.
+async fn invoke_oauth_service_query_with_stdin(
+    sql_args: &[&str],
+    stdin_plan: StdinPlan<'_>,
+) -> (std::process::Output, MockServer, MockServer) {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .respond_with(ResponseTemplate::new(200).set_body_string("1\n"))
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
+    std::fs::create_dir_all(&ch_dir).unwrap();
+    write_oauth_tokens(&ch_dir, &control.uri());
+
+    let mut args = vec![
+        "cloud".to_string(),
+        "--url".to_string(),
+        control.uri(),
+        "service".to_string(),
+        "query".to_string(),
+        "--id".to_string(),
+        QUERY_TEST_SERVICE_ID.to_string(),
+        "--org-id".to_string(),
+        "org-1".to_string(),
+    ];
+    args.extend(sql_args.iter().map(|arg| (*arg).to_string()));
+
+    let stdin = match &stdin_plan {
+        StdinPlan::Null => Stdio::null(),
+        StdinPlan::File(file) => Stdio::from(file.try_clone().unwrap()),
+        StdinPlan::Write(_) | StdinPlan::WriteAfter(..) | StdinPlan::IdleOpen => Stdio::piped(),
+    };
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let mut child = command
+        .env("DO_NOT_TRACK", "1")
+        .args(args)
+        .current_dir(dir.path())
+        .env("HOME", &home_dir)
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(stdin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+
+    // `wait_with_output` closes the child's stdin, so the writer has to be
+    // taken out of the `Child` for any plan that must outlive the wait.
+    let held_open = match stdin_plan {
+        StdinPlan::Write(bytes) => {
+            let mut pipe = child.stdin.take().expect("piped stdin");
+            pipe.write_all(bytes).unwrap();
+            None
+        }
+        StdinPlan::WriteAfter(bytes, delay) => {
+            let mut pipe = child.stdin.take().expect("piped stdin");
+            std::thread::sleep(delay);
+            pipe.write_all(bytes).unwrap();
+            None
+        }
+        StdinPlan::IdleOpen => Some(child.stdin.take().expect("piped stdin")),
+        StdinPlan::Null | StdinPlan::File(_) => None,
+    };
+    let output = child.wait_with_output().expect("failed to wait for output");
+    drop(held_open);
+
+    (output, control, query_host)
+}
+
+/// The `sql` field of a recorded Query API request body.
+fn query_sql_of(request: &wiremock::Request) -> String {
+    let body: Value = serde_json::from_slice(&request.body).expect("query body is JSON");
+    body["sql"].as_str().expect("sql field").to_string()
+}
+
+#[tokio::test]
+async fn service_query_refuses_data_on_stdin_before_any_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path().join("data.csv");
+    std::fs::write(&data, "1,alice\n2,bob\n").unwrap();
+    let file = std::fs::File::open(&data).unwrap();
+
+    let (output, control, query_host) = invoke_oauth_service_query_with_stdin(
+        &["--query", "INSERT INTO trips FORMAT CSV"],
+        StdinPlan::File(file),
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--query cannot be combined with SQL or data on stdin"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("cat - data.csv"), "{stderr}");
+    assert!(stderr.contains("--queries-file -"), "{stderr}");
+    assert!(output.stdout.is_empty(), "{:?}", output.stdout);
+    // The refusal happens while reading the SQL, so neither the control plane
+    // nor the query host is contacted.
+    assert!(control.received_requests().await.unwrap().is_empty());
+    assert!(query_host.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn service_query_refuses_data_that_arrives_after_the_check_starts() {
+    // `cat data.csv | clickhousectl ... --query ...`: the shell starts both
+    // processes at once, so the first byte can land after the CLI has begun
+    // looking at stdin. A zero-timeout readiness check would call that "no
+    // input" and send the empty INSERT, which is #641 all over again. The
+    // interleaving here depends on process startup, so the readiness timeout
+    // itself is pinned deterministically by the pipe-level unit tests in
+    // `cloud::services`; this is the end-to-end guard.
+    let (output, control, query_host) = invoke_oauth_service_query_with_stdin(
+        &["--query", "INSERT INTO trips FORMAT CSV"],
+        StdinPlan::WriteAfter(b"1,alice\n2,bob\n", std::time::Duration::from_millis(150)),
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--query cannot be combined with SQL or data on stdin"),
+        "{stderr}"
+    );
+    assert!(control.received_requests().await.unwrap().is_empty());
+    assert!(query_host.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn service_query_does_not_hang_on_a_pipe_nobody_writes_to() {
+    // The writer stays open for the whole run and never produces a byte. The
+    // bounded first-byte wait must expire and the query must still be sent.
+    let (output, _control, query_host) =
+        invoke_oauth_service_query_with_stdin(&["--query", "SELECT 1"], StdinPlan::IdleOpen).await;
+
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(query_sql_of(&requests[0]), "SELECT 1");
+}
+
+#[tokio::test]
+async fn service_query_with_query_and_empty_stdin_still_runs() {
+    let (output, _control, query_host) =
+        invoke_oauth_service_query_with_stdin(&["--query", "SELECT 1"], StdinPlan::Null).await;
+
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(query_sql_of(&requests[0]), "SELECT 1");
+}
+
+#[tokio::test]
+async fn service_query_still_reads_sql_piped_on_bare_stdin() {
+    let (output, _control, query_host) =
+        invoke_oauth_service_query_with_stdin(&[], StdinPlan::Write(b"SELECT 1\n")).await;
+
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(query_sql_of(&requests[0]), "SELECT 1\n");
+}
+
+#[tokio::test]
+async fn service_query_still_reads_sql_from_queries_file_dash() {
+    let (output, _control, query_host) = invoke_oauth_service_query_with_stdin(
+        &["--queries-file", "-"],
+        StdinPlan::Write(b"SELECT 1\n"),
+    )
+    .await;
+
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(query_sql_of(&requests[0]), "SELECT 1\n");
 }
 
 #[tokio::test]
@@ -3912,6 +4126,7 @@ async fn service_query_requires_exactly_one_selector_before_network_access() {
             .env("HOME", &home_dir)
             .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
             .current_dir(dir.path())
+            .stdin(Stdio::null())
             .args(args);
         if authenticated {
             command
@@ -3976,6 +4191,9 @@ async fn service_query_accepts_independent_sql_sources_and_stdin_fallback() {
             .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
             .env("CLICKHOUSE_CLOUD_QUERY_HOST", &query_host_url)
             .current_dir(dir.path())
+            // Explicit so the inline and file cases below never inherit the
+            // test runner's stdin, which `--query` now refuses (#641).
+            .stdin(Stdio::null())
             .args([
                 "cloud",
                 "--url",
@@ -4113,6 +4331,7 @@ async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -4179,6 +4398,7 @@ async fn service_query_uses_an_already_authorized_api_key_without_provisioning()
         .env("CLICKHOUSE_CLOUD_API_KEY", "assigned-key-id")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "assigned-key-secret")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -4263,6 +4483,7 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -4864,6 +5085,7 @@ fn service_query_process_with_sql(
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
         .current_dir(project_dir)
+        .stdin(Stdio::null())
         .args([
             "cloud",
             "--url",
@@ -5623,6 +5845,7 @@ async fn invoke_service_query_provisioning(control: &MockServer) -> (tempfile::T
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
 
@@ -5947,6 +6170,7 @@ async fn service_query_keeps_the_key_when_the_endpoint_response_omits_the_id() {
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -6092,6 +6316,7 @@ async fn provision_against_endpoint_with_keys(existing_keys: Value) -> (tempfile
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -6199,6 +6424,7 @@ async fn invoke_oauth_service_query_error(body: &str) -> std::process::Output {
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl")
 }
@@ -6288,6 +6514,7 @@ async fn service_query_resends_with_wake_header_when_service_is_idle() {
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -6353,6 +6580,7 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .stdin(Stdio::null())
         .output()
         .expect("failed to spawn clickhousectl");
 


### PR DESCRIPTION
## What

`cloud service query --query "INSERT INTO trips FORMAT CSV" < data.csv` now fails before any network call instead of silently discarding the redirected file, sending the bare statement, printing `OK` and exiting 0 with zero rows inserted.

`read_query_sql` classifies stdin on the `--query` path and returns a `CloudError` (exit code 1, the same structured error path every other cloud runtime failure uses, and the same rendering with `--json`):

```
Error: --query cannot be combined with SQL or data on stdin. The Query API sends one
request body, so redirected data is never read. Pipe the statement and its data
together on stdin instead: printf 'INSERT INTO t FORMAT CSV\n' | cat - data.csv |
clickhousectl cloud service query --id <id>. Or read a whole statement from stdin
with --queries-file -.
```

The refusal happens while reading the SQL, before organization and service resolution, so neither the control plane nor the query host is contacted. It inherits the existing `sql_input` telemetry stage through the `at_stage` call that already wraps `read_query_sql`, so no new telemetry vocabulary was added and nothing is derived from message text.

## Why

The Query API takes a single request body, so `--query` plus a separate data channel can never work over this transport. Before this change the CLI gave no signal at all: the docs page for uploading a CSV had to carry a warning and a workaround because a natural looking command reported success over an empty table. An agent redirecting a file into `--query` now gets a hard stop instead of a green result.

## Behaviour after the fix

- `--query` with a terminal stdin: unchanged, and stdin is never read, so it can never block on the user.
- `--query` with a non-terminal but empty stdin (`</dev/null`, a CI runner, a coding agent with no tty): unchanged, the query runs.
- `--query` with data on stdin, whether already waiting or produced a moment later: exit 1 with the message above and zero requests.
- Bare piped stdin and `--queries-file -`: unchanged.

Readiness comes from `poll` on stdin with a bounded 250 ms timeout, then `fill_buf` only if poll says a read is ready, so no byte is consumed and the other SQL sources are untouched. The timeout is what makes the check honest rather than cosmetic. A zero timeout would leave the reported bug in place as a race: in `cat data.csv | clickhousectl ... --query ...` the shell starts both processes at once, so the CLI can reach the check before `cat` has written its first byte and would go on to send the empty INSERT. Nothing that already knows its answer pays the wait: a regular file, `/dev/null`, a closed pipe (`POLLHUP`) and a pipe that already holds data all return immediately. The only invocation that waits is `--query` whose stdin is an open pipe with nothing written yet, which is the hang prone harness case, and it waits 250 ms rather than forever. The residual is narrow and documented: a producer that has written nothing within those 250 ms still reads as no input.

Help text for `--query` and the `CONTEXT FOR AGENTS` block now state that `--query` does not read stdin and show the pipe together form.

## Tests

- Unit tests next to the helpers in `crates/clickhousectl/src/cloud/services.rs`: the full matrix of stdin states (terminal, non-terminal empty, non-terminal with data) crossed with `--query` present and absent, the message content, and a help text assertion.
- Pipe level unit tests that pin the timeout deterministically, against a real `pipe()` rather than a subprocess so the interleaving is not left to process startup: a producer that writes its first byte 100 ms late is caught (this test fails if the timeout is set back to 0), a pipe nobody writes to gives up within the bound instead of hanging, and data already waiting is answered immediately.
- Subprocess plus wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs`, driven by a `StdinPlan` describing how the test feeds the child: a redirected file with content is refused with exit 1 and zero received requests on both mocks; data written 150 ms after spawn is refused the same way; a pipe held open and never written to still sends the query (the no hang guard); `</dev/null` still sends the query; bare piped stdin SQL and `--queries-file -` still work.
- The existing `service query` subprocess tests now pin `stdin` to `Stdio::null()` so they never inherit the test runner's stdin.
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (all 23 test binaries green, 1189 tests)
- Manual checks against the built binary: `( sleep 0.1; cat data.csv ) | clickhousectl ... --query ...` is refused (it was silently accepted with a zero timeout), a redirected file and immediate piped data are refused, `</dev/null` adds no measurable delay, and `sleep 30 | clickhousectl ... --query ...` proceeds after 0.26 s instead of hanging.

## Stacking

Part of a stacked PR chain: based on `feat/564-backup-start-time-clear`, not `main`.

Fixes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
