### PR TITLE
Add `clickpipe reverse-private-endpoint` management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,9 @@ clickhousectl cloud clickpipe scale <service-id> <clickpipe-id> \
 clickhousectl cloud clickpipe settings get <service-id> <clickpipe-id>
 clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
   --streaming-max-insert-wait-ms 10000
+
+# Manage reverse private endpoints for private source connectivity
+clickhousectl cloud clickpipe reverse-private-endpoint list <service-id>
 ```
 
 `settings get` and `settings update` apply to streaming (Kafka, Kinesis) and
@@ -1177,6 +1180,82 @@ must be between 10 and 600, and `--filter` takes a Pub/Sub CEL subscription
 filter of at most 256 characters. Both are checked before the request is sent.
 
 Use `clickhousectl cloud clickpipe create <source> --help` for the full list of options per source type.
+
+#### Reverse private endpoints (PrivateLink, Private Service Connect)
+
+A reverse private endpoint gives ClickPipes a private route to a source that is
+not reachable over the public internet. Create the endpoint on the service,
+wait for it to become `Ready`, then reference it from a pipe.
+
+```bash
+# List and inspect the endpoints of a service
+clickhousectl cloud clickpipe reverse-private-endpoint list <service-id>
+clickhousectl cloud clickpipe reverse-private-endpoint get <service-id> <endpoint-id>
+
+# AWS PrivateLink, VPC endpoint service
+clickhousectl cloud clickpipe reverse-private-endpoint create <service-id> \
+  --type VPC_ENDPOINT_SERVICE \
+  --description 'analytics source' \
+  --vpc-endpoint-service-name com.amazonaws.vpce.us-east-1.vpce-svc-12345678901234567
+
+# AWS PrivateLink, VPC resource
+clickhousectl cloud clickpipe reverse-private-endpoint create <service-id> \
+  --type VPC_RESOURCE \
+  --description 'analytics source' \
+  --vpc-resource-configuration-id rcfg-12345678901234567 \
+  --vpc-resource-share-arn arn:aws:ram:us-east-1:123456789012:resource-share/share-1
+
+# Amazon MSK multi-VPC connectivity
+clickhousectl cloud clickpipe reverse-private-endpoint create <service-id> \
+  --type MSK_MULTI_VPC \
+  --description 'msk source' \
+  --msk-cluster-arn arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster \
+  --msk-authentication SASL_IAM
+
+# Google Private Service Connect, with custom private DNS names
+clickhousectl cloud clickpipe reverse-private-endpoint create <service-id> \
+  --type GCP_PSC_SERVICE_ATTACHMENT \
+  --description 'gcp source' \
+  --gcp-service-attachment projects/my-project/regions/us-central1/serviceAttachments/my-service \
+  --custom-private-dns-mapping db.example.com \
+  --custom-private-dns-mapping '*.example.com'
+
+# Replace the custom private DNS mappings, or delete the endpoint
+clickhousectl cloud clickpipe reverse-private-endpoint update <service-id> <endpoint-id> \
+  --custom-private-dns-mapping db.example.com
+clickhousectl cloud clickpipe reverse-private-endpoint delete <service-id> <endpoint-id>
+```
+
+Using an endpoint from a pipe:
+
+- Kafka: pass the endpoint's `id` with `clickpipe create kafka
+  --reverse-private-endpoint-id <endpoint-id>`, which is repeatable.
+- Postgres and MySQL CDC: pass one of the endpoint's DNS names as `--host` on
+  `clickpipe create postgres` or `clickpipe create mysql`. `reverse-private-endpoint
+  get` prints `dnsNames`, along with any custom private DNS names.
+
+A pipe can only use an endpoint that has reached the `Ready` status. An AWS
+PrivateLink endpoint stays in `PendingAcceptance` until the connection request
+is accepted in the account that owns the source, so check
+`reverse-private-endpoint get` before creating the pipe.
+
+Each type has its own required flags, and a flag belonging to another type is a
+usage error (exit code 2) raised before any request is made:
+
+| `--type` | Required flags |
+| --- | --- |
+| `VPC_ENDPOINT_SERVICE` | `--vpc-endpoint-service-name` |
+| `VPC_RESOURCE` | `--vpc-resource-configuration-id`, `--vpc-resource-share-arn` |
+| `MSK_MULTI_VPC` | `--msk-cluster-arn`, `--msk-authentication` |
+| `GCP_PSC_SERVICE_ATTACHMENT` | `--gcp-service-attachment` |
+
+`--custom-private-dns-mapping` is repeatable and takes an exact or
+leading-wildcard name (`*.example.com`). The API does not support it for
+`MSK_MULTI_VPC`, which the CLI also rejects up front, and for the AWS
+PrivateLink types it has to be enabled for the service by ClickHouse support.
+The custom private DNS mappings are the only field the API's PATCH accepts, so
+`update` sends the complete list given on the command line: repeat every mapping
+the endpoint should keep.
 
 #### Discovering a source schema (beta)
 

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -1673,6 +1673,11 @@ impl std::fmt::Display for CreateReversePrivateEndpointMskauthentication {
     }
 }
 
+impl CreateReversePrivateEndpointMskauthentication {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["SASL_IAM", "SASL_SCRAM"];
+}
+
 /// Inline enum for `CreateReversePrivateEndpoint.type`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum CreateReversePrivateEndpointType {
@@ -1696,6 +1701,16 @@ impl std::fmt::Display for CreateReversePrivateEndpointType {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl CreateReversePrivateEndpointType {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &[
+        "VPC_ENDPOINT_SERVICE",
+        "VPC_RESOURCE",
+        "MSK_MULTI_VPC",
+        "GCP_PSC_SERVICE_ATTACHMENT",
+    ];
 }
 
 /// Inline enum for `ReversePrivateEndpoint.mskAuthentication`.

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -5829,3 +5829,76 @@ fn deserialize_clickstack_dashboard_chart_series_unknown_type_round_trip() {
     let expected: serde_json::Value = serde_json::from_str(json).unwrap();
     assert_eq!(serde_json::to_value(&series).unwrap(), expected);
 }
+
+#[test]
+fn reverse_private_endpoint_create_enums_round_trip_and_match_values() {
+    // The CLI validates `reverse-private-endpoint create --type` and
+    // `--msk-authentication` against `VALUES`, so each const must stay equal
+    // to the wire values its enum actually accepts.
+    assert_eq!(
+        CreateReversePrivateEndpointType::VALUES,
+        &[
+            "VPC_ENDPOINT_SERVICE",
+            "VPC_RESOURCE",
+            "MSK_MULTI_VPC",
+            "GCP_PSC_SERVICE_ATTACHMENT",
+        ]
+    );
+    for value in CreateReversePrivateEndpointType::VALUES {
+        let parsed: CreateReversePrivateEndpointType =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, CreateReversePrivateEndpointType::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+        assert_eq!(
+            serde_json::to_string(&parsed).unwrap(),
+            format!(r#""{value}""#)
+        );
+    }
+
+    assert_eq!(
+        CreateReversePrivateEndpointMskauthentication::VALUES,
+        &["SASL_IAM", "SASL_SCRAM"]
+    );
+    for value in CreateReversePrivateEndpointMskauthentication::VALUES {
+        let parsed: CreateReversePrivateEndpointMskauthentication =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(
+                parsed,
+                CreateReversePrivateEndpointMskauthentication::Unknown(_)
+            ),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+        assert_eq!(
+            serde_json::to_string(&parsed).unwrap(),
+            format!(r#""{value}""#)
+        );
+    }
+}
+
+/// The endpoint's own model is a response type: a key the API drops and a key
+/// it sends as `null` both have to land as `None`, and neither is emitted back.
+#[test]
+fn reverse_private_endpoint_tolerates_missing_and_null_fields() {
+    let sparse: ReversePrivateEndpoint = serde_json::from_str(r#"{"description":"warehouse"}"#)
+        .expect("a response with one key must deserialize");
+    assert_eq!(sparse.description.as_deref(), Some("warehouse"));
+    assert_eq!(sparse.dns_names, None);
+    assert_eq!(sparse.status, None);
+    assert_eq!(sparse.id, None);
+
+    let explicit_nulls: ReversePrivateEndpoint = serde_json::from_str(
+        r#"{"description":null,"dnsNames":null,"status":null,"id":null,"type":null}"#,
+    )
+    .expect("explicit nulls must deserialize");
+    assert_eq!(explicit_nulls, ReversePrivateEndpoint::default());
+    assert_eq!(
+        serde_json::to_string(&explicit_nulls).unwrap(),
+        "{}",
+        "absent fields must be omitted, never serialized as null"
+    );
+}

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -4,6 +4,10 @@ pub(crate) use crate::cloud::auth::AuthCommands;
 #[allow(unused_imports)]
 pub(crate) use crate::cloud::backups::{BackupCommands, BackupConfigCommands};
 #[allow(unused_imports)]
+pub(crate) use crate::cloud::clickpipe_endpoints::{
+    ReversePrivateEndpointCommands, ReversePrivateEndpointCreateArgs,
+};
+#[allow(unused_imports)]
 pub(crate) use crate::cloud::clickpipes::{
     BigQueryCreateArgs, ClickPipeCommands, ClickPipeCreateCommands,
     ClickPipeSchemaDiscoverCommands, ClickPipeSettingsCommands, KafkaCreateArgs, KafkaSourceFields,
@@ -63,6 +67,17 @@ impl CloudArgs {
             return None;
         };
         command.postgres_create_validation_error()
+    }
+
+    /// The `clickpipe reverse-private-endpoint create` validation message, if
+    /// the flags cannot describe the chosen `--type`. clap cannot express
+    /// "forbidden for this value of another argument", so the check runs after
+    /// parsing and is reported as a usage error against the owning command.
+    pub fn reverse_private_endpoint_validation_error(&self) -> Option<String> {
+        let CloudCommands::ClickPipe { command } = &self.command else {
+            return None;
+        };
+        command.reverse_private_endpoint_create_validation_error()
     }
 }
 
@@ -129,7 +144,8 @@ CONTEXT FOR AGENTS:
         after_help = "\
 CONTEXT FOR AGENTS:
     Manage ClickPipes for ingesting data into ClickHouse Cloud.
-    Subcommands: list, get, delete, start, stop, resync, scale, settings, create.
+    Subcommands: list, get, delete, start, stop, resync, scale, settings, create,
+    reverse-private-endpoint (PrivateLink connectivity for sources).
     Requires a service ID — get it from `clickhousectl cloud service list`."
     )]
     ClickPipe {
@@ -262,6 +278,31 @@ mod tests {
             ],
             false,
         );
+
+        // ClickPipe reverse private endpoint reads
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+                "list",
+                "svc-1",
+            ],
+            false,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+                "get",
+                "svc-1",
+                "rpe-1",
+            ],
+            false,
+        );
     }
 
     #[test]
@@ -391,6 +432,51 @@ mod tests {
         );
         assert_write(
             &["clickhousectl", "cloud", "postgres", "switchover", "pg-1"],
+            true,
+        );
+
+        // ClickPipe reverse private endpoint writes
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+                "create",
+                "svc-1",
+                "--type",
+                "GCP_PSC_SERVICE_ATTACHMENT",
+                "--description",
+                "endpoint",
+                "--gcp-service-attachment",
+                "projects/p/regions/us-central1/serviceAttachments/s",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+                "update",
+                "svc-1",
+                "rpe-1",
+                "--custom-private-dns-mapping",
+                "db.example.com",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+                "delete",
+                "svc-1",
+                "rpe-1",
+            ],
             true,
         );
     }

--- a/crates/clickhousectl/src/cloud/clickpipe_endpoints.rs
+++ b/crates/clickhousectl/src/cloud/clickpipe_endpoints.rs
@@ -1,0 +1,1128 @@
+//! `clickhousectl cloud clickpipe reverse-private-endpoint` — CRUD for the
+//! reverse private endpoints ClickPipes uses to reach a source privately.
+//!
+//! The commands are nested under `clickpipe` because an endpoint is only ever
+//! useful to a pipe: a Kafka pipe references it by ID
+//! (`clickpipe create kafka --reverse-private-endpoint-id`), and a Postgres or
+//! MySQL CDC pipe references it by passing one of its DNS names as `--host`.
+//! The surface lives in its own module rather than in `clickpipes.rs`, which is
+//! already several thousand lines of pipe-creation surface.
+
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::output::{ABSENT, or_absent, print_human};
+use crate::cloud::shared::{parse_serde_enum, resolve_org_id};
+use clap::builder::PossibleValuesParser;
+use clap::{Args, Subcommand};
+use clickhouse_cloud_api::models::{
+    CreateReversePrivateEndpoint, CreateReversePrivateEndpointMskauthentication,
+    CreateReversePrivateEndpointType, CustomPrivateDnsMapping, UpdateReversePrivateEndpoint,
+};
+use tabled::{Table, Tabled, settings::Style};
+
+/// Wire value of each reverse private endpoint type, so the per-type flag rules
+/// below read as the spec does rather than as string literals.
+const TYPE_VPC_ENDPOINT_SERVICE: &str = "VPC_ENDPOINT_SERVICE";
+const TYPE_VPC_RESOURCE: &str = "VPC_RESOURCE";
+const TYPE_MSK_MULTI_VPC: &str = "MSK_MULTI_VPC";
+const TYPE_GCP_PSC_SERVICE_ATTACHMENT: &str = "GCP_PSC_SERVICE_ATTACHMENT";
+
+#[derive(Subcommand)]
+pub enum ReversePrivateEndpointCommands {
+    /// List reverse private endpoints for a service
+    List {
+        /// Service ID
+        service_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Get reverse private endpoint details
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  `dnsNames` is what a Postgres or MySQL CDC pipe connects to: pass one of them
+  as --host on `clickhousectl cloud clickpipe create postgres|mysql`.
+  Kafka pipes use the endpoint's `id` with --reverse-private-endpoint-id.")]
+    Get {
+        /// Service ID
+        service_id: String,
+
+        /// Reverse private endpoint ID
+        endpoint_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Create a reverse private endpoint
+    #[command(long_about = "\
+Create a reverse private endpoint.
+
+Each type needs its own connection flags, and flags belonging to another type
+are rejected before any request is made:
+
+  --type VPC_ENDPOINT_SERVICE       --vpc-endpoint-service-name
+  --type VPC_RESOURCE               --vpc-resource-configuration-id and
+                                    --vpc-resource-share-arn
+  --type MSK_MULTI_VPC              --msk-cluster-arn and --msk-authentication
+  --type GCP_PSC_SERVICE_ATTACHMENT --gcp-service-attachment
+
+--custom-private-dns-mapping is repeatable and accepts exact or leading-wildcard
+names (`*.example.com`). The API does not support it for MSK_MULTI_VPC, and for
+AWS PrivateLink types it needs to be enabled for the service by ClickHouse
+support.")]
+    Create(Box<ReversePrivateEndpointCreateArgs>),
+
+    /// Replace the custom private DNS mappings of a reverse private endpoint
+    #[command(long_about = "\
+Replace the custom private DNS mappings of a reverse private endpoint.
+
+The custom private DNS mappings are the only field the API's PATCH accepts, so
+this command sends the complete list given on the command line: every mapping
+the endpoint should keep has to be repeated.")]
+    Update {
+        /// Service ID
+        service_id: String,
+
+        /// Reverse private endpoint ID
+        endpoint_id: String,
+
+        /// Custom private DNS name (repeatable; at least one required)
+        #[arg(long = "custom-private-dns-mapping", required = true)]
+        custom_private_dns_mappings: Vec<String>,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete a reverse private endpoint
+    Delete {
+        /// Service ID
+        service_id: String,
+
+        /// Reverse private endpoint ID
+        endpoint_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct ReversePrivateEndpointCreateArgs {
+    /// Service ID
+    pub service_id: String,
+
+    /// Endpoint type
+    #[arg(long = "type", value_name = "TYPE", value_parser = PossibleValuesParser::new(CreateReversePrivateEndpointType::VALUES))]
+    pub endpoint_type: String,
+
+    /// Endpoint description (max 255 characters)
+    #[arg(long)]
+    pub description: String,
+
+    /// VPC endpoint service name (for --type VPC_ENDPOINT_SERVICE)
+    #[arg(long)]
+    pub vpc_endpoint_service_name: Option<String>,
+
+    /// VPC resource configuration ID (for --type VPC_RESOURCE)
+    #[arg(long)]
+    pub vpc_resource_configuration_id: Option<String>,
+
+    /// VPC resource share ARN (for --type VPC_RESOURCE)
+    #[arg(long)]
+    pub vpc_resource_share_arn: Option<String>,
+
+    /// MSK cluster ARN (for --type MSK_MULTI_VPC)
+    #[arg(long)]
+    pub msk_cluster_arn: Option<String>,
+
+    /// MSK cluster authentication (for --type MSK_MULTI_VPC)
+    #[arg(long, value_parser = PossibleValuesParser::new(CreateReversePrivateEndpointMskauthentication::VALUES))]
+    pub msk_authentication: Option<String>,
+
+    /// GCP PSC service attachment URI, projects/{project}/regions/{region}/serviceAttachments/{name}
+    /// (for --type GCP_PSC_SERVICE_ATTACHMENT)
+    #[arg(long)]
+    pub gcp_service_attachment: Option<String>,
+
+    /// Custom private DNS name, exact or leading wildcard (repeatable)
+    #[arg(long = "custom-private-dns-mapping")]
+    pub custom_private_dns_mappings: Vec<String>,
+
+    /// Organization ID (auto-detected if not specified)
+    #[arg(long)]
+    pub org_id: Option<String>,
+}
+
+impl ReversePrivateEndpointCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            ReversePrivateEndpointCommands::List { .. } => false,
+            ReversePrivateEndpointCommands::Get { .. } => false,
+            ReversePrivateEndpointCommands::Create(_) => true,
+            ReversePrivateEndpointCommands::Update { .. } => true,
+            ReversePrivateEndpointCommands::Delete { .. } => true,
+        }
+    }
+
+    /// The client-side `create` validation message, for the post-parse usage
+    /// error in `main.rs`. `None` for every other subcommand and for a valid
+    /// `create`.
+    pub(crate) fn create_validation_error(&self) -> Option<String> {
+        let ReversePrivateEndpointCommands::Create(args) = self else {
+            return None;
+        };
+        validate_create_args(args).err().map(|error| error.message)
+    }
+}
+
+pub async fn run(
+    client: &CloudClient,
+    command: ReversePrivateEndpointCommands,
+    json: bool,
+) -> CloudResult<()> {
+    match command {
+        ReversePrivateEndpointCommands::List { service_id, org_id } => {
+            endpoint_list(client, &service_id, org_id.as_deref(), json).await
+        }
+        ReversePrivateEndpointCommands::Get {
+            service_id,
+            endpoint_id,
+            org_id,
+        } => endpoint_get(client, &service_id, &endpoint_id, org_id.as_deref(), json).await,
+        ReversePrivateEndpointCommands::Create(args) => endpoint_create(client, &args, json).await,
+        ReversePrivateEndpointCommands::Update {
+            service_id,
+            endpoint_id,
+            custom_private_dns_mappings,
+            org_id,
+        } => {
+            endpoint_update(
+                client,
+                &service_id,
+                &endpoint_id,
+                &custom_private_dns_mappings,
+                org_id.as_deref(),
+                json,
+            )
+            .await
+        }
+        ReversePrivateEndpointCommands::Delete {
+            service_id,
+            endpoint_id,
+            org_id,
+        } => endpoint_delete(client, &service_id, &endpoint_id, org_id.as_deref(), json).await,
+    }
+}
+
+/// Render a list-valued response field, treating an empty list the same as an
+/// absent one: neither tells the caller a name to connect to.
+fn join_names(names: Option<&Vec<String>>) -> String {
+    match names {
+        Some(names) if !names.is_empty() => names.join(", "),
+        _ => ABSENT.to_string(),
+    }
+}
+
+async fn endpoint_list(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let endpoints = client
+        .list_clickpipe_reverse_private_endpoints(&org_id, service_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&endpoints)?);
+    } else {
+        if endpoints.is_empty() {
+            println!("No reverse private endpoints found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "ID")]
+            id: String,
+            #[tabled(rename = "Type")]
+            endpoint_type: String,
+            #[tabled(rename = "Description")]
+            description: String,
+            #[tabled(rename = "Status")]
+            status: String,
+            #[tabled(rename = "DNS Names")]
+            dns_names: String,
+        }
+        let rows: Vec<Row> = endpoints
+            .iter()
+            .map(|endpoint| Row {
+                id: or_absent(endpoint.id.as_ref()),
+                endpoint_type: or_absent(endpoint.r#type.as_ref()),
+                description: or_absent(endpoint.description.as_deref()),
+                status: or_absent(endpoint.status.as_ref()),
+                dns_names: join_names(endpoint.dns_names.as_ref()),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn endpoint_get(
+    client: &CloudClient,
+    service_id: &str,
+    endpoint_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let endpoint = client
+        .get_clickpipe_reverse_private_endpoint(&org_id, service_id, endpoint_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&endpoint)?);
+    } else {
+        print_human(&endpoint)?;
+    }
+    Ok(())
+}
+
+async fn endpoint_create(
+    client: &CloudClient,
+    args: &ReversePrivateEndpointCreateArgs,
+    json: bool,
+) -> CloudResult<()> {
+    // Built before the org is resolved so an invalid flag combination costs no
+    // request at all, even when --org-id was omitted.
+    let request = build_create_reverse_private_endpoint_request(args)?;
+    let org_id = resolve_org_id(client, args.org_id.as_deref()).await?;
+    let endpoint = client
+        .create_clickpipe_reverse_private_endpoint(&org_id, &args.service_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&endpoint)?);
+    } else {
+        println!("Reverse private endpoint created");
+        println!("  ID: {}", or_absent(endpoint.id.as_ref()));
+        println!("  Type: {}", or_absent(endpoint.r#type.as_ref()));
+        println!("  Status: {}", or_absent(endpoint.status.as_ref()));
+        println!("  DNS names: {}", join_names(endpoint.dns_names.as_ref()));
+    }
+    Ok(())
+}
+
+async fn endpoint_update(
+    client: &CloudClient,
+    service_id: &str,
+    endpoint_id: &str,
+    custom_private_dns_mappings: &[String],
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let request = build_update_reverse_private_endpoint_request(custom_private_dns_mappings);
+    let endpoint = client
+        .update_clickpipe_reverse_private_endpoint(&org_id, service_id, endpoint_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&endpoint)?);
+    } else {
+        print_human(&endpoint)?;
+    }
+    Ok(())
+}
+
+async fn endpoint_delete(
+    client: &CloudClient,
+    service_id: &str,
+    endpoint_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    client
+        .delete_clickpipe_reverse_private_endpoint(&org_id, service_id, endpoint_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::json!({ "deleted": endpoint_id }));
+    } else {
+        println!("Reverse private endpoint {} deleted", endpoint_id);
+    }
+    Ok(())
+}
+
+/// The type-specific create flags, each paired with the endpoint type it
+/// belongs to and whether the invocation supplied it.
+///
+/// The pairing is the spec's own: `vpcResourceConfigurationId`,
+/// `vpcResourceShareArn`, `mskClusterArn`, `mskAuthentication` and
+/// `gcpServiceAttachment` are each documented as "Required for <TYPE> type".
+/// `vpcEndpointServiceName` carries no such marker, but it names its type
+/// exactly and no other type has any use for a VPC endpoint service name, so it
+/// is treated as belonging to `VPC_ENDPOINT_SERVICE` too.
+fn type_specific_flags(
+    args: &ReversePrivateEndpointCreateArgs,
+) -> [(&'static str, &'static str, bool); 6] {
+    [
+        (
+            "vpc-endpoint-service-name",
+            TYPE_VPC_ENDPOINT_SERVICE,
+            args.vpc_endpoint_service_name.is_some(),
+        ),
+        (
+            "vpc-resource-configuration-id",
+            TYPE_VPC_RESOURCE,
+            args.vpc_resource_configuration_id.is_some(),
+        ),
+        (
+            "vpc-resource-share-arn",
+            TYPE_VPC_RESOURCE,
+            args.vpc_resource_share_arn.is_some(),
+        ),
+        (
+            "msk-cluster-arn",
+            TYPE_MSK_MULTI_VPC,
+            args.msk_cluster_arn.is_some(),
+        ),
+        (
+            "msk-authentication",
+            TYPE_MSK_MULTI_VPC,
+            args.msk_authentication.is_some(),
+        ),
+        (
+            "gcp-service-attachment",
+            TYPE_GCP_PSC_SERVICE_ATTACHMENT,
+            args.gcp_service_attachment.is_some(),
+        ),
+    ]
+}
+
+/// Reject a `create` whose flags cannot describe the chosen type.
+///
+/// Only the rules the spec states are enforced: a missing flag the spec marks
+/// "Required for <TYPE> type", a flag that belongs to a different type, and
+/// `customPrivateDnsMappings` on `MSK_MULTI_VPC` ("Not supported for MSK
+/// multi-VPC"). An unrecognized `--type` is left to the API — clap's possible
+/// values already limit it to the four the library models.
+fn validate_create_args(args: &ReversePrivateEndpointCreateArgs) -> CloudResult<()> {
+    let requested = args.endpoint_type.as_str();
+    let flags = type_specific_flags(args);
+
+    for (flag, owner, present) in flags {
+        if present && owner != requested {
+            return Err(CloudError::new(format!(
+                "--{flag} applies to --type {owner}, not --type {requested}"
+            )));
+        }
+    }
+
+    let missing: Vec<String> = flags
+        .iter()
+        .filter(|(_, owner, present)| *owner == requested && !*present)
+        .map(|(flag, _, _)| format!("--{flag}"))
+        .collect();
+    if !missing.is_empty() {
+        return Err(CloudError::new(format!(
+            "--type {requested} requires {}",
+            missing.join(" and ")
+        )));
+    }
+
+    if requested == TYPE_MSK_MULTI_VPC && !args.custom_private_dns_mappings.is_empty() {
+        return Err(CloudError::new(
+            "--custom-private-dns-mapping is not supported for --type MSK_MULTI_VPC",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Map repeated `--custom-private-dns-mapping` values onto the API's array of
+/// objects, omitting the field entirely when no mapping was given.
+fn build_custom_private_dns_mappings(names: &[String]) -> Option<Vec<CustomPrivateDnsMapping>> {
+    if names.is_empty() {
+        return None;
+    }
+    Some(
+        names
+            .iter()
+            .map(|name| CustomPrivateDnsMapping {
+                private_dns_name: Some(name.clone()),
+            })
+            .collect(),
+    )
+}
+
+fn build_create_reverse_private_endpoint_request(
+    args: &ReversePrivateEndpointCreateArgs,
+) -> CloudResult<CreateReversePrivateEndpoint> {
+    validate_create_args(args)?;
+
+    Ok(CreateReversePrivateEndpoint {
+        description: args.description.clone(),
+        r#type: parse_serde_enum(
+            &args.endpoint_type,
+            "type",
+            CreateReversePrivateEndpointType::VALUES,
+        )?,
+        vpc_endpoint_service_name: args.vpc_endpoint_service_name.clone(),
+        vpc_resource_configuration_id: args.vpc_resource_configuration_id.clone(),
+        vpc_resource_share_arn: args.vpc_resource_share_arn.clone(),
+        msk_cluster_arn: args.msk_cluster_arn.clone(),
+        msk_authentication: args
+            .msk_authentication
+            .as_deref()
+            .map(|value| {
+                parse_serde_enum(
+                    value,
+                    "msk-authentication",
+                    CreateReversePrivateEndpointMskauthentication::VALUES,
+                )
+            })
+            .transpose()?,
+        gcp_service_attachment: args.gcp_service_attachment.clone(),
+        custom_private_dns_mappings: build_custom_private_dns_mappings(
+            &args.custom_private_dns_mappings,
+        ),
+    })
+}
+
+fn build_update_reverse_private_endpoint_request(names: &[String]) -> UpdateReversePrivateEndpoint {
+    UpdateReversePrivateEndpoint {
+        custom_private_dns_mappings: build_custom_private_dns_mappings(names),
+    }
+}
+
+impl CloudClient {
+    pub async fn list_clickpipe_reverse_private_endpoints(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::ReversePrivateEndpoint>>
+    {
+        let response = self
+            .api()
+            .click_pipe_reverse_private_endpoint_get_list(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_clickpipe_reverse_private_endpoint(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        endpoint_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ReversePrivateEndpoint> {
+        let response = self
+            .api()
+            .click_pipe_reverse_private_endpoint_get(org_id, service_id, endpoint_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn create_clickpipe_reverse_private_endpoint(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &CreateReversePrivateEndpoint,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ReversePrivateEndpoint> {
+        let response = self
+            .api()
+            .click_pipe_reverse_private_endpoint_create(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_clickpipe_reverse_private_endpoint(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        endpoint_id: &str,
+        request: &UpdateReversePrivateEndpoint,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ReversePrivateEndpoint> {
+        let response = self
+            .api()
+            .click_pipe_reverse_private_endpoint_update(org_id, service_id, endpoint_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_clickpipe_reverse_private_endpoint(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        endpoint_id: &str,
+    ) -> crate::cloud::client::Result<crate::cloud::types::DeleteResponse> {
+        let response = self
+            .api()
+            .click_pipe_reverse_private_endpoint_delete(org_id, service_id, endpoint_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(crate::cloud::types::DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use crate::cloud::cli::CloudCommands;
+    use clap::Parser;
+
+    fn parse_endpoint_command(args: &[&str]) -> ReversePrivateEndpointCommands {
+        let cli = Cli::try_parse_from(
+            [
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+            ]
+            .into_iter()
+            .chain(args.iter().copied()),
+        )
+        .expect("reverse-private-endpoint command should parse");
+        let Commands::Cloud(cloud) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let CloudCommands::ClickPipe { command } = cloud.command else {
+            panic!("expected clickpipe command");
+        };
+        let crate::cloud::clickpipes::ClickPipeCommands::ReversePrivateEndpoint { command } =
+            *command
+        else {
+            panic!("expected reverse-private-endpoint command");
+        };
+        command
+    }
+
+    fn parse_error(args: &[&str]) -> clap::Error {
+        Cli::try_parse_from(
+            [
+                "clickhousectl",
+                "cloud",
+                "clickpipe",
+                "reverse-private-endpoint",
+            ]
+            .into_iter()
+            .chain(args.iter().copied()),
+        )
+        .err()
+        .unwrap_or_else(|| panic!("expected parse failure for: {}", args.join(" ")))
+    }
+
+    fn create_args(extra: &[&str]) -> Box<ReversePrivateEndpointCreateArgs> {
+        let mut args = vec!["create", "svc-1", "--description", "endpoint"];
+        args.extend_from_slice(extra);
+        let ReversePrivateEndpointCommands::Create(args) = parse_endpoint_command(&args) else {
+            panic!("expected create command");
+        };
+        args
+    }
+
+    /// A `VPC_ENDPOINT_SERVICE` create with only its own required flag.
+    fn minimal_vpc_endpoint_service_args() -> Box<ReversePrivateEndpointCreateArgs> {
+        create_args(&[
+            "--type",
+            TYPE_VPC_ENDPOINT_SERVICE,
+            "--vpc-endpoint-service-name",
+            "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+        ])
+    }
+
+    #[test]
+    fn parses_list_and_get() {
+        let ReversePrivateEndpointCommands::List { service_id, org_id } =
+            parse_endpoint_command(&["list", "svc-1"])
+        else {
+            panic!("expected list command");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(org_id, None);
+
+        let ReversePrivateEndpointCommands::Get {
+            service_id,
+            endpoint_id,
+            org_id,
+        } = parse_endpoint_command(&["get", "svc-1", "rpe-1", "--org-id", "org-1"])
+        else {
+            panic!("expected get command");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(endpoint_id, "rpe-1");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_delete() {
+        let ReversePrivateEndpointCommands::Delete {
+            service_id,
+            endpoint_id,
+            org_id,
+        } = parse_endpoint_command(&["delete", "svc-1", "rpe-1"])
+        else {
+            panic!("expected delete command");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(endpoint_id, "rpe-1");
+        assert_eq!(org_id, None);
+    }
+
+    #[test]
+    fn parses_update_with_repeatable_mappings() {
+        let ReversePrivateEndpointCommands::Update {
+            service_id,
+            endpoint_id,
+            custom_private_dns_mappings,
+            org_id,
+        } = parse_endpoint_command(&[
+            "update",
+            "svc-1",
+            "rpe-1",
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--custom-private-dns-mapping",
+            "*.example.com",
+            "--org-id",
+            "org-1",
+        ])
+        else {
+            panic!("expected update command");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(endpoint_id, "rpe-1");
+        assert_eq!(
+            custom_private_dns_mappings,
+            vec!["db.example.com".to_string(), "*.example.com".to_string()]
+        );
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    /// The PATCH body only carries the mappings, so an update with none would
+    /// send `{}`: clap must reject it instead.
+    #[test]
+    fn update_requires_at_least_one_mapping() {
+        let error = parse_error(&["update", "svc-1", "rpe-1"]);
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        assert!(
+            error.to_string().contains("--custom-private-dns-mapping"),
+            "error should name the flag: {error}"
+        );
+    }
+
+    #[test]
+    fn parses_create_flags_for_every_type() {
+        let args = minimal_vpc_endpoint_service_args();
+        assert_eq!(args.service_id, "svc-1");
+        assert_eq!(args.endpoint_type, TYPE_VPC_ENDPOINT_SERVICE);
+        assert_eq!(args.description, "endpoint");
+        assert_eq!(
+            args.vpc_endpoint_service_name.as_deref(),
+            Some("com.amazonaws.vpce.us-east-1.vpce-svc-1")
+        );
+        assert!(args.custom_private_dns_mappings.is_empty());
+
+        let args = create_args(&[
+            "--type",
+            TYPE_VPC_RESOURCE,
+            "--vpc-resource-configuration-id",
+            "rcfg-1",
+            "--vpc-resource-share-arn",
+            "arn:aws:ram:us-east-1:1:resource-share/share-1",
+        ]);
+        assert_eq!(
+            args.vpc_resource_configuration_id.as_deref(),
+            Some("rcfg-1")
+        );
+        assert_eq!(
+            args.vpc_resource_share_arn.as_deref(),
+            Some("arn:aws:ram:us-east-1:1:resource-share/share-1")
+        );
+
+        let args = create_args(&[
+            "--type",
+            TYPE_MSK_MULTI_VPC,
+            "--msk-cluster-arn",
+            "arn:aws:kafka:us-east-1:1:cluster/c",
+            "--msk-authentication",
+            "SASL_SCRAM",
+        ]);
+        assert_eq!(
+            args.msk_cluster_arn.as_deref(),
+            Some("arn:aws:kafka:us-east-1:1:cluster/c")
+        );
+        assert_eq!(args.msk_authentication.as_deref(), Some("SASL_SCRAM"));
+
+        let args = create_args(&[
+            "--type",
+            TYPE_GCP_PSC_SERVICE_ATTACHMENT,
+            "--gcp-service-attachment",
+            "projects/p/regions/us-central1/serviceAttachments/s",
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--custom-private-dns-mapping",
+            "*.example.com",
+            "--org-id",
+            "org-1",
+        ]);
+        assert_eq!(
+            args.gcp_service_attachment.as_deref(),
+            Some("projects/p/regions/us-central1/serviceAttachments/s")
+        );
+        assert_eq!(
+            args.custom_private_dns_mappings,
+            vec!["db.example.com".to_string(), "*.example.com".to_string()]
+        );
+        assert_eq!(args.org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn create_rejects_unknown_type_and_authentication_values() {
+        for args in [
+            vec![
+                "create",
+                "svc-1",
+                "--description",
+                "d",
+                "--type",
+                "VPC_ENDPOINT",
+            ],
+            vec![
+                "create",
+                "svc-1",
+                "--description",
+                "d",
+                "--type",
+                TYPE_MSK_MULTI_VPC,
+                "--msk-cluster-arn",
+                "arn",
+                "--msk-authentication",
+                "SASL_PLAIN",
+            ],
+        ] {
+            assert_eq!(
+                parse_error(&args).kind(),
+                clap::error::ErrorKind::InvalidValue,
+                "expected an invalid-value error for: {}",
+                args.join(" ")
+            );
+        }
+    }
+
+    #[test]
+    fn create_requires_type_and_description() {
+        for args in [
+            vec!["create", "svc-1", "--description", "d"],
+            vec!["create", "svc-1", "--type", TYPE_VPC_RESOURCE],
+        ] {
+            assert_eq!(
+                parse_error(&args).kind(),
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "expected a missing-argument error for: {}",
+                args.join(" ")
+            );
+        }
+    }
+
+    #[test]
+    fn validation_names_the_flags_each_type_requires() {
+        for (endpoint_type, expected) in [
+            (
+                TYPE_VPC_ENDPOINT_SERVICE,
+                "--type VPC_ENDPOINT_SERVICE requires --vpc-endpoint-service-name",
+            ),
+            (
+                TYPE_VPC_RESOURCE,
+                "--type VPC_RESOURCE requires --vpc-resource-configuration-id and \
+                 --vpc-resource-share-arn",
+            ),
+            (
+                TYPE_MSK_MULTI_VPC,
+                "--type MSK_MULTI_VPC requires --msk-cluster-arn and --msk-authentication",
+            ),
+            (
+                TYPE_GCP_PSC_SERVICE_ATTACHMENT,
+                "--type GCP_PSC_SERVICE_ATTACHMENT requires --gcp-service-attachment",
+            ),
+        ] {
+            let args = create_args(&["--type", endpoint_type]);
+            let error = validate_create_args(&args).expect_err("expected a validation error");
+            assert_eq!(error.message, expected);
+            // The same message reaches main.rs for the usage error.
+            assert_eq!(
+                ReversePrivateEndpointCommands::Create(args).create_validation_error(),
+                Some(expected.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn validation_rejects_a_flag_belonging_to_another_type() {
+        let args = create_args(&[
+            "--type",
+            TYPE_VPC_ENDPOINT_SERVICE,
+            "--vpc-endpoint-service-name",
+            "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+            "--msk-cluster-arn",
+            "arn:aws:kafka:us-east-1:1:cluster/c",
+        ]);
+        assert_eq!(
+            validate_create_args(&args).unwrap_err().message,
+            "--msk-cluster-arn applies to --type MSK_MULTI_VPC, not --type VPC_ENDPOINT_SERVICE"
+        );
+
+        let args = create_args(&[
+            "--type",
+            TYPE_VPC_RESOURCE,
+            "--vpc-resource-configuration-id",
+            "rcfg-1",
+            "--vpc-resource-share-arn",
+            "arn:aws:ram:us-east-1:1:resource-share/share-1",
+            "--gcp-service-attachment",
+            "projects/p/regions/us-central1/serviceAttachments/s",
+        ]);
+        assert_eq!(
+            validate_create_args(&args).unwrap_err().message,
+            "--gcp-service-attachment applies to --type GCP_PSC_SERVICE_ATTACHMENT, not --type \
+             VPC_RESOURCE"
+        );
+    }
+
+    /// "Not supported for MSK multi-VPC", per the spec's field description.
+    #[test]
+    fn validation_rejects_custom_dns_mappings_for_msk() {
+        let args = create_args(&[
+            "--type",
+            TYPE_MSK_MULTI_VPC,
+            "--msk-cluster-arn",
+            "arn:aws:kafka:us-east-1:1:cluster/c",
+            "--msk-authentication",
+            "SASL_IAM",
+            "--custom-private-dns-mapping",
+            "db.example.com",
+        ]);
+        assert_eq!(
+            validate_create_args(&args).unwrap_err().message,
+            "--custom-private-dns-mapping is not supported for --type MSK_MULTI_VPC"
+        );
+    }
+
+    #[test]
+    fn every_valid_type_combination_passes_validation() {
+        for args in [
+            minimal_vpc_endpoint_service_args(),
+            create_args(&[
+                "--type",
+                TYPE_VPC_RESOURCE,
+                "--vpc-resource-configuration-id",
+                "rcfg-1",
+                "--vpc-resource-share-arn",
+                "arn:aws:ram:us-east-1:1:resource-share/share-1",
+            ]),
+            create_args(&[
+                "--type",
+                TYPE_MSK_MULTI_VPC,
+                "--msk-cluster-arn",
+                "arn:aws:kafka:us-east-1:1:cluster/c",
+                "--msk-authentication",
+                "SASL_IAM",
+            ]),
+            create_args(&[
+                "--type",
+                TYPE_GCP_PSC_SERVICE_ATTACHMENT,
+                "--gcp-service-attachment",
+                "projects/p/regions/us-central1/serviceAttachments/s",
+            ]),
+        ] {
+            validate_create_args(&args).expect("valid combination should pass");
+            assert_eq!(
+                ReversePrivateEndpointCommands::Create(args).create_validation_error(),
+                None
+            );
+        }
+    }
+
+    /// A non-create subcommand has nothing to validate.
+    #[test]
+    fn create_validation_error_is_none_for_other_subcommands() {
+        assert_eq!(
+            parse_endpoint_command(&["list", "svc-1"]).create_validation_error(),
+            None
+        );
+    }
+
+    #[test]
+    fn build_create_request_minimal_sends_only_the_type_and_description() {
+        let request =
+            build_create_reverse_private_endpoint_request(&minimal_vpc_endpoint_service_args())
+                .expect("minimal create should build");
+
+        assert_eq!(request.description, "endpoint");
+        assert_eq!(
+            request.r#type,
+            CreateReversePrivateEndpointType::VPC_ENDPOINT_SERVICE
+        );
+        assert_eq!(
+            request.vpc_endpoint_service_name.as_deref(),
+            Some("com.amazonaws.vpce.us-east-1.vpce-svc-1")
+        );
+        assert_eq!(request.vpc_resource_configuration_id, None);
+        assert_eq!(request.vpc_resource_share_arn, None);
+        assert_eq!(request.msk_cluster_arn, None);
+        assert_eq!(request.msk_authentication, None);
+        assert_eq!(request.gcp_service_attachment, None);
+        assert_eq!(request.custom_private_dns_mappings, None);
+    }
+
+    #[test]
+    fn build_create_request_maximal_maps_every_flag() {
+        let request = build_create_reverse_private_endpoint_request(&create_args(&[
+            "--type",
+            TYPE_GCP_PSC_SERVICE_ATTACHMENT,
+            "--gcp-service-attachment",
+            "projects/p/regions/us-central1/serviceAttachments/s",
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--custom-private-dns-mapping",
+            "*.example.com",
+        ]))
+        .expect("maximal create should build");
+
+        assert_eq!(
+            request.r#type,
+            CreateReversePrivateEndpointType::GCP_PSC_SERVICE_ATTACHMENT
+        );
+        assert_eq!(
+            request.gcp_service_attachment.as_deref(),
+            Some("projects/p/regions/us-central1/serviceAttachments/s")
+        );
+        assert_eq!(
+            request.custom_private_dns_mappings,
+            Some(vec![
+                CustomPrivateDnsMapping {
+                    private_dns_name: Some("db.example.com".into()),
+                },
+                CustomPrivateDnsMapping {
+                    private_dns_name: Some("*.example.com".into()),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn build_create_request_maps_the_msk_authentication_enum() {
+        let request = build_create_reverse_private_endpoint_request(&create_args(&[
+            "--type",
+            TYPE_MSK_MULTI_VPC,
+            "--msk-cluster-arn",
+            "arn:aws:kafka:us-east-1:1:cluster/c",
+            "--msk-authentication",
+            "SASL_SCRAM",
+        ]))
+        .expect("MSK create should build");
+
+        assert_eq!(
+            request.msk_authentication,
+            Some(CreateReversePrivateEndpointMskauthentication::SASL_SCRAM)
+        );
+        assert_eq!(
+            request.r#type,
+            CreateReversePrivateEndpointType::MSK_MULTI_VPC
+        );
+    }
+
+    /// The builder validates too, so a handler reached by any other route
+    /// cannot send an invalid body.
+    #[test]
+    fn build_create_request_refuses_an_invalid_combination() {
+        let error = build_create_reverse_private_endpoint_request(&create_args(&[
+            "--type",
+            TYPE_VPC_RESOURCE,
+            "--vpc-resource-configuration-id",
+            "rcfg-1",
+        ]))
+        .expect_err("expected a validation error");
+        assert_eq!(
+            error.message,
+            "--type VPC_RESOURCE requires --vpc-resource-share-arn"
+        );
+    }
+
+    #[test]
+    fn build_update_request_sends_the_complete_mapping_list() {
+        let request = build_update_reverse_private_endpoint_request(&[
+            "db.example.com".to_string(),
+            "*.example.com".to_string(),
+        ]);
+        assert_eq!(
+            request.custom_private_dns_mappings,
+            Some(vec![
+                CustomPrivateDnsMapping {
+                    private_dns_name: Some("db.example.com".into()),
+                },
+                CustomPrivateDnsMapping {
+                    private_dns_name: Some("*.example.com".into()),
+                },
+            ])
+        );
+
+        // Clap requires a mapping, so this shape is unreachable from the CLI;
+        // pinned so the builder never invents an empty array either.
+        assert_eq!(
+            build_update_reverse_private_endpoint_request(&[]).custom_private_dns_mappings,
+            None
+        );
+    }
+
+    /// Every field of the response model is `Option`, so a list row must render
+    /// absence rather than unwrap.
+    #[test]
+    fn join_names_renders_absence_and_an_empty_list_alike() {
+        assert_eq!(join_names(None), ABSENT);
+        assert_eq!(join_names(Some(&vec![])), ABSENT);
+        assert_eq!(
+            join_names(Some(&vec!["a.example.com".to_string(), "b".to_string()])),
+            "a.example.com, b"
+        );
+    }
+
+    #[test]
+    fn read_and_write_classification() {
+        assert!(!parse_endpoint_command(&["list", "svc-1"]).is_write());
+        assert!(!parse_endpoint_command(&["get", "svc-1", "rpe-1"]).is_write());
+        assert!(
+            ReversePrivateEndpointCommands::Create(minimal_vpc_endpoint_service_args()).is_write()
+        );
+        assert!(
+            parse_endpoint_command(&[
+                "update",
+                "svc-1",
+                "rpe-1",
+                "--custom-private-dns-mapping",
+                "db.example.com",
+            ])
+            .is_write()
+        );
+        assert!(parse_endpoint_command(&["delete", "svc-1", "rpe-1"]).is_write());
+    }
+}

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -227,6 +227,37 @@ CONTEXT FOR AGENTS:
         org_id: Option<String>,
     },
 
+    /// Manage reverse private endpoints (PrivateLink, Private Service Connect)
+    #[command(
+        name = "reverse-private-endpoint",
+        long_about = "\
+Manage the reverse private endpoints ClickPipes uses to reach a source over
+private networking instead of the public internet.
+
+Create the endpoint first, then reference it from a pipe:
+
+  Kafka: pass the endpoint's id to `clickpipe create kafka
+  --reverse-private-endpoint-id <ID>`, which is repeatable.
+
+  Postgres and MySQL CDC: pass one of the endpoint's DNS names as --host on
+  `clickpipe create postgres` or `clickpipe create mysql`. `reverse-private-endpoint get`
+  prints the dnsNames the endpoint answers on, plus any custom private DNS
+  names configured for it.
+
+A pipe can only use an endpoint that has reached the Ready status. An AWS
+PrivateLink endpoint stays in PendingAcceptance until the connection request is
+accepted in the account that owns the source, so check `reverse-private-endpoint
+get` before creating the pipe.
+
+Types: VPC_ENDPOINT_SERVICE and VPC_RESOURCE (AWS PrivateLink), MSK_MULTI_VPC
+(Amazon MSK multi-VPC connectivity), GCP_PSC_SERVICE_ATTACHMENT (Google Private
+Service Connect)."
+    )]
+    ReversePrivateEndpoint {
+        #[command(subcommand)]
+        command: crate::cloud::clickpipe_endpoints::ReversePrivateEndpointCommands,
+    },
+
     /// Create a ClickPipe
     Create {
         #[command(subcommand)]
@@ -251,6 +282,7 @@ impl ClickPipeCommands {
             ClickPipeCommands::SchemaDiscover { .. } => true,
             ClickPipeCommands::Create { .. } => true,
             ClickPipeCommands::Settings { command } => command.is_write(),
+            ClickPipeCommands::ReversePrivateEndpoint { command } => command.is_write(),
         }
     }
 
@@ -265,6 +297,14 @@ impl ClickPipeCommands {
         validate_postgres_create_args(args)
             .err()
             .map(|error| error.message)
+    }
+
+    pub(crate) fn reverse_private_endpoint_create_validation_error(&self) -> Option<String> {
+        let ClickPipeCommands::ReversePrivateEndpoint { command } = self else {
+            return None;
+        };
+
+        command.create_validation_error()
     }
 }
 
@@ -1400,6 +1440,9 @@ pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -
             org_id,
         } => {
             clickpipe_schema_discover(client, &service_id, &command, org_id.as_deref(), json).await
+        }
+        ClickPipeCommands::ReversePrivateEndpoint { command } => {
+            crate::cloud::clickpipe_endpoints::run(client, command, json).await
         }
         ClickPipeCommands::Create { command } => match command {
             ClickPipeCreateCommands::ObjectStorage(args) => {

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -3,6 +3,7 @@ pub mod api_keys;
 pub mod auth;
 pub mod backups;
 pub mod cli;
+pub mod clickpipe_endpoints;
 pub mod clickpipes;
 pub mod client;
 pub mod credentials;

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -158,6 +158,19 @@ fn validate_post_parse(cli: &Cli, cmd: &mut clap::Command) -> std::result::Resul
         ));
     }
 
+    // Each reverse private endpoint type has its own required flags, and the
+    // flags of the other types are meaningless for it; clap has no way to
+    // forbid an argument based on another argument's value.
+    if let Some(message) = args.reverse_private_endpoint_validation_error() {
+        let endpoint = cmd
+            .find_subcommand_mut("cloud")
+            .and_then(|cloud| cloud.find_subcommand_mut("clickpipe"))
+            .and_then(|clickpipe| clickpipe.find_subcommand_mut("reverse-private-endpoint"))
+            .and_then(|endpoint| endpoint.find_subcommand_mut("create"))
+            .expect("clickpipe reverse-private-endpoint create command must exist");
+        return Err(endpoint.error(ErrorKind::ArgumentConflict, message));
+    }
+
     // clap can require --iam-role for one auth value, but cannot express the
     // inverse conflict or condition --replication-slot-name on another value.
     let Some(message) = args.postgres_clickpipe_validation_error() else {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -8970,3 +8970,538 @@ async fn service_query_help_names_the_gateway_timeout() {
     );
     assert!(help.contains("--port 9440 --user"), "{help}");
 }
+
+// ── `clickpipe reverse-private-endpoint` CRUD (issue #567) ─────────────────
+//
+// PrivateLink connectivity for ClickPipes is a reverse private endpoint the
+// user creates on the service and then references from a pipe: by ID for
+// Kafka, or by DNS name as `--host` for Postgres/MySQL CDC. These tests pin
+// the five requests, the request bodies (including which fields stay off the
+// wire), and the client-side type/flag validation that must cost no request.
+
+const RPE_COLLECTION_PATH: &str =
+    "/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints";
+const RPE_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+fn reverse_private_endpoint_path() -> String {
+    format!("{RPE_COLLECTION_PATH}/{RPE_ID}")
+}
+
+/// One endpoint as the API returns it, with the fields the CLI renders.
+fn reverse_private_endpoint_json() -> serde_json::Value {
+    serde_json::json!({
+        "id": RPE_ID,
+        "serviceId": "11111111-2222-3333-4444-555555555555",
+        "type": "VPC_ENDPOINT_SERVICE",
+        "description": "warehouse",
+        "status": "PendingAcceptance",
+        "endpointId": "vpce-12345678901234567",
+        "dnsNames": ["vpce-1-abc.vpce.amazonaws.com"],
+        "vpcEndpointServiceName": "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+    })
+}
+
+fn reverse_private_endpoint_envelope(result: serde_json::Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "result": result,
+        "status": 200,
+        "requestId": "stub-reverse-private-endpoint",
+    }))
+}
+
+/// Run the binary with credentials but *without* `--json`, so human output can
+/// be asserted. `invoke_cli_with_cloud_credentials` always adds `--json`.
+fn invoke_cli_human(mock: &MockServer, cli_args: &[&str]) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = mock.uri();
+    let mut args = vec!["cloud", "--url", &url];
+    args.extend(cli_args);
+    let mut command = Command::new(clickhousectl_binary());
+    // Agent detection turns on `--json` on its own, so the inherited
+    // environment has to go for human output to be observable at all.
+    clear_inherited_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args(args);
+    command.output().expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_list_returns_the_resource_array() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(RPE_COLLECTION_PATH))
+        .respond_with(reverse_private_endpoint_envelope(serde_json::json!([
+            reverse_private_endpoint_json()
+        ])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the resource array as JSON");
+    assert_eq!(stdout[0]["id"], RPE_ID);
+    assert_eq!(stdout[0]["status"], "PendingAcceptance");
+    assert!(
+        stdout.get("status").is_none() && stdout.get("requestId").is_none(),
+        "must not emit the raw API envelope, got: {stdout}"
+    );
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("GET".to_string(), RPE_COLLECTION_PATH.to_string())]
+    );
+}
+
+/// Every response field is `Option`, so a row with nothing but an ID must
+/// render placeholders rather than fabricate values.
+#[tokio::test]
+async fn reverse_private_endpoint_list_table_renders_absent_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(RPE_COLLECTION_PATH))
+        .respond_with(reverse_private_endpoint_envelope(serde_json::json!([
+            { "id": RPE_ID }
+        ])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("| ID"), "{stdout}");
+    assert!(stdout.contains("DNS Names"), "{stdout}");
+    assert!(stdout.contains(RPE_ID), "{stdout}");
+    // Type, Description, Status and DNS Names are all absent here.
+    assert_eq!(stdout.matches(" - ").count(), 4, "{stdout}");
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_list_reports_an_empty_collection() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(RPE_COLLECTION_PATH))
+        .respond_with(reverse_private_endpoint_envelope(serde_json::json!([])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "No reverse private endpoints found"
+    );
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_get_reads_the_single_endpoint() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(reverse_private_endpoint_path()))
+        .respond_with(reverse_private_endpoint_envelope(
+            reverse_private_endpoint_json(),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "get",
+            "svc-1",
+            RPE_ID,
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+        .expect("stdout should be the resource object as JSON");
+    assert_eq!(stdout["endpointId"], "vpce-12345678901234567");
+    assert_eq!(stdout["dnsNames"][0], "vpce-1-abc.vpce.amazonaws.com");
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("GET".to_string(), reverse_private_endpoint_path())]
+    );
+}
+
+/// One create per endpoint type: the POST body carries the type's own fields
+/// and nothing else, so an omitted flag never reaches the wire as `""`.
+#[tokio::test]
+async fn reverse_private_endpoint_create_sends_the_body_for_each_type() {
+    let cases: Vec<(Vec<&str>, serde_json::Value)> = vec![
+        (
+            vec![
+                "--type",
+                "VPC_ENDPOINT_SERVICE",
+                "--vpc-endpoint-service-name",
+                "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+            ],
+            serde_json::json!({
+                "description": "warehouse",
+                "type": "VPC_ENDPOINT_SERVICE",
+                "vpcEndpointServiceName": "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+            }),
+        ),
+        (
+            vec![
+                "--type",
+                "VPC_RESOURCE",
+                "--vpc-resource-configuration-id",
+                "rcfg-12345678901234567",
+                "--vpc-resource-share-arn",
+                "arn:aws:ram:us-east-1:123456789012:resource-share/share-1",
+            ],
+            serde_json::json!({
+                "description": "warehouse",
+                "type": "VPC_RESOURCE",
+                "vpcResourceConfigurationId": "rcfg-12345678901234567",
+                "vpcResourceShareArn":
+                    "arn:aws:ram:us-east-1:123456789012:resource-share/share-1",
+            }),
+        ),
+        (
+            vec![
+                "--type",
+                "MSK_MULTI_VPC",
+                "--msk-cluster-arn",
+                "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster",
+                "--msk-authentication",
+                "SASL_IAM",
+            ],
+            serde_json::json!({
+                "description": "warehouse",
+                "type": "MSK_MULTI_VPC",
+                "mskClusterArn": "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster",
+                "mskAuthentication": "SASL_IAM",
+            }),
+        ),
+        (
+            vec![
+                "--type",
+                "GCP_PSC_SERVICE_ATTACHMENT",
+                "--gcp-service-attachment",
+                "projects/p/regions/us-central1/serviceAttachments/s",
+                "--custom-private-dns-mapping",
+                "db.example.com",
+                "--custom-private-dns-mapping",
+                "*.example.com",
+            ],
+            serde_json::json!({
+                "description": "warehouse",
+                "type": "GCP_PSC_SERVICE_ATTACHMENT",
+                "gcpServiceAttachment": "projects/p/regions/us-central1/serviceAttachments/s",
+                "customPrivateDnsMappings": [
+                    { "privateDnsName": "db.example.com" },
+                    { "privateDnsName": "*.example.com" },
+                ],
+            }),
+        ),
+    ];
+
+    for (flags, expected_body) in cases {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(RPE_COLLECTION_PATH))
+            .respond_with(reverse_private_endpoint_envelope(
+                reverse_private_endpoint_json(),
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let mut args = vec![
+            "clickpipe",
+            "reverse-private-endpoint",
+            "create",
+            "svc-1",
+            "--description",
+            "warehouse",
+            "--org-id",
+            "org-1",
+        ];
+        args.extend_from_slice(&flags);
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_success(&output);
+        let requests = mock.received_requests().await.unwrap();
+        assert_eq!(
+            received_request_shape(&mock).await,
+            vec![("POST".to_string(), RPE_COLLECTION_PATH.to_string())],
+            "unexpected requests for {flags:?}"
+        );
+        let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body, expected_body, "unexpected body for {flags:?}");
+    }
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_create_prints_the_status_to_wait_for() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(RPE_COLLECTION_PATH))
+        .respond_with(reverse_private_endpoint_envelope(
+            reverse_private_endpoint_json(),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "create",
+            "svc-1",
+            "--description",
+            "warehouse",
+            "--type",
+            "VPC_ENDPOINT_SERVICE",
+            "--vpc-endpoint-service-name",
+            "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Reverse private endpoint created"),
+        "{stdout}"
+    );
+    assert!(stdout.contains(RPE_ID), "{stdout}");
+    assert!(stdout.contains("Status: PendingAcceptance"), "{stdout}");
+    assert!(
+        stdout.contains("DNS names: vpce-1-abc.vpce.amazonaws.com"),
+        "{stdout}"
+    );
+}
+
+/// The flags a type needs, and the flags belonging to another type, are
+/// checked before any network call: a bad combination is a usage error
+/// (exit 2) with no request sent.
+#[tokio::test]
+async fn reverse_private_endpoint_create_validates_flags_before_any_request() {
+    let cases: [(Vec<&str>, &str); 3] = [
+        (
+            vec![
+                "--type",
+                "VPC_RESOURCE",
+                "--vpc-resource-configuration-id",
+                "rcfg-1",
+            ],
+            "--type VPC_RESOURCE requires --vpc-resource-share-arn",
+        ),
+        (
+            vec![
+                "--type",
+                "VPC_ENDPOINT_SERVICE",
+                "--vpc-endpoint-service-name",
+                "com.amazonaws.vpce.us-east-1.vpce-svc-1",
+                "--msk-cluster-arn",
+                "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster",
+            ],
+            "--msk-cluster-arn applies to --type MSK_MULTI_VPC, not --type VPC_ENDPOINT_SERVICE",
+        ),
+        (
+            vec![
+                "--type",
+                "MSK_MULTI_VPC",
+                "--msk-cluster-arn",
+                "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster",
+                "--msk-authentication",
+                "SASL_IAM",
+                "--custom-private-dns-mapping",
+                "db.example.com",
+            ],
+            "--custom-private-dns-mapping is not supported for --type MSK_MULTI_VPC",
+        ),
+    ];
+
+    for (flags, expected_message) in cases {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(RPE_COLLECTION_PATH))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock)
+            .await;
+
+        // No --org-id either: a rejected invocation must not even look one up.
+        let mut args = vec![
+            "clickpipe",
+            "reverse-private-endpoint",
+            "create",
+            "svc-1",
+            "--description",
+            "warehouse",
+        ];
+        args.extend_from_slice(&flags);
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_eq!(output.status.code(), Some(2), "expected a usage error");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(expected_message), "{stderr}");
+        assert!(
+            mock.received_requests().await.unwrap().is_empty(),
+            "a rejected create must not reach the API"
+        );
+    }
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_update_patches_the_full_mapping_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path(reverse_private_endpoint_path()))
+        .respond_with(reverse_private_endpoint_envelope(
+            reverse_private_endpoint_json(),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "update",
+            "svc-1",
+            RPE_ID,
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--custom-private-dns-mapping",
+            "*.example.com",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("PATCH".to_string(), reverse_private_endpoint_path())]
+    );
+    let requests = mock.received_requests().await.unwrap();
+    let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "customPrivateDnsMappings": [
+                { "privateDnsName": "db.example.com" },
+                { "privateDnsName": "*.example.com" },
+            ],
+        })
+    );
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_delete_confirms_the_removal() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(reverse_private_endpoint_path()))
+        .respond_with(successful_delete_response("stub-rpe-delete"))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let args = [
+        "clickpipe",
+        "reverse-private-endpoint",
+        "delete",
+        "svc-1",
+        RPE_ID,
+        "--org-id",
+        "org-1",
+    ];
+
+    let human = invoke_cli_human(&mock, &args);
+    assert_success(&human);
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout).trim(),
+        format!("Reverse private endpoint {RPE_ID} deleted")
+    );
+
+    let json = invoke_cli_with_cloud_credentials(&mock, &args);
+    assert_success(&json);
+    let stdout: Value = serde_json::from_str(String::from_utf8_lossy(&json.stdout).trim())
+        .expect("stdout should be JSON");
+    assert_eq!(stdout, serde_json::json!({ "deleted": RPE_ID }));
+
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![
+            ("DELETE".to_string(), reverse_private_endpoint_path()),
+            ("DELETE".to_string(), reverse_private_endpoint_path()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_help_explains_how_pipes_reference_it() {
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .args(["cloud", "clickpipe", "reverse-private-endpoint", "--help"])
+        .output()
+        .expect("render reverse-private-endpoint help");
+
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(help.contains("--reverse-private-endpoint-id"), "{help}");
+    assert!(
+        help.contains("pass one of the endpoint's DNS names as --host"),
+        "{help}"
+    );
+    assert!(help.contains("reached the Ready status"), "{help}");
+    assert!(help.contains("PendingAcceptance"), "{help}");
+}


### PR DESCRIPTION
## What

Adds `clickhousectl cloud clickpipe reverse-private-endpoint` with the full CRUD set:

- `list <service-id>` renders a `tabled` table (ID, Type, Description, Status, DNS Names) and supports `--json`.
- `get <service-id> <endpoint-id>` renders through `print_human` and supports `--json`.
- `create <service-id> --type <TYPE> --description <D>` plus the type-specific flags: `--vpc-endpoint-service-name`, `--vpc-resource-configuration-id`, `--vpc-resource-share-arn`, `--msk-cluster-arn`, `--msk-authentication`, `--gcp-service-attachment`, and the repeatable `--custom-private-dns-mapping`.
- `update <service-id> <endpoint-id> --custom-private-dns-mapping <NAME>` sends the complete mapping list, the only field the API's PATCH accepts.
- `delete <service-id> <endpoint-id>` prints a plain confirmation line, or `{"deleted": <id>}` under `--json`.

The surface lives in a new `crates/clickhousectl/src/cloud/clickpipe_endpoints.rs` rather than in `clickpipes.rs`, which is already several thousand lines of pipe-creation surface, and nests under `clickpipe` because an endpoint is only ever useful to a pipe. It is wired per CLAUDE.md: a domain module, a private re-export from `src/cloud/cli.rs`, an exhaustive `is_write()` (list and get read, create, update and delete write), a dispatch arm in the `clickpipe` dispatcher, five thin `CloudClient` wrappers, and `build_*_request` helpers.

The group's `long_about` explains how a pipe references an endpoint: the endpoint ID for Kafka via `--reverse-private-endpoint-id`, and one of the endpoint's DNS names as `--host` for Postgres and MySQL CDC. It also says a pipe can only use an endpoint that has reached `Ready`, and that an AWS PrivateLink endpoint stays in `PendingAcceptance` until the connection request is accepted in the account that owns the source.

## Why

The Cloud API has had full CRUD for ClickPipes reverse private endpoints for a while, but the CLI had no way to reach it. `clickpipe create kafka --reverse-private-endpoint-id` could only reference an endpoint somebody else had created, and a PrivateLink-connected Postgres CDC pipe was impossible end to end from the CLI, because that pipe connects to the endpoint's DNS name rather than to an ID.

## Why the API library changed too

`CreateReversePrivateEndpointType` and `CreateReversePrivateEndpointMskauthentication` are now validated by the CLI as `--type` and `--msk-authentication` string arguments, so each declares the opt-in `pub const VALUES` the analyzer checks against its variant wire values. That keeps the accepted values in one place, checkable in CI, instead of a hand-copied literal list in the CLI.

## Behaviour after the fix

Client-side validation of `create` runs after parsing, because clap cannot forbid an argument based on another argument's value. It is a usage error (exit code 2) against the owning command, raised before any request and before the organization lookup, matching how `clickpipe create postgres` validates its cross-value relationships. Only the rules the OpenAPI spec states are enforced:

| `--type` | Required flags |
| --- | --- |
| `VPC_ENDPOINT_SERVICE` | `--vpc-endpoint-service-name` |
| `VPC_RESOURCE` | `--vpc-resource-configuration-id`, `--vpc-resource-share-arn` |
| `MSK_MULTI_VPC` | `--msk-cluster-arn`, `--msk-authentication` |
| `GCP_PSC_SERVICE_ATTACHMENT` | `--gcp-service-attachment` |

A flag belonging to another type is rejected by name ("`--msk-cluster-arn` applies to `--type MSK_MULTI_VPC`, not `--type VPC_ENDPOINT_SERVICE`"), and `--custom-private-dns-mapping` is refused for `MSK_MULTI_VPC` because the spec says it is not supported there. `vpcEndpointServiceName` is the one field the spec does not mark "Required for `<TYPE>` type", but it names its type exactly and has no meaning for any other type, so it is treated as `VPC_ENDPOINT_SERVICE`'s required flag. Everything else, including whether a value is well formed, is left to the API.

`delete` copies `clickpipe delete` exactly: no interactive confirmation and no `--force`, because no cloud delete in this CLI prompts today, and `service delete --force` means "stop the service first" rather than "skip a prompt". Inventing a prompt here would have made this the only command that has one.

Absence is rendered, never unwrapped: an absent list-row field shows `-`, and an endpoint whose DNS names are absent or empty renders the same placeholder for both, since neither tells the caller a name to connect to.

## Tests

- `crates/clickhousectl/src/cloud/clickpipe_endpoints.rs`: clap `try_parse_from` coverage for all five subcommands, including every type's flags, rejected `--type` and `--msk-authentication` values, `create` requiring `--type` and `--description`, and `update` requiring at least one mapping; `build_create_reverse_private_endpoint_request` minimal and maximal cases asserting on library request-struct fields; `build_update_reverse_private_endpoint_request`; the validation messages per type; read and write classification.
- `crates/clickhousectl/src/cloud/cli.rs`: the new commands added to the top-level `is_write_command()` read and write classification tests.
- `crates/clickhousectl/tests/cli_request_shape_test.rs`: subprocess plus wiremock coverage for list (JSON array, human table with placeholders, empty collection), get, create for each of the four types asserting the exact POST body, the human create output naming the status to wait for, update's PATCH body, delete in both output modes, the three client-side validation cases asserting exit code 2 and that the mock received nothing, and a help-text assertion pinning the Kafka and Postgres/MySQL usage guidance.
- `crates/clickhouse-cloud-api/tests/models_test.rs`: both `VALUES` consts and their round-trips, plus `ReversePrivateEndpoint` resolving a missing key and an explicit `null` to `None` and omitting both on serialization.
- `README.md`: a new "Reverse private endpoints (PrivateLink, Private Service Connect)" subsection under ClickPipes with one create example per type, the required-flag table, and how a pipe references the endpoint.

Verification commands, all green:

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo test -p clickhouse-cloud-api --lib --test spec_coverage_test --test models_test`
- `cargo test -p clickhouse-openapi-analyzer`
- `cargo check --workspace --all-features`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`

No cloud resources were created: every new test runs against a local wiremock server.

## Stacking

Part of a stacked PR chain: based on `feat/587-pubsub-source`, not `main`.

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
