### PR TITLE
Add `--name` to `cloud postgres update` for parity with `service update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,8 +764,9 @@ clickhousectl cloud postgres create \
   --tag env=prod \
   --pg-config-file ./pg.json
 
-# Update size, HA, or tags (all flags optional)
+# Update name, size, HA, or tags (all flags optional)
 clickhousectl cloud postgres update <pg-id> \
+  --name renamed-pg \
   --size m7i.4xlarge \
   --add-tag env=prod --remove-tag legacy
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -3,7 +3,7 @@ use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
-    ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgIdProperty, PgProvider, PgVersion,
+    ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgIdProperty, PgProvider, PgSize, PgVersion,
     PostgresInstanceConfig, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
     PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
     PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
@@ -69,6 +69,9 @@ pub enum PostgresCommands {
     /// Update an existing Postgres service (metadata only)
     Update {
         postgres_id: String,
+        /// New service name
+        #[arg(long)]
+        name: Option<String>,
         #[arg(long)]
         size: Option<String>,
         #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgHaType::VALUES))]
@@ -322,6 +325,7 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
         }
         PostgresCommands::Update {
             postgres_id,
+            name,
             size,
             ha_type,
             add_tag,
@@ -329,6 +333,7 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
             org_id,
         } => {
             let opts = PostgresUpdateOptions {
+                name: name.as_deref(),
                 size: size.as_deref(),
                 ha_type: ha_type.as_deref(),
                 add_tag: &add_tag,
@@ -816,6 +821,7 @@ pub struct PostgresCreateOptions<'a> {
 }
 
 pub struct PostgresUpdateOptions<'a> {
+    pub name: Option<&'a str>,
     pub size: Option<&'a str>,
     pub ha_type: Option<&'a str>,
     pub add_tag: &'a [String],
@@ -1054,6 +1060,23 @@ pub async fn postgres_create(
     Ok(())
 }
 
+/// Builds the `postgres update` PATCH body from the already-parsed pieces
+/// (name, size, HA type, merged tags). Kept separate from `postgres_update`
+/// so the shape sent on the wire is unit-testable without a mock server.
+fn build_postgres_update_request(
+    name: Option<&str>,
+    size: Option<PgSize>,
+    ha_type: Option<PgHaType>,
+    tags: Option<Vec<ResourceTagsV1>>,
+) -> PostgresServicePatchRequest {
+    PostgresServicePatchRequest {
+        name: name.map(str::to_string),
+        size,
+        ha_type,
+        tags,
+    }
+}
+
 pub async fn postgres_update(
     client: &CloudClient,
     postgres_id: &str,
@@ -1082,12 +1105,7 @@ pub async fn postgres_update(
         None
     };
 
-    let req = PostgresServicePatchRequest {
-        name: None,
-        size,
-        ha_type,
-        tags,
-    };
+    let req = build_postgres_update_request(opts.name, size, ha_type, tags);
 
     let resp = client
         .api()
@@ -2031,13 +2049,38 @@ mod tests {
     fn parses_postgres_update_no_fields() {
         let cmd = parse_postgres(&["clickhousectl", "cloud", "postgres", "update", "pg-1"]);
         let PostgresCommands::Update {
-            postgres_id, size, ..
+            postgres_id,
+            name,
+            size,
+            ..
         } = cmd
         else {
             panic!("expected update");
         };
         assert_eq!(postgres_id, "pg-1");
+        assert!(name.is_none());
         assert!(size.is_none());
+    }
+
+    #[test]
+    fn parses_postgres_update_name() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "update",
+            "pg-1",
+            "--name",
+            "renamed-pg",
+        ]);
+        let PostgresCommands::Update {
+            postgres_id, name, ..
+        } = cmd
+        else {
+            panic!("expected update");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(name.as_deref(), Some("renamed-pg"));
     }
 
     #[test]
@@ -2742,6 +2785,32 @@ mod tests {
         }];
         let out = merge_response_tags(Some(vec![]), &add, &[]).unwrap();
         assert_eq!(out, add);
+    }
+
+    #[test]
+    fn build_postgres_update_request_omits_name_when_not_given() {
+        let req = build_postgres_update_request(None, None, None, None);
+        assert!(req.name.is_none());
+        assert!(req.size.is_none());
+        assert!(req.ha_type.is_none());
+        assert!(req.tags.is_none());
+    }
+
+    #[test]
+    fn build_postgres_update_request_sets_name_when_given() {
+        let req = build_postgres_update_request(
+            Some("renamed-pg"),
+            Some(PgSize::C6gd_large),
+            Some(PgHaType::Sync),
+            Some(vec![ResourceTagsV1 {
+                key: "env".into(),
+                value: Some("prod".into()),
+            }]),
+        );
+        assert_eq!(req.name.as_deref(), Some("renamed-pg"));
+        assert!(req.size.is_some());
+        assert_eq!(req.ha_type, Some(PgHaType::Sync));
+        assert_eq!(req.tags.unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -871,6 +871,63 @@ async fn postgres_delete_json_emits_the_resource_object_not_the_envelope() {
     );
 }
 
+// ── Postgres update --name (issue #663) ────────────────────────────────────
+
+/// `postgres update --name` must PATCH the API with only `name` set: no
+/// `size`, `haType`, or `tags` key should appear when only `--name` is
+/// passed, and no discovery `GET` is issued (no tag diff was requested).
+#[tokio::test]
+async fn postgres_update_name_sends_only_the_name_field() {
+    let mock = MockServer::start().await;
+    let postgres_id = "11111111-2222-3333-4444-555555555555";
+    Mock::given(method("PATCH"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{postgres_id}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": postgres_id,
+                "name": "renamed-pg",
+                "state": "running",
+            },
+            "status": 200,
+            "requestId": "stub-postgres-update",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "update",
+            postgres_id,
+            "--org-id",
+            "org-1",
+            "--name",
+            "renamed-pg",
+        ],
+    );
+
+    assert_success(&output);
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "expected only the PATCH, no discovery GET"
+    );
+    assert_eq!(requests[0].method, wiremock::http::Method::PATCH);
+
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("PATCH body wasn't JSON");
+    assert_eq!(body["name"], "renamed-pg");
+    assert!(
+        body.get("size").is_none() && body.get("haType").is_none() && body.get("tags").is_none(),
+        "unexpected keys in PATCH body: {body}"
+    );
+}
+
 // ── Postgres list --filter validation (issue #603) ────────────────────────
 
 fn postgres_list_response() -> ResponseTemplate {


### PR DESCRIPTION
## What

Adds a `--name <NAME>` flag to `clickhousectl cloud postgres update`, wired
through to the `name` field of `PostgresServicePatchRequest`. Extracts a
`build_postgres_update_request(...)` helper in
`crates/clickhousectl/src/cloud/postgres.rs` that builds the PATCH body from
the already-parsed name/size/HA-type/tags, replacing the previous inline
struct literal that hardcoded `name: None`.

## Why

`PATCH /v1/organizations/{org}/postgres/{id}` with `{"name": "..."}` returns
200 and renames the service, and the vendored OpenAPI snapshot lists `name`
in `PostgresServicePatchRequest`. The library model
(`crates/clickhouse-cloud-api/src/models/postgres.rs`) already had
`PostgresServicePatchRequest.name: Option<PgNameProperty>`, but the CLI's
`Update` variant had no `--name` flag and `postgres_update` hardcoded
`name: None` when building the request, so there was no way to rename a
Postgres service from the CLI even though `cloud service update` already
exposes `--name` for the equivalent ClickHouse service operation. No API
library changes were needed; this is a CLI-only fix.

## Behaviour after the fix

`clickhousectl cloud postgres update <pg-id> --name new-name` sends a PATCH
whose body contains only `{"name": "new-name"}` when no other flags are
given. Omitting `--name` behaves exactly as before: the key stays absent
from the wire body.

## Tests

- `parses_postgres_update_name` and the extended `parses_postgres_update_no_fields`
  (clap `try_parse_from` coverage) in `crates/clickhousectl/src/cloud/postgres.rs`.
- `build_postgres_update_request_omits_name_when_not_given` and
  `build_postgres_update_request_sets_name_when_given` unit tests on the new
  request-builder helper.
- `postgres_update_name_sends_only_the_name_field` in
  `crates/clickhousectl/tests/cli_request_shape_test.rs`: spawns the real
  binary against a wiremock server and asserts the PATCH body has `name` set
  and no `size`/`haType`/`tags` keys, with no discovery `GET` issued.
- Verification commands:
  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
  - `cargo test -p clickhousectl`

## Stacking

Part of a stacked PR chain: based on `fix/661-clickpipe-help-about`, not `main`.

Fixes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
