### PR TITLE
Name the 30-second Query API limit and hint the native client on a gateway timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,34 @@ printf 'INSERT INTO trips FORMAT CSV\n' | cat - data.csv | \
 
 Only real input counts as a conflict. A redirected file, a closed pipe, `/dev/null` and a pipe that already holds data are all answered immediately, and a pipe that is open but silent is given 250 ms to produce its first byte before the CLI treats stdin as empty and runs the query. So an empty non-terminal stdin, which is what CI runners and coding agents normally have, leaves `--query` working as before, a pipe nobody writes to can never hang the command, and a producer that is merely slow to start still gets caught. The residual is narrow and deliberate: a producer that has written nothing within those 250 ms is indistinguishable from no input at all.
 
+The Query API gateway stops waiting after about 30 seconds. When it does, the request fails (exit code `1`) but **the statement keeps running on the service** — only the HTTP response is lost. The error says so, points at `SELECT query_id, elapsed FROM system.processes` so a still-running statement is not started a second time, and prints the `clickhouse client` command for the service's own native endpoint. Nothing is retried automatically: re-sending a large `INSERT` would load the data twice.
+
+For anything that may run longer than that — large `INSERT`s, backfills, `url()` loads — use the native protocol from the start:
+
+```bash
+clickhousectl local use latest   # puts the standard `clickhouse` binary on PATH
+clickhouse client --host <nativesecure-host> --secure --port 9440 \
+  --user default --password '<password>' --query '<your SQL>'
+```
+
+`clickhousectl cloud service get <service-id>` lists the service endpoints, including the `nativesecure` host and port. The password is the one shown when the service was created; `clickhousectl cloud service reset-password <service-id>` issues a new one.
+
+Under `--json` (or when a coding agent is detected) that failure is emitted as one JSON object on stderr, in the same envelope local errors use:
+
+```json
+{
+  "error": {
+    "code": "query_timeout",
+    "message": "the query timed out at the Query API gateway, ...",
+    "host": "my-service.us-east-1.aws.clickhouse.cloud",
+    "port": 9440,
+    "command": "clickhouse client --host my-service.us-east-1.aws.clickhouse.cloud --secure --port 9440 --user default --password '<password>' --query '<your SQL>'"
+  }
+}
+```
+
+`code` is a stable machine-readable identifier. `host` and `port` are omitted when the API response carried no native endpoint, in which case `command` names the `<host>` placeholder instead. The suggested command never contains your SQL or your password: both are placeholders. Cloud failures that have no structured remedy stay prose on stderr (`Error: <message>`).
+
 Whatever the source, the SQL must be a single statement. The Query API runs exactly one statement per request, so a multi-statement `.sql` script is rejected by ClickHouse (error 62, `Multi-statements are not allowed`). Run statements one invocation at a time, or put a real client on PATH with `clickhousectl local use latest` and run the script through `clickhouse client` connected to the service.
 
 Private endpoint IDs supplied to `private-endpoint create --endpoint-id` and `service update --add-private-endpoint-id` are format-checked before the request is sent, because adding one registers it for the whole organization and a typo has to be unpicked from both the service and the organization. Each provider uses its own format — AWS a `vpce-` VPC endpoint ID, GCP the numeric Private Service Connect connection ID, Azure the private endpoint Resource ID or `resourceGuid` — and the provider is not known when the flag is parsed, so only provider-independent mistakes are rejected (exit code `2`): empty values, values containing whitespace, and any value carrying `vpce-` that is not exactly a well-formed AWS VPC endpoint ID (`vpce-` plus 8 or 17 lowercase hex characters) — which also catches a pasted VPC endpoint ARN or endpoint service name. Azure Resource IDs (values starting with `/`) are exempt from that check, since an Azure resource may itself be named `vpce-...`. Whether the endpoint actually exists and belongs to you is not validated by the CLI or, currently, by the Cloud API. Removal flags are never format-checked, so an already-registered bogus ID stays removable.

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -88,6 +88,9 @@ fn query_api_sql_error(body: &str) -> Option<(String, String)> {
 /// only print the error see no change; callers that need to know *what kind of
 /// failure this was* read the variant instead of the message.
 fn query_api_error(status: reqwest::StatusCode, body: &str) -> Error {
+    if query_api_reports_timeout(status, body) {
+        return Error::QueryTimeout;
+    }
     if let Some((code, details)) = query_api_sql_error(body) {
         return Error::Sql {
             status: status.as_u16(),
@@ -103,6 +106,25 @@ fn query_api_error(status: reqwest::StatusCode, body: &str) -> Error {
             format!("Query API returned HTTP {status}: {body}")
         },
     }
+}
+
+/// Whether a Query API failure is the gateway giving up on the statement:
+/// HTTP 500 whose body is exactly `{"error": "Timeout error."}`.
+///
+/// The body is parsed as JSON and the `error` field compared in full, the same
+/// shape as [`query_api_reports_stopped_service`]. A substring match on
+/// `Timeout` would also fire on a ClickHouse error *about* a timeout that the
+/// service itself reported, which is a different failure with a different
+/// remedy.
+fn query_api_reports_timeout(status: reqwest::StatusCode, body: &str) -> bool {
+    const TIMEOUT_MESSAGE: &str = "Timeout error.";
+
+    status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        && serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .is_some_and(|value| {
+                value.get("error").and_then(serde_json::Value::as_str) == Some(TIMEOUT_MESSAGE)
+            })
 }
 
 fn query_api_reports_stopped_service(status: reqwest::StatusCode, body: &str) -> bool {
@@ -529,6 +551,64 @@ mod tests {
             error.to_string(),
             "API error (status 502): Query API returned HTTP 502 Bad Gateway: upstream failed"
         );
+    }
+
+    #[test]
+    fn query_api_error_recognizes_the_gateway_timeout() {
+        let error = query_api_error(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"error":"Timeout error."}"#,
+        );
+        assert!(
+            matches!(&error, Error::QueryTimeout),
+            "the gateway timeout must be its own variant, got {error:?}"
+        );
+        // The text is what a user sees, so it is pinned: it says the response
+        // was lost, not that the statement was.
+        assert_eq!(
+            error.to_string(),
+            "the query timed out at the Query API gateway; the statement may still be running on \
+             the service"
+        );
+    }
+
+    #[test]
+    fn query_api_error_keeps_other_500s_generic() {
+        for body in [
+            // A different gateway message.
+            r#"{"error":"Internal error."}"#,
+            // A body that merely mentions a timeout: the service reported it,
+            // the gateway did not give up.
+            r#"{"error":"Timeout exceeded while reading from socket"}"#,
+            // Right message, wrong shape.
+            r#"{"error":{"message":"Timeout error."}}"#,
+            // Not JSON at all.
+            "Timeout error.",
+            "",
+        ] {
+            let error = query_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, body);
+            assert!(
+                matches!(&error, Error::Api { status: 500, .. }),
+                "only the exact gateway timeout body may become QueryTimeout: {body} -> {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn query_api_error_only_reads_the_timeout_out_of_a_500() {
+        // The same body under any other status is not the gateway timeout.
+        for status in [
+            reqwest::StatusCode::PARTIAL_CONTENT,
+            reqwest::StatusCode::BAD_REQUEST,
+            reqwest::StatusCode::BAD_GATEWAY,
+            reqwest::StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            let error = query_api_error(status, r#"{"error":"Timeout error."}"#);
+            assert!(
+                matches!(&error, Error::Api { .. }),
+                "status {status} must not produce QueryTimeout: {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clickhouse-cloud-api/src/error.rs
+++ b/crates/clickhouse-cloud-api/src/error.rs
@@ -54,4 +54,18 @@ pub enum Error {
     /// service is never woken by the Query API; it must be started explicitly.
     #[error("service is stopped; it must be started before it can be queried")]
     ServiceStopped,
+
+    /// The Query API gateway stopped waiting for the statement (HTTP 500 with
+    /// the body `{"error": "Timeout error."}`).
+    ///
+    /// Only the HTTP response is lost: the statement keeps running on the
+    /// service. That is why this is a variant of its own rather than an
+    /// [`Error::Api`] a caller would have to recognise by its status — a
+    /// caller that treats it as a transient 500 and resends the request runs
+    /// the statement twice, which for an `INSERT` means loading the data
+    /// twice.
+    #[error(
+        "the query timed out at the Query API gateway; the statement may still be running on the service"
+    )]
+    QueryTimeout,
 }

--- a/crates/clickhouse-cloud-api/tests/run_query_test.rs
+++ b/crates/clickhouse-cloud-api/tests/run_query_test.rs
@@ -299,3 +299,50 @@ async fn run_query_preserves_malformed_json_error_with_status() {
         other => panic!("expected Error::Api, got: {other:?}"),
     }
 }
+
+// ── the gateway's own timeout (issue #644) ─────────────────────────────────
+//
+// The Query API gateway stops waiting after roughly 30 seconds and answers
+// HTTP 500 with `{"error": "Timeout error."}`. The statement keeps running on
+// the service, so the failure gets its own variant: a caller that read it as
+// a transient 500 and resent the request would run the statement twice.
+
+#[tokio::test]
+async fn run_query_500_gateway_timeout_maps_to_query_timeout() {
+    let mock = start_mock_query_host(500, r#"{"error":"Timeout error."}"#).await;
+    let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());
+
+    let err = client
+        .run_query_bearer("svc-1", "SELECT sleep(3)", None, "CSV", false)
+        .await
+        .expect_err("expected QueryTimeout");
+    assert!(
+        matches!(err, Error::QueryTimeout),
+        "expected QueryTimeout, got: {err:?}"
+    );
+    // Exactly one request: the library never resends a statement that may
+    // still be running.
+    assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn run_query_other_500_body_stays_an_api_error() {
+    let body = r#"{"error":"Internal error."}"#;
+    let mock = start_mock_query_host(500, body).await;
+    let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());
+
+    let err = client
+        .run_query_bearer("svc-1", "SELECT 1", None, "CSV", false)
+        .await
+        .expect_err("expected Api error");
+    match err {
+        Error::Api { status, message } => {
+            assert_eq!(status, 500);
+            assert_eq!(
+                message,
+                format!("Query API returned HTTP 500 Internal Server Error: {body}")
+            );
+        }
+        other => panic!("expected Error::Api, got: {other:?}"),
+    }
+}

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1,3 +1,4 @@
+use crate::cloud::output::CloudErrorDetail;
 use crate::dotenv::DotenvVars;
 use crate::failure::{ApiFailure, FailureKind, FailureStage};
 use std::env;
@@ -21,6 +22,11 @@ pub struct CloudError {
     /// message. `None` when no boundary claimed it, which
     /// [`CloudError::at_stage`] reports as [`FailureKind::Other`].
     pub failure: Option<ApiFailure>,
+    /// Machine-readable form of this failure, for `--json` mode (#644).
+    /// `None` for the ordinary case, where the message is the whole error;
+    /// `Some` when the remedy is structured enough that an agent should not
+    /// have to parse prose for it.
+    pub details: Option<Box<CloudErrorDetail>>,
 }
 
 impl CloudError {
@@ -29,6 +35,7 @@ impl CloudError {
             message: message.into(),
             kind: CloudErrorKind::Generic,
             failure: None,
+            details: None,
         }
     }
 
@@ -37,12 +44,20 @@ impl CloudError {
             message: message.into(),
             kind: CloudErrorKind::Auth,
             failure: None,
+            details: None,
         }
     }
 
     /// Attach the classification of the failure this error stands for.
     pub fn with_failure(mut self, failure: ApiFailure) -> Self {
         self.failure = Some(failure);
+        self
+    }
+
+    /// Attach the machine-readable form of this failure, which `--json` mode
+    /// emits instead of the prose message.
+    pub fn with_details(mut self, details: CloudErrorDetail) -> Self {
+        self.details = Some(Box::new(details));
         self
     }
 

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -102,9 +102,14 @@ pub async fn run(args: CloudArgs, json: bool) -> Result<()> {
 }
 
 fn cloud_error_to_top_level(e: CloudError) -> Error {
-    match e.kind {
-        CloudErrorKind::Auth => Error::AuthRequired(e.message),
-        CloudErrorKind::Generic => Error::Cloud(e.message),
+    match (e.kind, e.details) {
+        // Auth failures own the exit code (4) and have their own remediation
+        // text, so a structured detail never displaces them.
+        (CloudErrorKind::Auth, _) => Error::AuthRequired(e.message),
+        // A structured detail replaces the prose *only* in JSON mode; its
+        // `message` is the same text, so human output is unchanged (#644).
+        (CloudErrorKind::Generic, Some(details)) => Error::CloudDetailed(details),
+        (CloudErrorKind::Generic, None) => Error::Cloud(e.message),
     }
 }
 
@@ -194,6 +199,49 @@ mod runtime_tests {
         assert!(matches!(&generic, Error::Cloud(message) if message == "boom"));
         assert_eq!(generic.exit_code(), 1);
         assert_eq!(CloudError::new("x").kind, CloudErrorKind::Generic);
+    }
+
+    /// A structured detail travels to the top level, where JSON mode emits
+    /// it; human mode keeps rendering the same message (#644).
+    #[test]
+    fn cloud_error_details_reach_the_top_level_error() {
+        let detail = crate::cloud::output::CloudErrorDetail {
+            code: crate::cloud::output::CloudErrorCode::QueryTimeout,
+            message: "timed out".into(),
+            host: Some("demo.clickhouse.cloud".into()),
+            port: Some(9440),
+            command: Some("clickhouse client".into()),
+        };
+        let error = cloud_error_to_top_level(CloudError::new("timed out").with_details(detail));
+        match &error {
+            Error::CloudDetailed(details) => {
+                assert_eq!(
+                    details.code,
+                    crate::cloud::output::CloudErrorCode::QueryTimeout
+                );
+                assert_eq!(details.host.as_deref(), Some("demo.clickhouse.cloud"));
+            }
+            other => panic!("expected CloudDetailed, got {other:?}"),
+        }
+        // Human output is unchanged, and the exit code is the ordinary 1.
+        assert_eq!(error.to_string(), "timed out");
+        assert_eq!(error.exit_code(), 1);
+    }
+
+    /// An auth failure owns exit code 4 and its own remediation, so a detail
+    /// never displaces it.
+    #[test]
+    fn auth_errors_are_not_displaced_by_details() {
+        let detail = crate::cloud::output::CloudErrorDetail {
+            code: crate::cloud::output::CloudErrorCode::QueryTimeout,
+            message: "nope".into(),
+            host: None,
+            port: None,
+            command: None,
+        };
+        let error = cloud_error_to_top_level(CloudError::auth("nope").with_details(detail));
+        assert!(matches!(&error, Error::AuthRequired(message) if message == "nope"));
+        assert_eq!(error.exit_code(), 4);
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -57,6 +57,66 @@ pub(crate) fn print_line(line: impl std::fmt::Display) {
     let _ = writeln!(std::io::stdout(), "{line}");
 }
 
+// ── structured errors (issue #644) ─────────────────────────────────────────
+//
+// Cloud failures are prose on stderr: `Error: <message>`. That is fine for a
+// human, but an agent asked to recover from one has to parse it. A failure
+// whose remedy is a concrete command therefore also carries a machine-readable
+// detail, emitted under `--json` in the same envelope local errors use
+// (#475/#608): one object on stderr, `{"error": {"code": ..., "message": ...}}`,
+// with a `command` a caller can run.
+
+/// Stable machine-readable code for a cloud failure that carries structured
+/// remediation. Literal wire values only, and never widened by anything the
+/// API sends: the vocabulary is this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudErrorCode {
+    /// The Query API gateway stopped waiting for the statement (#644).
+    QueryTimeout,
+}
+
+/// One cloud failure, as `--json` reports it.
+///
+/// `message` is the same text human mode prints, so the two modes never
+/// disagree. The remaining fields are the structured form of the hint: absent
+/// fields are omitted rather than serialized as `null`, matching the response
+/// models.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CloudErrorDetail {
+    pub code: CloudErrorCode,
+    pub message: String,
+    /// Native-protocol host to reconnect to, when the API returned one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// Native-protocol port paired with `host`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i64>,
+    /// A command that acts on the failure. Never carries the user's SQL or
+    /// any credential: both are placeholders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CloudErrorOutput<'a> {
+    error: &'a CloudErrorDetail,
+}
+
+/// Write exactly one cloud error object to stderr, for `--json` mode.
+///
+/// Serialization failure is swallowed for the same reason [`eprint_line`]
+/// swallows a write failure: the exit code reports the outcome, so a closed
+/// stderr must not become a panic.
+pub fn print_error(detail: &CloudErrorDetail) {
+    use std::io::Write;
+    let stderr = std::io::stderr();
+    let mut stderr = stderr.lock();
+    if serde_json::to_writer_pretty(&mut stderr, &CloudErrorOutput { error: detail }).is_ok() {
+        let _ = writeln!(stderr);
+    }
+}
+
 /// Serialize `value` and print it as an indented, human-readable tree.
 ///
 /// - Object keys are printed verbatim (camelCase, as the API returns them).

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -2,7 +2,9 @@ use crate::cloud::api_keys::{cleanup_service_query_key, service_query_key_cleanu
 use crate::cloud::backups::BackupConfigCommands;
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
-use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_human, print_line};
+use crate::cloud::output::{
+    ABSENT, CloudErrorCode, CloudErrorDetail, eprint_line, or_absent, print_human, print_line,
+};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::{self, ApiFailure, FailureKind, FailureStage, ProvisioningState};
@@ -12,11 +14,11 @@ use clickhouse_cloud_api::models::{
     AutoscalingMode, InstancePrivateEndpointsPatch, InstanceServiceQueryApiEndpointsPostRequest,
     InstanceTagsPatch, IpAccessListEntry, IpAccessListPatch, QueryEndpointRole,
     ServicPrivateEndpointePostRequest, Service, ServiceEndpoint, ServiceEndpointChange,
-    ServiceEndpointChangeProtocol, ServicePasswordPatchRequest, ServicePatchRequest,
-    ServicePatchRequestReleasechannel, ServicePostRequest, ServicePostRequestCompliancetype,
-    ServicePostRequestProfile, ServicePostRequestProvider, ServicePostRequestRegion,
-    ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest, ServiceState,
-    ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
+    ServiceEndpointChangeProtocol, ServiceEndpointProtocol, ServicePasswordPatchRequest,
+    ServicePatchRequest, ServicePatchRequestReleasechannel, ServicePostRequest,
+    ServicePostRequestCompliancetype, ServicePostRequestProfile, ServicePostRequestProvider,
+    ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest,
+    ServiceState, ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
 };
 #[cfg(test)]
 use clickhouse_cloud_api::models::{IpAccessListEntryResponse, ResourceTagsV1Response};
@@ -441,9 +443,12 @@ CONTEXT FOR AGENTS:
   With OAuth (cloud auth login): sends your own bearer token — SQL runs as
   your cloud user with read-only access (SELECT only, no writes); no key
   provisioning and no query endpoint required on the service.
-  For queries that may exceed Query API timeouts, `clickhousectl local use latest`
-  puts the standard `clickhouse` binary on PATH; use `clickhouse client` to connect
-  to the service instead.
+  The Query API times out after about 30 seconds; the statement keeps running
+  on the service but the result is lost. For anything longer (large INSERTs,
+  backfills, `url()` loads), run it over the native protocol instead:
+  `clickhousectl local use latest` puts the standard `clickhouse` binary on
+  PATH, then `clickhouse client --host <host> --secure --port 9440 --user
+  default --password <password>`.
   SQL sources: --query and --queries-file are mutually exclusive. When neither
   is supplied, SQL is read from stdin. --query never reads stdin, so data
   redirected or piped alongside it is an error rather than a silent no-op:
@@ -2075,19 +2080,17 @@ where
 #[allow(clippy::too_many_arguments)]
 async fn run_just_provisioned_service_query(
     client: &CloudClient,
-    service_id: &str,
     key_id: &str,
     key_secret: &str,
     sql: &str,
     database: Option<&str>,
     format: &str,
-    service_name: &str,
-    org_id: &str,
+    target: QueryTarget<'_>,
     readiness: QueryEndpointReadiness,
 ) -> CloudResult<reqwest::Response> {
     let confirmed_idle = wait_for_query_endpoint_readiness(readiness, || {
         client.api().run_query(
-            service_id,
+            target.service_id,
             key_id,
             key_secret,
             "SELECT 1",
@@ -2099,24 +2102,22 @@ async fn run_just_provisioned_service_query(
     .await
     .map_err(|error| match error {
         QueryReadinessError::TimedOut(timeout) => query_readiness_timeout_error(timeout),
-        QueryReadinessError::Api(error) => {
-            convert_query_error(client, error, service_name, service_id, org_id)
-        }
+        QueryReadinessError::Api(error) => convert_query_error(client, error, target),
     })?;
 
     run_basic_service_query(
         client,
-        service_id,
+        target.service_id,
         key_id,
         key_secret,
         sql,
         database,
         format,
-        service_name,
+        target.service_name,
         confirmed_idle,
     )
     .await
-    .map_err(|error| convert_query_error(client, error, service_name, service_id, org_id))
+    .map_err(|error| convert_query_error(client, error, target))
 }
 
 /// Whether an error means "the Query API endpoint is not (yet) usable by this
@@ -2200,6 +2201,17 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
         })?,
     };
     let service_name = or_absent(service.name.as_deref());
+    // Resolved once, from the `GET service` response the query already needed:
+    // the gateway-timeout hint spells out a `clickhouse client` command, and
+    // it must use the service's real native endpoint when the API returned
+    // one (#644).
+    let native = native_secure_endpoint(service.endpoints.as_deref());
+    let target = QueryTarget {
+        service_name: &service_name,
+        service_id: &service_id,
+        org_id: &org_id,
+        native: native.as_ref(),
+    };
 
     let format = options.format.unwrap_or_else(|| {
         if options.json {
@@ -2237,13 +2249,11 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
             other => other,
         };
         result.map_err(|error| {
-            convert_query_error(client, error, &service_name, &service_id, &org_id)
-                .at_stage(FailureStage::QueryRequest)
+            convert_query_error(client, error, target).at_stage(FailureStage::QueryRequest)
         })?
     } else {
-        let convert = |error: clickhouse_cloud_api::Error| {
-            convert_query_error(client, error, &service_name, &service_id, &org_id)
-        };
+        let convert =
+            |error: clickhouse_cloud_api::Error| convert_query_error(client, error, target);
         let result = if let Some(key) = credentials::try_get_service_query_key(&service_id)
             .map_err(|error| error.at_stage(FailureStage::QueryRequest))?
         {
@@ -2311,14 +2321,12 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                     failure::set_provisioning_state(ProvisioningState::Provisioned);
                     run_just_provisioned_service_query(
                         client,
-                        &service_id,
                         &key.key_id,
                         &key.key_secret,
                         &sql,
                         options.database.as_deref(),
                         &format,
-                        &service_name,
-                        &org_id,
+                        target,
                         QUERY_ENDPOINT_READINESS,
                     )
                     .await
@@ -2401,20 +2409,132 @@ fn eprint_waking_service(service_name: &str) {
     eprintln!("Service '{service_name}' is idle; waking it (this may take a minute)...");
 }
 
+/// A service's native-protocol (`nativesecure`) endpoint.
+///
+/// Both halves are required. A hint that named the real host but guessed the
+/// port would hand the user a command that does not connect, which is worse
+/// than a command that visibly needs filling in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeEndpoint {
+    host: String,
+    port: i64,
+}
+
+/// What the query path knows about its target service when it has to render
+/// an error: enough to name the service, to point at `service start`, and to
+/// spell out the native-protocol command that routes around the Query API
+/// gateway timeout (#644).
+#[derive(Debug, Clone, Copy)]
+struct QueryTarget<'a> {
+    service_name: &'a str,
+    service_id: &'a str,
+    org_id: &'a str,
+    /// The service's `nativesecure` endpoint, when the `GET service`
+    /// response carried a complete one.
+    native: Option<&'a NativeEndpoint>,
+}
+
+/// The service's `nativesecure` endpoint, when the API returned a complete
+/// one.
+///
+/// Every field of a response model is optional, so a partial endpoint (a host
+/// with no port, or the reverse) counts as absent here rather than being
+/// half-rendered into a command.
+fn native_secure_endpoint(endpoints: Option<&[ServiceEndpoint]>) -> Option<NativeEndpoint> {
+    endpoints?.iter().find_map(|endpoint| {
+        if endpoint.protocol != Some(ServiceEndpointProtocol::Nativesecure) {
+            return None;
+        }
+        Some(NativeEndpoint {
+            host: endpoint.host.clone()?,
+            port: endpoint.port?,
+        })
+    })
+}
+
+/// Stand-in for a host the API did not return. A placeholder, never a guess.
+const NATIVE_HOST_PLACEHOLDER: &str = "<host>";
+
+/// The standard native-protocol TLS port. Only used in the placeholder
+/// command, where there is no endpoint to read a real port from.
+const DEFAULT_NATIVE_SECURE_PORT: i64 = 9440;
+
+/// The `clickhouse client` command that reruns the statement over the native
+/// protocol.
+///
+/// The SQL and the password are always literal placeholders: the user's
+/// statement is never echoed back into an error message, and no credential is
+/// ever rendered.
+fn native_client_command(native: Option<&NativeEndpoint>) -> String {
+    let (host, port) = match native {
+        Some(endpoint) => (endpoint.host.as_str(), endpoint.port),
+        None => (NATIVE_HOST_PLACEHOLDER, DEFAULT_NATIVE_SECURE_PORT),
+    };
+    format!(
+        "clickhouse client --host {host} --secure --port {port} --user default \
+         --password '<password>' --query '<your SQL>'"
+    )
+}
+
+/// The Query API gateway stopped waiting for the statement (#644).
+///
+/// The statement itself is unaffected, so the message leads with that and
+/// points at `system.processes` *before* offering the native-protocol route:
+/// re-running an `INSERT` that is still executing loads the data twice. There
+/// is deliberately no retry anywhere on this path.
+fn query_timeout_error(target: QueryTarget<'_>) -> CloudError {
+    let command = native_client_command(target.native);
+    let endpoint_guidance = if target.native.is_some() {
+        String::new()
+    } else {
+        format!(
+            "\nThe API response carried no native endpoint for this service; read the host and \
+             port from `clickhousectl cloud service get {} --org-id {}`.",
+            target.service_id, target.org_id
+        )
+    };
+    let message = format!(
+        "the query timed out at the Query API gateway, which stops waiting after about 30 \
+         seconds.\nThe statement may still be running on the service; check `SELECT query_id, \
+         elapsed FROM system.processes` before running it again.\n\nHint: run long statements \
+         over the native protocol instead. Install the client with\n  clickhousectl local use \
+         latest\nthen rerun the query with\n  {command}{endpoint_guidance}\nThe password is the \
+         one shown when the service was created; `clickhousectl cloud service reset-password {}` \
+         issues a new one.",
+        target.service_id
+    );
+
+    CloudError::new(message.clone())
+        // Rewriting the message must not lose the classification the variant
+        // already established, and the classification still comes only from
+        // the variant (#450).
+        .with_failure(failure::classify_api_error(
+            &clickhouse_cloud_api::Error::QueryTimeout,
+        ))
+        // The same failure, machine-readable, for `--json` mode.
+        .with_details(CloudErrorDetail {
+            code: CloudErrorCode::QueryTimeout,
+            message,
+            host: target.native.map(|native| native.host.clone()),
+            port: target.native.map(|native| native.port),
+            command: Some(command),
+        })
+}
+
 fn convert_query_error(
     client: &CloudClient,
     error: clickhouse_cloud_api::Error,
-    service_name: &str,
-    service_id: &str,
-    org_id: &str,
+    target: QueryTarget<'_>,
 ) -> CloudError {
     match error {
         clickhouse_cloud_api::Error::ServiceStopped => CloudError::new(format!(
-            "service '{service_name}' is stopped; start it with `clickhousectl cloud service start {service_id} --org-id {org_id}` and retry"
+            "service '{}' is stopped; start it with `clickhousectl cloud service start {} --org-id {}` and retry",
+            target.service_name, target.service_id, target.org_id
         ))
         // Rewriting the message must not lose the classification the variant
         // already established (#450).
         .with_failure(ApiFailure::new(FailureKind::ServiceStopped)),
+        clickhouse_cloud_api::Error::QueryTimeout => query_timeout_error(target),
         other => client.convert_error(other),
     }
 }
@@ -2879,8 +2999,19 @@ mod tests {
         assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
         let help = error.to_string();
 
-        assert!(help.contains("Query API timeouts"), "{help}");
+        // The gateway limit is named, not alluded to, and so is what happens
+        // to the statement when it fires (#644).
+        assert!(help.contains("times out after about 30 seconds"), "{help}");
+        assert!(help.contains("the statement keeps running"), "{help}");
+        assert!(help.contains("native protocol"), "{help}");
         assert!(help.contains("`clickhousectl local use latest`"), "{help}");
+        // The native-client command, which clap wraps across lines.
+        assert!(
+            help.contains("clickhouse client --host <host> --secure"),
+            "{help}"
+        );
+        assert!(help.contains("--port 9440 --user"), "{help}");
+        assert!(help.contains("--password <password>"), "{help}");
         assert!(help.contains("`clickhouse client`"), "{help}");
         assert!(
             help.contains("--query and --queries-file are mutually exclusive"),
@@ -4743,6 +4874,216 @@ mod tests {
         );
     }
 
+    /// A query target for the error-rendering tests. `native` decides whether
+    /// the timeout hint has a real endpoint to name.
+    fn test_query_target(native: Option<&NativeEndpoint>) -> QueryTarget<'_> {
+        QueryTarget {
+            service_name: "demo",
+            service_id: "svc-1",
+            org_id: "org-1",
+            native,
+        }
+    }
+
+    #[test]
+    fn native_secure_endpoint_picks_the_native_protocol_endpoint() {
+        let endpoints = vec![
+            ServiceEndpoint {
+                host: Some("demo.gcp.clickhouse.cloud".into()),
+                port: Some(8443),
+                protocol: Some(ServiceEndpointProtocol::Https),
+                username: None,
+            },
+            ServiceEndpoint {
+                host: Some("demo.gcp.clickhouse.cloud".into()),
+                port: Some(9440),
+                protocol: Some(ServiceEndpointProtocol::Nativesecure),
+                username: Some("default".into()),
+            },
+        ];
+        assert_eq!(
+            native_secure_endpoint(Some(&endpoints)),
+            Some(NativeEndpoint {
+                host: "demo.gcp.clickhouse.cloud".into(),
+                port: 9440,
+            })
+        );
+    }
+
+    #[test]
+    fn native_secure_endpoint_is_absent_when_the_response_is_incomplete() {
+        // No endpoints at all, and an empty list.
+        assert_eq!(native_secure_endpoint(None), None);
+        assert_eq!(native_secure_endpoint(Some(&[])), None);
+        // Only the HTTPS endpoint.
+        assert_eq!(
+            native_secure_endpoint(Some(&[ServiceEndpoint {
+                host: Some("demo.clickhouse.cloud".into()),
+                port: Some(8443),
+                protocol: Some(ServiceEndpointProtocol::Https),
+                username: None,
+            }])),
+            None
+        );
+        // Every response field is optional, so a half-returned endpoint is
+        // absent rather than half-rendered into a command.
+        for partial in [
+            ServiceEndpoint {
+                host: Some("demo.clickhouse.cloud".into()),
+                port: None,
+                protocol: Some(ServiceEndpointProtocol::Nativesecure),
+                username: None,
+            },
+            ServiceEndpoint {
+                host: None,
+                port: Some(9440),
+                protocol: Some(ServiceEndpointProtocol::Nativesecure),
+                username: None,
+            },
+            ServiceEndpoint {
+                host: Some("demo.clickhouse.cloud".into()),
+                port: Some(9440),
+                protocol: None,
+                username: None,
+            },
+        ] {
+            assert_eq!(
+                native_secure_endpoint(Some(std::slice::from_ref(&partial))),
+                None
+            );
+        }
+    }
+
+    /// The gateway timeout names the limit, warns before a rerun, and hands
+    /// over a native-protocol command built from the service's own endpoint
+    /// (#644).
+    #[test]
+    fn query_timeout_error_hints_the_native_endpoint() {
+        let native = NativeEndpoint {
+            host: "demo.gcp.clickhouse.cloud".into(),
+            port: 9440,
+        };
+        let error = query_timeout_error(test_query_target(Some(&native)));
+
+        assert!(
+            error.message.contains("about 30 seconds"),
+            "{}",
+            error.message
+        );
+        assert!(
+            error
+                .message
+                .contains("SELECT query_id, elapsed FROM system.processes"),
+            "{}",
+            error.message
+        );
+        assert!(
+            error.message.contains("clickhousectl local use latest"),
+            "{}",
+            error.message
+        );
+        assert!(
+            error.message.contains(
+                "clickhouse client --host demo.gcp.clickhouse.cloud --secure --port 9440 \
+                 --user default --password '<password>' --query '<your SQL>'"
+            ),
+            "{}",
+            error.message
+        );
+        assert!(
+            error
+                .message
+                .contains("clickhousectl cloud service reset-password svc-1"),
+            "{}",
+            error.message
+        );
+        // With a real endpoint there is nothing to look up.
+        assert!(
+            !error.message.contains("cloud service get"),
+            "{}",
+            error.message
+        );
+        assert!(!error.message.contains("<host>"), "{}", error.message);
+
+        // A timeout is exit code 1 (Generic), never an auth failure, and the
+        // classification is the variant's (#450).
+        assert_eq!(error.kind, crate::cloud::client::CloudErrorKind::Generic);
+        assert_eq!(
+            error.failure,
+            Some(ApiFailure::with_status(FailureKind::Timeout, 500))
+        );
+
+        let details = error.details.as_deref().expect("json details");
+        assert_eq!(details.code, CloudErrorCode::QueryTimeout);
+        assert_eq!(details.message, error.message);
+        assert_eq!(details.host.as_deref(), Some("demo.gcp.clickhouse.cloud"));
+        assert_eq!(details.port, Some(9440));
+        assert_eq!(
+            details.command.as_deref(),
+            Some(
+                "clickhouse client --host demo.gcp.clickhouse.cloud --secure --port 9440 --user \
+                 default --password '<password>' --query '<your SQL>'"
+            )
+        );
+    }
+
+    #[test]
+    fn query_timeout_error_falls_back_to_a_host_placeholder() {
+        let error = query_timeout_error(test_query_target(None));
+
+        assert!(
+            error.message.contains(
+                "clickhouse client --host <host> --secure --port 9440 --user default \
+                 --password '<password>' --query '<your SQL>'"
+            ),
+            "{}",
+            error.message
+        );
+        // No endpoint in the response, so the message says where to get one.
+        assert!(
+            error
+                .message
+                .contains("clickhousectl cloud service get svc-1 --org-id org-1"),
+            "{}",
+            error.message
+        );
+
+        let details = error.details.as_deref().expect("json details");
+        // Absent means omitted: no fabricated host or port.
+        assert_eq!(details.host, None);
+        assert_eq!(details.port, None);
+        assert!(
+            details
+                .command
+                .as_deref()
+                .is_some_and(|command| command.contains("--host <host>")),
+            "{details:?}"
+        );
+        let json = serde_json::to_value(details).expect("details serialize");
+        assert_eq!(json["code"], "query_timeout");
+        assert!(json.get("host").is_none(), "{json}");
+        assert!(json.get("port").is_none(), "{json}");
+    }
+
+    /// The message is rendered from the target and fixed placeholders only,
+    /// so neither the statement nor any credential can reach it.
+    #[test]
+    fn query_timeout_error_never_echoes_sql_or_credentials() {
+        let native = NativeEndpoint {
+            host: "demo.gcp.clickhouse.cloud".into(),
+            port: 9440,
+        };
+        for target in [test_query_target(Some(&native)), test_query_target(None)] {
+            let error = query_timeout_error(target);
+            assert!(error.message.contains("'<your SQL>'"), "{}", error.message);
+            assert!(
+                error.message.contains("--password '<password>'"),
+                "{}",
+                error.message
+            );
+        }
+    }
+
     /// Every query-path error a boundary rewrites keeps a classification
     /// derived from what actually failed, not from its message (#450).
     #[test]
@@ -4759,9 +5100,7 @@ mod tests {
         let stopped = convert_query_error(
             &client,
             clickhouse_cloud_api::Error::ServiceStopped,
-            "demo",
-            "svc-1",
-            "org-1",
+            test_query_target(None),
         );
         assert!(stopped.message.contains("is stopped"));
         assert_eq!(
@@ -4776,9 +5115,7 @@ mod tests {
                 code: "62".into(),
                 details: "Syntax error".into(),
             },
-            "demo",
-            "svc-1",
-            "org-1",
+            test_query_target(None),
         );
         assert_eq!(
             sql.failure,

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -678,6 +678,14 @@ pub enum Error {
     #[error("{0}")]
     Cloud(String),
 
+    /// A cloud failure that also carries a machine-readable detail (#644).
+    ///
+    /// Human mode prints exactly what [`Error::Cloud`] would — the detail's
+    /// own message — so the two modes never disagree; `--json` emits the
+    /// detail instead of the prose.
+    #[error("{}", .0.message)]
+    CloudDetailed(Box<crate::cloud::output::CloudErrorDetail>),
+
     #[error("{0}")]
     AuthRequired(String),
 

--- a/crates/clickhousectl/src/failure.rs
+++ b/crates/clickhousectl/src/failure.rs
@@ -249,6 +249,10 @@ pub fn classify_api_error(error: &clickhouse_cloud_api::Error) -> ApiFailure {
             FailureKind::Transport
         }),
         E::ServiceStopped => ApiFailure::new(FailureKind::ServiceStopped),
+        // The Query API gateway stopped waiting (#644). It is a timeout even
+        // though the transport succeeded, and the status is not invented: the
+        // variant is produced from an HTTP 500 and nothing else.
+        E::QueryTimeout => ApiFailure::with_status(FailureKind::Timeout, 500),
         // An idle service is normally handled by re-sending with the wake
         // confirmation; if the error escapes anyway it is a state problem,
         // not a transport or SQL one.
@@ -549,6 +553,9 @@ mod tests {
             ),
             (E::ServiceStopped, FailureKind::ServiceStopped, None),
             (E::ServiceIdle, FailureKind::Other, None),
+            // The gateway timeout is a timeout, classified from the variant
+            // and not from the 500 status it arrives with (#644).
+            (E::QueryTimeout, FailureKind::Timeout, Some(500)),
             (E::AuthMismatch("nope".into()), FailureKind::Other, None),
             // A status outside the allowlist keeps its class and drops the
             // exact value.

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -446,13 +446,14 @@ impl LocalErrorOutput {
 
             // ── bounded fallback ────────────────────────────────────────────
             // Subprocess text and `Postgres` (OS text from a failed psql
-            // exec) are foreign output. `Cloud`, `AuthRequired` and `Skills`
-            // belong to other command surfaces and are never printed through
-            // this envelope; `ChildExit` passes the child's status through
+            // exec) are foreign output. `Cloud`, `CloudDetailed`,
+            // `AuthRequired` and `Skills` belong to other command surfaces
+            // and are never printed through this envelope; `ChildExit` passes the child's status through
             // without an error object at all.
             Error::Exec(_)
             | Error::Postgres(_)
             | Error::Cloud(_)
+            | Error::CloudDetailed(_)
             | Error::AuthRequired(_)
             | Error::Skills(_)
             | Error::ChildExit(_) => {

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -209,6 +209,10 @@ async fn run_parsed(cli: Cli) -> (i32, bool, bool) {
         Commands::Local(args) => json_output(args.json),
         _ => false,
     };
+    let cloud_json = match &cli.command {
+        Commands::Cloud(args) => json_output(args.json),
+        _ => false,
+    };
 
     let result = run(cli.command).await;
 
@@ -223,17 +227,33 @@ async fn run_parsed(cli: Cli) -> (i32, bool, bool) {
         Ok(()) => (0, false, false),
         Err(e) => {
             let is_child_exit = matches!(&e, Error::ChildExit(_));
+            // A cloud failure that carries a machine-readable detail is
+            // emitted as one JSON object on stderr in JSON mode (#644),
+            // matching the envelope local errors use. Cloud failures without
+            // a detail stay prose: nothing structured has been resolved for
+            // them, and inventing a code per message is exactly the
+            // text-derived vocabulary this codebase avoids.
+            let structured_cloud_error =
+                cloud_json && matches!(&e, Error::CloudDetailed(_)) && !is_child_exit;
             if !is_child_exit {
-                if local_json {
-                    local::output::print_error(&e);
-                } else {
-                    use std::io::Write;
-                    // Not `eprintln!`, which panics on a closed stderr — see
-                    // `telemetry::print_first_run_notice`.
-                    let _ = writeln!(std::io::stderr(), "Error: {}", e);
+                match &e {
+                    _ if local_json => local::output::print_error(&e),
+                    Error::CloudDetailed(details) if cloud_json => {
+                        cloud::output::print_error(details);
+                    }
+                    _ => {
+                        use std::io::Write;
+                        // Not `eprintln!`, which panics on a closed stderr — see
+                        // `telemetry::print_first_run_notice`.
+                        let _ = writeln!(std::io::stderr(), "Error: {}", e);
+                    }
                 }
             }
-            (e.exit_code(), is_child_exit, local_json && !is_child_exit)
+            (
+                e.exit_code(),
+                is_child_exit,
+                (local_json && !is_child_exit) || structured_cloud_error,
+            )
         }
     };
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -7975,3 +7975,285 @@ async fn clickpipe_scale_with_a_single_flag_sends_the_request() {
     let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
     assert_eq!(body["replicas"], 4);
 }
+
+// ── the Query API gateway timeout (issue #644) ─────────────────────────────
+//
+// The gateway stops waiting after roughly 30 seconds and answers HTTP 500
+// with `{"error":"Timeout error."}`. The statement keeps running on the
+// service, so the CLI must (a) say so, (b) point at `system.processes` before
+// a rerun, (c) hand over the native-protocol command built from the service's
+// own `nativesecure` endpoint, and (d) never resend the statement itself.
+
+/// The gateway's timeout body, verbatim.
+const QUERY_GATEWAY_TIMEOUT_BODY: &str = r#"{"error":"Timeout error."}"#;
+
+const QUERY_TEST_NATIVE_HOST: &str = "demo.gcp.clickhouse.cloud";
+
+/// A control plane whose `GET service` response carries both endpoints, the
+/// shape a real service has.
+async fn start_mock_control_plane_with_native_endpoint() -> MockServer {
+    let mock = MockServer::start().await;
+    let stub_service = serde_json::json!({
+        "result": {
+            "id": QUERY_TEST_SERVICE_ID,
+            "name": "demo",
+            "endpoints": [
+                { "protocol": "https", "host": QUERY_TEST_NATIVE_HOST, "port": 8443 },
+                {
+                    "protocol": "nativesecure",
+                    "host": QUERY_TEST_NATIVE_HOST,
+                    "port": 9440,
+                    "username": "default",
+                },
+            ],
+        },
+        "status": 200,
+        "requestId": "stub-service-get",
+    });
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(stub_service))
+        .mount(&mock)
+        .await;
+    mock
+}
+
+/// Run `cloud service query` with API-key auth against a query host that
+/// fails with `status`/`body`. Returns the process output and the query host,
+/// so a test can count how many times the statement was actually sent.
+async fn invoke_service_query_against_failing_query_host(
+    control: &MockServer,
+    status: u16,
+    body: &str,
+    extra_args: &[&str],
+) -> (std::process::Output, MockServer) {
+    let query_host = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("home")).unwrap();
+    let mut command = service_query_process(dir.path(), control, &query_host);
+    command.args(extra_args);
+    let output = command
+        .output()
+        .await
+        .expect("failed to spawn clickhousectl");
+
+    (output, query_host)
+}
+
+#[tokio::test]
+async fn query_gateway_timeout_hints_the_native_client_without_retrying() {
+    let control = start_mock_control_plane_with_native_endpoint().await;
+    let (output, query_host) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        QUERY_GATEWAY_TIMEOUT_BODY,
+        &[],
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stops waiting after about 30 seconds"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("The statement may still be running on the service"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("SELECT query_id, elapsed FROM system.processes"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("clickhousectl local use latest"),
+        "{stderr}"
+    );
+    // The host and port come from the mocked service response, not from a
+    // placeholder or a guess.
+    assert!(
+        stderr.contains(&format!(
+            "clickhouse client --host {QUERY_TEST_NATIVE_HOST} --secure --port 9440 --user \
+             default --password '<password>' --query '<your SQL>'"
+        )),
+        "{stderr}"
+    );
+    // The user's SQL is never echoed back, and no credential appears.
+    assert!(!stderr.contains("SELECT 1"), "{stderr}");
+    assert!(!stderr.contains("fake-secret-for-tests"), "{stderr}");
+    // The anonymous 500 the old code surfaced is gone.
+    assert!(
+        !stderr.contains("Internal Server Error"),
+        "the gateway timeout must not be reported as a bare 500: {stderr}"
+    );
+    assert!(output.stdout.is_empty(), "{:?}", output.stdout);
+
+    // Exactly one attempt: a statement that may still be running is never
+    // resent.
+    assert_eq!(
+        query_host.received_requests().await.unwrap().len(),
+        1,
+        "the gateway timeout must not be retried"
+    );
+}
+
+#[tokio::test]
+async fn query_gateway_timeout_without_endpoints_points_at_service_get() {
+    // The default stub service carries no `endpoints` at all.
+    let control = start_mock_control_plane_with_service().await;
+    let (output, query_host) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        QUERY_GATEWAY_TIMEOUT_BODY,
+        &[],
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("clickhouse client --host <host> --secure --port 9440"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "clickhousectl cloud service get 11111111-2222-3333-4444-555555555555 --org-id org-1"
+        ),
+        "{stderr}"
+    );
+    assert_eq!(query_host.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn query_gateway_timeout_json_emits_a_structured_error() {
+    let control = start_mock_control_plane_with_native_endpoint().await;
+    let (output, _query_host) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        QUERY_GATEWAY_TIMEOUT_BODY,
+        &["--json"],
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty(), "{:?}", output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let error: Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|e| panic!("stderr is not one JSON object ({e}): {stderr}"));
+    assert_eq!(error["error"]["code"], "query_timeout");
+    assert_eq!(error["error"]["host"], QUERY_TEST_NATIVE_HOST);
+    assert_eq!(error["error"]["port"], 9440);
+    assert_eq!(
+        error["error"]["command"],
+        format!(
+            "clickhouse client --host {QUERY_TEST_NATIVE_HOST} --secure --port 9440 --user \
+             default --password '<password>' --query '<your SQL>'"
+        )
+    );
+    let message = error["error"]["message"]
+        .as_str()
+        .expect("message is a string");
+    assert!(message.contains("about 30 seconds"), "{message}");
+    assert!(
+        message.contains("SELECT query_id, elapsed FROM system.processes"),
+        "{message}"
+    );
+}
+
+#[tokio::test]
+async fn query_gateway_timeout_json_omits_an_absent_endpoint() {
+    let control = start_mock_control_plane_with_service().await;
+    let (output, _query_host) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        QUERY_GATEWAY_TIMEOUT_BODY,
+        &["--json"],
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let error: Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|e| panic!("stderr is not one JSON object ({e}): {stderr}"));
+    assert_eq!(error["error"]["code"], "query_timeout");
+    // Absent means omitted, never a fabricated host or a `null`.
+    assert!(error["error"].get("host").is_none(), "{stderr}");
+    assert!(error["error"].get("port").is_none(), "{stderr}");
+    assert!(
+        error["error"]["command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--host <host>")),
+        "{stderr}"
+    );
+}
+
+/// The control case: a 500 that is *not* the gateway timeout keeps the
+/// generic API error, in both output modes.
+#[tokio::test]
+async fn other_query_500s_keep_the_generic_api_error() {
+    let control = start_mock_control_plane_with_native_endpoint().await;
+    let (output, query_host) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        r#"{"error":"Internal error."}"#,
+        &[],
+    )
+    .await;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            r#"Query API returned HTTP 500 Internal Server Error: {"error":"Internal error."}"#
+        ),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("30 seconds"), "{stderr}");
+    assert!(!stderr.contains("clickhouse client"), "{stderr}");
+    assert_eq!(query_host.received_requests().await.unwrap().len(), 1);
+
+    // In JSON mode it stays prose too: no structured detail was resolved for
+    // it, so no code is invented.
+    let (json_output, _) = invoke_service_query_against_failing_query_host(
+        &control,
+        500,
+        r#"{"error":"Internal error."}"#,
+        &["--json"],
+    )
+    .await;
+    let stderr = String::from_utf8_lossy(&json_output.stderr);
+    assert!(stderr.starts_with("Error: "), "{stderr}");
+    assert!(
+        serde_json::from_str::<Value>(stderr.trim()).is_err(),
+        "{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn service_query_help_names_the_gateway_timeout() {
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .args(["cloud", "service", "query", "--help"])
+        .output()
+        .expect("render service query help");
+
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(help.contains("times out after about 30 seconds"), "{help}");
+    assert!(help.contains("the statement keeps running"), "{help}");
+    assert!(help.contains("clickhousectl local use latest"), "{help}");
+    assert!(
+        help.contains("clickhouse client --host <host> --secure"),
+        "{help}"
+    );
+    assert!(help.contains("--port 9440 --user"), "{help}");
+}


### PR DESCRIPTION
## What

`cloud service query` now recognises the Query API gateway timeout as its own failure and tells the user what to do about it.

Library (`clickhouse-cloud-api`): new `Error::QueryTimeout`, produced by the query path when the gateway answers HTTP 500 with a JSON body whose `error` field is exactly `Timeout error.`. The body is parsed as JSON and the field compared in full, the same shape as the existing stopped-service detection, so a ClickHouse error that merely mentions a timeout cannot be mistaken for the gateway giving up. Every other 500 body still maps to `Error::Api` with an unchanged message.

Telemetry: the new variant maps to the existing `timeout` failure kind, from the variant and never from message text, carrying the HTTP 500 it is only ever produced from.

CLI: the `CONTEXT FOR AGENTS` block on `service query` names the roughly 30 second limit, says the statement keeps running on the service, and gives the native-protocol route. On `Error::QueryTimeout` the error itself says the gateway stops waiting after about 30 seconds, points at `SELECT query_id, elapsed FROM system.processes` before any rerun, then hints `clickhousectl local use latest` plus a `clickhouse client` command built from the service's own `nativesecure` endpoint, taken from the `GET service` response the query already made. When the response carries no complete native endpoint, the command keeps a `<host>` placeholder and the message says to read the host and port from `clickhousectl cloud service get <id> --org-id <org>`. Nothing is guessed, the user's SQL and the password are always literal placeholders, exit code stays 1, and there is no retry anywhere on this path.

`--json` gets the same failure machine-readably. `CloudError` can now carry a `CloudErrorDetail`, which reaches the top level as `Error::CloudDetailed` and is written as one object on stderr in the envelope local structured errors already use: a stable `query_timeout` code plus `host`, `port` and `command`. Absent fields are omitted rather than nulled, and a cloud failure with no structured remedy stays prose, so no code is ever invented from a message.

## Why

The gateway aborts after roughly 30 seconds and the statement keeps running on the service; only the HTTP response is lost. Reported as `Query API returned HTTP 500 Internal Server Error: {"error":"Timeout error."}`, that reads as transient, so a human and much more readily an agent retries it, and for an `INSERT` that means loading the data twice. This was hit loading the UK Price Paid dataset: the INSERT finished minutes after the CLI had exited. The old help text ("for queries that may exceed Query API timeouts") also gave no number, so a user could not tell whether their query was at risk.

## Why the API library changed too

A failure a caller must tell apart gets its own variant rather than a recognisable message, which is the crate's rule for `Error::Sql` and `Error::ServiceStopped`. Making it a variant is also what lets the failure classification come from the type instead of from text, and what lets the CLI attach a hint to exactly this failure without pattern matching on a 500 body.

## Behaviour after the fix

```console
$ clickhousectl cloud service query --id "$CH_ID" --query "INSERT INTO pp_complete SELECT ... FROM url(...)"
Error: the query timed out at the Query API gateway, which stops waiting after about 30 seconds.
The statement may still be running on the service; check `SELECT query_id, elapsed FROM system.processes` before running it again.

Hint: run long statements over the native protocol instead. Install the client with
  clickhousectl local use latest
then rerun the query with
  clickhouse client --host demo.gcp.clickhouse.cloud --secure --port 9440 --user default --password '<password>' --query '<your SQL>'
The password is the one shown when the service was created; `clickhousectl cloud service reset-password <service-id>` issues a new one.
exit=1
```

Under `--json`, or when a coding agent is detected:

```json
{
  "error": {
    "code": "query_timeout",
    "message": "the query timed out at the Query API gateway, ...",
    "host": "demo.gcp.clickhouse.cloud",
    "port": 9440,
    "command": "clickhouse client --host demo.gcp.clickhouse.cloud --secure --port 9440 --user default --password '<password>' --query '<your SQL>'"
  }
}
```

## Tests

- Library unit tests on the classifier: the exact gateway body becomes `QueryTimeout` with its `Display` pinned; a different message, a body that merely mentions a timeout, the right message in the wrong shape, non-JSON and an empty body all stay `Error::Api`; the same body under 206, 400, 502 and 504 stays `Error::Api`.
- Library wiremock tests in `tests/run_query_test.rs`: a 500 timeout body maps to `QueryTimeout` and exactly one request is sent; a different 500 body keeps its `Error::Api` message verbatim.
- Telemetry mapping table gains `QueryTimeout` to `timeout` with status 500.
- CLI unit tests: `nativesecure` endpoint selection, including that a half-returned endpoint (no host, no port, or no protocol) counts as absent; the timeout message and its JSON detail with a real endpoint; the `<host>` placeholder and `service get` guidance without one, with `host` and `port` omitted from the JSON; and that neither the SQL nor a credential can reach the message.
- Pinned help test updated to assert the named limit, the "statement keeps running" wording and the native-client command.
- Subprocess and wiremock tests in `tests/cli_request_shape_test.rs`: a query host returning the 500 timeout body gives exit 1, the 30 second sentence, the `system.processes` sentence and the substituted `nativesecure` host from the mocked service GET, with exactly one query request sent; a service response without endpoints asserts the `<host>` fallback and the `service get` guidance; two `--json` variants assert the code, host, port and command, and that an absent endpoint is omitted rather than nulled; a control case with a different 500 body keeps the generic error in both output modes; and `service query --help` names the limit.
- Verification commands, all passing: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`, `cargo test -p clickhousectl` (887 unit plus 172 request-shape plus the remaining integration binaries, 0 failures), `cargo test -p clickhouse-cloud-api --lib --test spec_coverage_test`, `cargo test -p clickhouse-cloud-api --test run_query_test`, `cargo check --workspace --all-features`, `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`.
- README `service query` section documents the limit, the native-client route and the `query_timeout` JSON error shape.

## Stacking

Part of a stacked PR chain: based on `fix/643-clickpipe-settings-get-db-pipes`, not `main`.

Fixes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
