### PR TITLE
Fix missing `about` text for the `clickpipe` cloud subcommand

### DIFF
--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -138,15 +138,15 @@ CONTEXT FOR AGENTS:
         command: BackupCommands,
     },
 
-    // Clickpipe commands
+    /// Manage ClickPipes for data ingestion
     #[command(
         name = "clickpipe",
         after_help = "\
 CONTEXT FOR AGENTS:
-    Manage ClickPipes for ingesting data into ClickHouse Cloud.
-    Subcommands: list, get, delete, start, stop, resync, scale, settings, create,
-    reverse-private-endpoint (PrivateLink connectivity for sources).
-    Requires a service ID — get it from `clickhousectl cloud service list`."
+  Manage ClickPipes for ingesting data into ClickHouse Cloud.
+  Subcommands: list, get, delete, start, stop, resync, scale, settings, create,
+  reverse-private-endpoint (PrivateLink connectivity for sources).
+  Requires a service ID — get it from `clickhousectl cloud service list`."
     )]
     ClickPipe {
         #[command(subcommand)]
@@ -479,5 +479,24 @@ mod tests {
             ],
             true,
         );
+    }
+
+    #[test]
+    fn every_cloud_subcommand_has_a_help_about() {
+        use clap::CommandFactory;
+
+        let mut command = Cli::command();
+        let cloud = command
+            .find_subcommand_mut("cloud")
+            .expect("cloud subcommand");
+
+        for sub in cloud.get_subcommands() {
+            let about = sub.get_about().map(|a| a.to_string()).unwrap_or_default();
+            assert!(
+                !about.trim().is_empty(),
+                "cloud subcommand `{}` has no about text",
+                sub.get_name()
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

`crates/clickhousectl/src/cloud/cli.rs` gives the `ClickPipe` variant of `CloudCommands` a `///` doc comment ("Manage ClickPipes for data ingestion") instead of the plain `// Clickpipe commands` comment it had. Also normalizes the `after_help` body indentation on that variant from four spaces to two, matching every sibling `CONTEXT FOR AGENTS` block (Auth, Org, Service, Backup, Postgres). The `name = "clickpipe"` attribute and the after_help content itself are unchanged.

## Why

clap derives a subcommand's `about` text from its `///` doc comment. Because the `ClickPipe` variant used a regular `//` comment, clap had no about for it, so `cloud --help` rendered a blank description next to `clickpipe` in the subcommand list, and `cloud clickpipe --help` started straight at `Usage:` with no about line above it, unlike every other cloud domain.

## Behaviour after the fix

`clickhousectl cloud --help` now lists:
```
  clickpipe   Manage ClickPipes for data ingestion
```

`clickhousectl cloud clickpipe --help` now starts with:
```
Manage ClickPipes for data ingestion

Usage: clickhousectl cloud clickpipe [OPTIONS] <COMMAND>
```

## Tests

- Added `cloud::cli::tests::every_cloud_subcommand_has_a_help_about`, a structural regression test that builds the real clap command via `Cli::command()`, finds the `cloud` subcommand, and asserts every one of its subcommands has a non-blank `about()`. It does not pin exact wording, only presence. Verified it fails against the pre-fix code (reproduces the bug) and passes after the fix.
- `cargo fmt --all` (no diff produced)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings` (clean)
- `cargo test -p clickhousectl` (all binaries green, including the new test; 981 passed in the main binary target)
- Manually ran `cargo run -q -p clickhousectl -- cloud --help` and `cargo run -q -p clickhousectl -- cloud clickpipe --help` to confirm the about text now renders in both places.

No README change: README's ClickPipe section is usage examples, not a reproduction of the `cloud --help` subcommand listing table, so nothing there needed updating.

## Stacking

Part of a stacked PR chain: based on `fix/658-key-propagation-retry`, not `main`.

Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
