### PR TITLE
Expose destination roles on `clickpipe create` (`--role`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,25 @@ clickhousectl cloud clickpipe create bigquery <service-id> \
   --service-account-file ./sa-key.json \
   --staging-path gs://bucket/staging \
   --table-mapping "dataset.table:target_table"
+
+# Grant extra ClickHouse roles to the destination user (any create subcommand)
+clickhousectl cloud clickpipe create kafka <service-id> \
+  --name my-kafka-pipe \
+  --brokers 'broker:9092' --topics events \
+  --format JSONEachRow \
+  --database default --table events \
+  --column "event_id:Int64" \
+  --role analytics_reader --role analytics_writer
 ```
+
+`--role` is available on every `clickpipe create` subcommand and is repeatable.
+ClickPipes creates a ClickHouse user for the pipe; when `--role` is omitted that
+user is granted the default role only, and the request omits the field
+altogether. Each `--role` grants one more existing role on top of the default,
+so roles are added and never taken away. Repeated values are sent once in the
+order given. The names `clickpipes` and `clickpipes_system` are reserved by
+ClickPipes: the CLI rejects them as usage errors (exit code 2) before making
+any request.
 
 #### PostgreSQL ClickPipe prerequisites
 

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -394,6 +394,20 @@ DOCUMENTATION:
     BigQuery(BigQueryCreateArgs),
 }
 
+/// Destination-permission flags shared by every `clickpipe create` subcommand.
+/// Flattened into each create args struct so `--role` and its help text have a
+/// single definition, the way `KafkaSourceFields` shares the Kafka source flags.
+#[derive(Args, Debug, Default)]
+pub struct DestinationRoleArgs {
+    /// Extra ClickHouse role to grant the ClickPipes destination user (repeatable)
+    ///
+    /// When omitted, ClickPipes grants that user the default role only. Each
+    /// --role adds a role on top of the default; nothing is taken away. The
+    /// API-reserved names `clickpipes` and `clickpipes_system` are rejected.
+    #[arg(long = "role", value_name = "ROLE", value_parser = parse_destination_role)]
+    pub roles: Vec<String>,
+}
+
 #[derive(Args, Debug)]
 pub struct ObjectStorageCreateArgs {
     /// Service ID
@@ -488,6 +502,9 @@ pub struct ObjectStorageCreateArgs {
     /// Path to GCP service account JSON key file
     #[arg(long)]
     pub service_account_file: Option<String>,
+
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
 
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
@@ -617,6 +634,9 @@ pub struct KafkaCreateArgs {
     #[arg(long = "column")]
     pub columns: Vec<String>,
 
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
+
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
     pub org_id: Option<String>,
@@ -699,6 +719,9 @@ pub struct KinesisCreateArgs {
     /// Destination columns as name:type pairs (e.g., --column "event_id:Int64")
     #[arg(long = "column")]
     pub columns: Vec<String>,
+
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
 
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
@@ -790,6 +813,9 @@ pub struct PostgresCreateArgs {
     /// Replication slot name (only with --replication-mode cdc_only)
     #[arg(long)]
     pub replication_slot_name: Option<String>,
+
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
 
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
@@ -883,6 +909,9 @@ pub struct MySqlCreateArgs {
     #[arg(long, value_parser = clap::value_parser!(u64).range(1..=4294967295))]
     pub server_id: Option<u64>,
 
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
+
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
     pub org_id: Option<String>,
@@ -941,6 +970,9 @@ pub struct MongoDbCreateArgs {
     #[arg(long)]
     pub disable_tls: bool,
 
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
+
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
     pub org_id: Option<String>,
@@ -966,6 +998,9 @@ pub struct BigQueryCreateArgs {
     /// Table mappings as dataset.table:target_table (repeatable)
     #[arg(long = "table-mapping")]
     pub table_mappings: Vec<String>,
+
+    #[command(flatten)]
+    pub destination_roles: DestinationRoleArgs,
 
     /// Organization ID (auto-detected if not specified)
     #[arg(long)]
@@ -1236,7 +1271,12 @@ async fn clickpipe_create_object_storage(
             object_storage: Some(source),
             ..Default::default()
         },
-        destination: build_destination(&args.database, &args.table, parsed_columns),
+        destination: build_destination(
+            &args.database,
+            &args.table,
+            parsed_columns,
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -1478,7 +1518,12 @@ async fn clickpipe_create_kafka(
             kafka: Some(source),
             ..Default::default()
         },
-        destination: build_destination(&args.database, &args.table, parsed_columns),
+        destination: build_destination(
+            &args.database,
+            &args.table,
+            parsed_columns,
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -1507,7 +1552,12 @@ async fn clickpipe_create_kinesis(
             kinesis: Some(source),
             ..Default::default()
         },
-        destination: build_destination(&args.database, &args.table, parsed_columns),
+        destination: build_destination(
+            &args.database,
+            &args.table,
+            parsed_columns,
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -1963,11 +2013,59 @@ fn parse_columns(
         .collect()
 }
 
+/// Role names the API reserves for ClickPipes itself and rejects in
+/// `destination.roles`. Caught client-side so the failure names the flag
+/// instead of relaying a server-side validation error.
+const RESERVED_DESTINATION_ROLES: &[&str] = &["clickpipes", "clickpipes_system"];
+
+/// Validate one `--role` value, returning the trimmed role name.
+fn parse_destination_role_name(role: &str) -> CloudResult<String> {
+    let trimmed = role.trim();
+    if trimmed.is_empty() {
+        return Err(CloudError::new("a role name must not be empty"));
+    }
+    if RESERVED_DESTINATION_ROLES
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(trimmed))
+    {
+        return Err(CloudError::new(format!(
+            "role names reserved by ClickPipes cannot be granted: {}",
+            RESERVED_DESTINATION_ROLES.join(", ")
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// clap `value_parser` wrapper for `--role`, so a bad name is a usage error
+/// (exit 2) formatted against the create subcommand that was invoked, before
+/// any credential lookup or network call.
+fn parse_destination_role(role: &str) -> Result<String, String> {
+    parse_destination_role_name(role).map_err(|error| error.message)
+}
+
+/// Resolve the repeatable `--role` values into `destination.roles`. Every value
+/// is already validated and trimmed by `parse_destination_role`; duplicates are
+/// dropped with declaration order preserved, and no flags at all leave the
+/// field absent from the request body.
+fn build_destination_roles(roles: &[String]) -> Option<Vec<String>> {
+    if roles.is_empty() {
+        return None;
+    }
+    let mut deduped: Vec<String> = Vec::with_capacity(roles.len());
+    for role in roles {
+        if !deduped.iter().any(|existing| existing == role) {
+            deduped.push(role.clone());
+        }
+    }
+    Some(deduped)
+}
+
 /// Build a managed-table destination with the default MergeTree engine.
 fn build_destination(
     database: &str,
     table: &str,
     columns: Vec<clickhouse_cloud_api::models::ClickPipeDestinationColumn>,
+    roles: Option<Vec<String>>,
 ) -> clickhouse_cloud_api::models::ClickPipeMutateDestination {
     // Database pipes (Postgres/MySQL/BigQuery) carry the destination table on
     // the per-mapping `targetTable` and reject any of {table, managedTable,
@@ -1976,6 +2074,9 @@ fn build_destination(
     if table.is_empty() {
         return clickhouse_cloud_api::models::ClickPipeMutateDestination {
             database: database.to_string(),
+            // `roles` is not one of the four fields database pipes reject, so
+            // it is wired here too.
+            roles,
             ..Default::default()
         };
     }
@@ -1984,7 +2085,7 @@ fn build_destination(
         table: Some(table.to_string()),
         columns,
         managed_table: Some(true),
-        roles: None,
+        roles,
         table_definition: Some(
             clickhouse_cloud_api::models::ClickPipeDestinationTableDefinition::default(),
         ),
@@ -2175,7 +2276,12 @@ fn build_postgres_request(
             postgres: Some(source),
             ..Default::default()
         },
-        destination: build_destination("default", "", vec![]),
+        destination: build_destination(
+            "default",
+            "",
+            vec![],
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     })
 }
@@ -2291,7 +2397,12 @@ async fn clickpipe_create_mysql(
             mysql: Some(source),
             ..Default::default()
         },
-        destination: build_destination("default", "", vec![]),
+        destination: build_destination(
+            "default",
+            "",
+            vec![],
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -2370,7 +2481,12 @@ async fn clickpipe_create_mongodb(
             mongodb: Some(source),
             ..Default::default()
         },
-        destination: build_destination("default", "", vec![]),
+        destination: build_destination(
+            "default",
+            "",
+            vec![],
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -2438,7 +2554,12 @@ async fn clickpipe_create_bigquery(
             bigquery: Some(source),
             ..Default::default()
         },
-        destination: build_destination("default", "", vec![]),
+        destination: build_destination(
+            "default",
+            "",
+            vec![],
+            build_destination_roles(&args.destination_roles.roles),
+        ),
         ..Default::default()
     };
 
@@ -5048,6 +5169,7 @@ mod tests {
             ca_certificate: None,
             publication_name: None,
             replication_slot_name: None,
+            destination_roles: DestinationRoleArgs::default(),
             org_id: None,
         }
     }
@@ -5135,12 +5257,22 @@ mod tests {
         args.ca_certificate = Some(ca_certificate.to_string_lossy().into_owned());
         args.publication_name = Some("clickpipe_publication".into());
         args.replication_slot_name = Some("clickpipe_slot".into());
+        args.destination_roles = DestinationRoleArgs {
+            roles: vec!["analytics_reader".into(), "analytics_writer".into()],
+        };
         args.org_id = Some("org-1".into());
 
         let request = build_postgres_request(&args).unwrap();
         assert_eq!(request.name, "maximal-pipe");
         assert_eq!(request.destination.database, "default");
         assert_eq!(request.destination.table, None);
+        assert_eq!(
+            request.destination.roles,
+            Some(vec![
+                "analytics_reader".to_string(),
+                "analytics_writer".to_string()
+            ])
+        );
         let source = request.source.postgres.as_ref().expect("postgres source");
         assert_eq!(source.r#type.as_ref().unwrap().to_string(), "rdspostgres");
         assert_eq!(source.authentication.to_string(), "IAM_ROLE");
@@ -5351,7 +5483,7 @@ mod tests {
 
     #[test]
     fn build_destination_uses_defaults_for_table_definition() {
-        let destination = build_destination("mydb", "events", vec![]);
+        let destination = build_destination("mydb", "events", vec![], None);
         assert_eq!(destination.database, "mydb");
         assert_eq!(destination.table.as_deref(), Some("events"));
         assert_eq!(destination.managed_table, Some(true));
@@ -5369,13 +5501,240 @@ mod tests {
 
     #[test]
     fn build_destination_omits_table_fields_for_database_pipes() {
-        let destination = build_destination("default", "", vec![]);
+        let destination = build_destination("default", "", vec![], None);
         assert_eq!(destination.database, "default");
         assert_eq!(destination.table, None);
         assert!(destination.columns.is_empty());
         assert_eq!(destination.managed_table, None);
         assert_eq!(destination.roles, None);
         assert_eq!(destination.table_definition, None);
+    }
+
+    // `--role` → `destination.roles` (issue #568). Omitted means the field is
+    // absent from the body, so ClickPipes applies the default role on its own.
+
+    #[test]
+    fn build_destination_carries_roles_on_both_destination_shapes() {
+        let roles = Some(vec!["reader".to_string(), "writer".to_string()]);
+        let streaming = build_destination("mydb", "events", vec![], roles.clone());
+        assert_eq!(streaming.roles, roles);
+        // Database pipes send only `database`, but `roles` is not one of the
+        // four fields they reject, so it must survive that branch too.
+        let database_pipe = build_destination("default", "", vec![], roles.clone());
+        assert_eq!(database_pipe.roles, roles);
+        assert_eq!(database_pipe.table, None);
+    }
+
+    #[test]
+    fn build_destination_roles_omits_field_when_no_flags_passed() {
+        assert_eq!(build_destination_roles(&[]), None);
+    }
+
+    #[test]
+    fn build_destination_roles_dedupes_preserving_declaration_order() {
+        let roles = [
+            "writer".to_string(),
+            "reader".to_string(),
+            "writer".to_string(),
+        ];
+        assert_eq!(
+            build_destination_roles(&roles),
+            Some(vec!["writer".to_string(), "reader".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_destination_role_name_trims_and_accepts_ordinary_names() {
+        assert_eq!(
+            parse_destination_role_name("  analytics_reader  ").unwrap(),
+            "analytics_reader"
+        );
+    }
+
+    #[test]
+    fn parse_destination_role_name_rejects_blank_names() {
+        for blank in ["", "   ", "\t"] {
+            let error = parse_destination_role_name(blank)
+                .expect_err("a blank role name must be rejected client-side");
+            assert!(error.message.contains("must not be empty"), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn parse_destination_role_name_rejects_api_reserved_names() {
+        for reserved in [
+            "clickpipes",
+            "clickpipes_system",
+            "ClickPipes",
+            "  clickpipes_system  ",
+        ] {
+            let error = parse_destination_role_name(reserved)
+                .expect_err("reserved role names must be rejected client-side");
+            assert!(
+                error.message.contains("reserved by ClickPipes"),
+                "{error:?}"
+            );
+            assert!(error.message.contains("clickpipes_system"), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn parses_repeatable_role_on_kafka_create() {
+        let mut args = kafka_create_cli_args();
+        args.extend(["--role", "reader", "--role", "writer"]);
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Kafka(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected clickpipe create kafka");
+        };
+        assert_eq!(parsed.destination_roles.roles, vec!["reader", "writer"]);
+
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Kafka(parsed),
+        } = parse_clickpipe(&kafka_create_cli_args())
+        else {
+            panic!("expected clickpipe create kafka");
+        };
+        assert!(parsed.destination_roles.roles.is_empty());
+    }
+
+    #[test]
+    fn parses_repeatable_role_on_postgres_create() {
+        let mut args = postgres_cli_args(Some("public.events:events"));
+        args.extend(["--role", "reader", "--role", "writer"]);
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Postgres(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected clickpipe create postgres");
+        };
+        assert_eq!(parsed.destination_roles.roles, vec!["reader", "writer"]);
+
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Postgres(parsed),
+        } = parse_clickpipe(&postgres_cli_args(Some("public.events:events")))
+        else {
+            panic!("expected clickpipe create postgres");
+        };
+        assert!(parsed.destination_roles.roles.is_empty());
+    }
+
+    #[test]
+    fn role_is_available_on_every_create_subcommand() {
+        for (subcommand, extra) in [
+            (
+                "object-storage",
+                vec![
+                    "--source-url",
+                    "https://bucket.example/data",
+                    "--format",
+                    "JSONEachRow",
+                    "--database",
+                    "db",
+                    "--table",
+                    "events",
+                ],
+            ),
+            (
+                "kafka",
+                vec![
+                    "--brokers",
+                    "broker:9092",
+                    "--topics",
+                    "topic",
+                    "--format",
+                    "JSONEachRow",
+                    "--database",
+                    "db",
+                    "--table",
+                    "events",
+                ],
+            ),
+            (
+                "kinesis",
+                vec![
+                    "--stream-name",
+                    "stream",
+                    "--region",
+                    "us-east-1",
+                    "--format",
+                    "JSONEachRow",
+                    "--database",
+                    "db",
+                    "--table",
+                    "events",
+                ],
+            ),
+            (
+                "postgres",
+                vec![
+                    "--host",
+                    "postgres.example",
+                    "--pg-database",
+                    "source-db",
+                    "--username",
+                    "user",
+                    "--password",
+                    "password",
+                    "--table-mapping",
+                    "public.events:events",
+                ],
+            ),
+            (
+                "mysql",
+                vec![
+                    "--host",
+                    "mysql.example",
+                    "--username",
+                    "user",
+                    "--password",
+                    "password",
+                    "--table-mapping",
+                    "mydb.events:events",
+                ],
+            ),
+            (
+                "mongodb",
+                vec![
+                    "--uri",
+                    "mongodb://mongo.example:27017",
+                    "--username",
+                    "user",
+                    "--password",
+                    "password",
+                    "--table-mapping",
+                    "mydb.events:events",
+                ],
+            ),
+            (
+                "bigquery",
+                vec![
+                    "--service-account-file",
+                    "./sa-key.json",
+                    "--staging-path",
+                    "gs://bucket/staging",
+                    "--table-mapping",
+                    "dataset.events:events",
+                ],
+            ),
+        ] {
+            let mut args = vec!["create", subcommand, "svc-1", "--name", "pipe-1"];
+            args.extend(extra);
+            args.extend(["--role", "reader"]);
+            parse_clickpipe(&args);
+
+            let mut reserved = args.clone();
+            reserved.pop();
+            reserved.push("clickpipes");
+            let error = clickpipe_parse_error(&reserved);
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+            assert_eq!(error.exit_code(), 2);
+            assert!(
+                error.to_string().contains("reserved by ClickPipes"),
+                "{subcommand}: {error}"
+            );
+        }
     }
 
     // `build_kafka_credentials` tests — lock the wire shape for each auth mode.
@@ -5412,6 +5771,7 @@ mod tests {
             database: "d".into(),
             table: "t".into(),
             columns: vec![],
+            destination_roles: DestinationRoleArgs::default(),
             org_id: None,
         }
     }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3283,6 +3283,98 @@ async fn postgres_invalid_inputs_exit_as_usage_errors_before_auth_file_or_networ
     assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
+// ── Destination roles (issue #568) ─────────────────────────────────────────
+//
+// `--role` maps to `destination.roles`. Omitting it must leave the key out of
+// the body entirely, because ClickPipes reads absence as "grant the default
+// role"; an empty array would be a different instruction.
+
+#[tokio::test]
+async fn kafka_destination_roles_serialize_in_declaration_order() {
+    let mock = start_mock_clickpipes_api().await;
+    let mut args = kafka_args_minimal();
+    args.extend([
+        "--role",
+        "analytics_writer",
+        "--role",
+        "analytics_reader",
+        // A repeated value is de-duplicated rather than sent twice.
+        "--role",
+        "analytics_writer",
+    ]);
+    let body = invoke_cli_capture_body(&mock, &args).await;
+
+    assert_eq!(
+        body["destination"]["roles"],
+        serde_json::json!(["analytics_writer", "analytics_reader"]),
+        "destination.roles should carry the --role values in order: {}",
+        body["destination"],
+    );
+}
+
+#[tokio::test]
+async fn kafka_destination_roles_absent_when_role_omitted() {
+    let mock = start_mock_clickpipes_api().await;
+    let body = invoke_cli_capture_body(&mock, &kafka_args_minimal()).await;
+
+    let dest = &body["destination"];
+    assert!(
+        dest.get("roles").is_none(),
+        "roles leaked into the destination body when --role was omitted: {dest}",
+    );
+}
+
+#[tokio::test]
+async fn postgres_destination_roles_serialize_on_database_pipes() {
+    let mock = start_mock_clickpipes_api().await;
+    let mut args = postgres_args_minimal();
+    args.extend([
+        "--role".to_string(),
+        "analytics_reader".to_string(),
+        "--role".to_string(),
+        "analytics_writer".to_string(),
+    ]);
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+
+    let dest = &body["destination"];
+    assert_eq!(
+        dest["roles"],
+        serde_json::json!(["analytics_reader", "analytics_writer"]),
+        "destination.roles should survive the database-pipe destination: {dest}",
+    );
+    // The four fields database pipes reject must still be absent.
+    for field in ["table", "columns", "managedTable", "tableDefinition"] {
+        assert!(
+            dest.get(field).is_none(),
+            "{field} leaked into the postgres destination body: {dest}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn reserved_destination_role_is_a_usage_error_before_any_request() {
+    let mock = start_mock_clickpipes_api().await;
+
+    for reserved in ["clickpipes", "clickpipes_system"] {
+        let mut args = postgres_args_minimal();
+        args.extend(["--role".to_string(), reserved.to_string()]);
+        let output = invoke_cli_without_cloud_credentials(&mock, &args);
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("reserved by ClickPipes"), "{stderr}");
+        assert!(stderr.contains(reserved), "{stderr}");
+    }
+
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
 #[tokio::test]
 async fn postgres_publication_name_serializes_when_provided() {
     let mock = start_mock_clickpipes_api().await;


### PR DESCRIPTION
## What

Adds a repeatable `--role <ROLE>` flag to every `clickpipe create` subcommand (object-storage, kafka, kinesis, postgres, mysql, mongodb, bigquery) and wires it to `destination.roles` in the create request.

The flag lives in one place: a new flattened `DestinationRoleArgs` struct, the same pattern `KafkaSourceFields` already uses for the shared Kafka source flags, so the definition and the help text are not copied seven times.

Behaviour:

- Omitted: `roles` stays out of the JSON body, which is how ClickPipes reads "grant the destination user the default role". This is today's behaviour, unchanged.
- Given: `roles` carries the names in declaration order, trimmed, with duplicates dropped rather than sent twice.
- A blank or whitespace-only name, and the API-reserved names `clickpipes` and `clickpipes_system`, are rejected by a clap value parser. That makes them usage errors (exit code 2) formatted against the create subcommand that was invoked, raised before any credential lookup, file read, or network call. The reserved check is case-insensitive.

`build_destination` now takes the resolved roles and sets the field on both of its branches, including the database-pipe branch that previously emitted only `database` via `Default`. `roles` is not one of the four fields (`table`, `columns`, `managedTable`, `tableDefinition`) that database pipes reject, so Postgres, MySQL, MongoDB and BigQuery pipes can grant roles too.

## Why

`ClickPipeMutateDestination.roles` is the closest API surface to the UI's permission-role selection at pipe creation, and the CLI hard-coded `roles: None`, so custom roles could not be granted from the CLI on any pipe type. The API library already models the field, so this is CLI-only work.

The reserved names are rejected client-side rather than relayed from the server so the diagnostic names the flag and the two forbidden values, and so no request is made for an invocation that cannot succeed.

The issue's open question about the UI's "Full access" versus "Only destination table" modes is out of scope here: the API field only adds roles on top of the default, and this PR exposes what the API already supports.

## Behaviour after the fix

```
$ clickhousectl cloud clickpipe create postgres svc --name p --host h --pg-database d \
    --username u --password p --table-mapping public.t:t --role clickpipes_system
error: invalid value 'clickpipes_system' for '--role <ROLE>': role names reserved by ClickPipes cannot be granted: clickpipes, clickpipes_system

For more information, try '--help'.
```

## Tests

- Clap `try_parse_from` coverage next to the command definitions: repeatability and the empty default on `create kafka` and `create postgres`, plus a loop asserting `--role` parses on all seven create subcommands and that a reserved name is a `ValueValidation` error with exit code 2 on each.
- Unit tests for the validator (trimming, blank names, reserved names including a mixed-case and a padded form) and for the role resolver (absent when no flags, de-duplication preserving order).
- `build_destination` tests asserting the library struct field on both destination shapes, and the maximal `build_postgres_request` test extended with two roles.
- Subprocess plus wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs`: `destination.roles` order and de-duplication for a streaming create, its absence when `--role` is omitted, `destination.roles` on a database pipe alongside the four fields that must stay absent, and a reserved-name case asserting exit code 2 with no request recorded by the mock.
- README documents the flag in the `clickpipe create` section with an example.

Verified with:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (898 bin tests, 176 request-shape tests, all other targets green)
- `cargo check --workspace --all-features`

## Stacking

Part of a stacked PR chain: based on `feat/644-query-timeout`, not `main`.

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
