### PR TITLE
Stop requiring --username/--password for IAM_ROLE Postgres ClickPipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,9 +1102,10 @@ PostgreSQL ClickPipes require at least one table mapping, from either
 (see [PostgreSQL table mappings](#postgresql-table-mappings)). Ports must be in
 `1..=65535`. `--auth IAM_ROLE` requires `--iam-role`; the CLI rejects
 `--iam-role` with basic auth rather than silently ignoring it.
-`--username` and `--password` are basic-auth only: they are required for the
-default `--auth basic`, and rejected with `--auth IAM_ROLE`, where the role ARN
-is the whole credential and no `credentials` object is sent.
+`--username` and `--password` are basic-auth only and must be given together:
+they are required for the default `--auth basic`, and rejected with
+`--auth IAM_ROLE`, where the role ARN is the whole credential and
+no `credentials` object is sent.
 `--replication-slot-name` is valid only with `--replication-mode cdc_only`.
 
 #### PostgreSQL table mappings

--- a/README.md
+++ b/README.md
@@ -948,6 +948,16 @@ clickhousectl cloud clickpipe create postgres <service-id> \
   --table-mapping "public.users:public_users" \
   --table-mapping "public.orders:public_orders"
 
+# From an RDS or Aurora PostgreSQL with IAM role authentication (CDC)
+# IAM_ROLE auth takes no --username/--password: the role ARN is the credential
+clickhousectl cloud clickpipe create postgres <service-id> \
+  --name my-rds-pg-pipe \
+  --host db.abcdefg.us-east-1.rds.amazonaws.com --pg-database mydb \
+  --postgres-type rdspostgres \
+  --auth IAM_ROLE --iam-role "$POSTGRES_IAM_ROLE_ARN" \
+  --publication-name clickpipes \
+  --table-mapping "public.users:public_users"
+
 # From PostgreSQL with a private or self-signed CA (CDC)
 clickhousectl cloud clickpipe create postgres <service-id> \
   --name my-private-pg-pipe \
@@ -1092,6 +1102,9 @@ PostgreSQL ClickPipes require at least one table mapping, from either
 (see [PostgreSQL table mappings](#postgresql-table-mappings)). Ports must be in
 `1..=65535`. `--auth IAM_ROLE` requires `--iam-role`; the CLI rejects
 `--iam-role` with basic auth rather than silently ignoring it.
+`--username` and `--password` are basic-auth only: they are required for the
+default `--auth basic`, and rejected with `--auth IAM_ROLE`, where the role ARN
+is the whole credential and no `credentials` object is sent.
 `--replication-slot-name` is valid only with `--replication-mode cdc_only`.
 
 #### PostgreSQL table mappings

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -2374,7 +2374,14 @@ pub struct ClickPipeMutatePostgresSource {
     // `Option<String>` so callers can omit it.
     #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    pub credentials: PLAIN,
+    // credentials is the basic-auth username/password pair. The schema carries
+    // no `required[]`, so requiredness resolves from the description heuristic
+    // and the field reads as required, but IAM_ROLE authentication has no
+    // username or password: the role ARN in `iamRole` is the whole credential.
+    // Modeled as `Option<PLAIN>` so an IAM_ROLE request can omit the object
+    // entirely instead of sending an empty `{"username":"","password":""}`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<PLAIN>,
     pub database: String,
     #[serde(rename = "disableTls")]
     pub disable_tls: bool,

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/postgres.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/postgres.rs
@@ -389,10 +389,10 @@ async fn run_variant(
                 postgres: Some(ClickPipeMutatePostgresSource {
                     r#type: Some(ClickPipeMutatePostgresSourceType::Postgres),
                     authentication: ClickPipeMutatePostgresSourceAuthentication::Basic,
-                    credentials: PLAIN {
+                    credentials: Some(PLAIN {
                         username: clickpipe_user.to_string(),
                         password: clickpipe_pass.to_string(),
-                    },
+                    }),
                     host: host_ip.to_string(),
                     port: 5432,
                     database: db_name.to_string(),

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -1278,6 +1278,41 @@ fn serialize_clickpipe_object_storage_ingestion_controls() {
 }
 
 #[test]
+fn serialize_clickpipe_mutate_postgres_source_omits_absent_credentials() {
+    // IAM_ROLE authentication has no username or password: `iamRole` is the
+    // whole credential, so the `credentials` object must not reach the wire.
+    let iam_role = ClickPipeMutatePostgresSource {
+        authentication: ClickPipeMutatePostgresSourceAuthentication::IAM_ROLE,
+        credentials: None,
+        iam_role: Some("arn:aws:iam::123456789012:role/clickpipe".to_string()),
+        host: "postgres.example".to_string(),
+        port: 5432,
+        database: "source-db".to_string(),
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&iam_role).unwrap();
+    assert!(
+        json.get("credentials").is_none(),
+        "credentials must be omitted, got {json}"
+    );
+    assert_eq!(json["iamRole"], "arn:aws:iam::123456789012:role/clickpipe");
+    assert_eq!(json["authentication"], "IAM_ROLE");
+
+    // Basic auth still sends the pair verbatim.
+    let basic = ClickPipeMutatePostgresSource {
+        authentication: ClickPipeMutatePostgresSourceAuthentication::Basic,
+        credentials: Some(PLAIN {
+            username: "user".to_string(),
+            password: "secret".to_string(),
+        }),
+        ..iam_role.clone()
+    };
+    let json = serde_json::to_value(&basic).unwrap();
+    assert_eq!(json["credentials"]["username"], "user");
+    assert_eq!(json["credentials"]["password"], "secret");
+}
+
+#[test]
 fn deserialize_scaling_schedule_entry_fixed_scaling_fields() {
     let json = r#"{
         "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -117,6 +117,14 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     ("ClickPipeMutatePostgresSource", "caCertificate"),
     ("ClickPipeMutatePostgresSource", "iamRole"),
     ("ClickPipeMutatePostgresSource", "tlsHost"),
+    // IAM_ROLE authentication has no username or password: `iamRole` is the
+    // whole credential. The schema carries no `required[]`, so requiredness
+    // resolves from the description heuristic and `credentials` reads as
+    // required, but an IAM_ROLE pipe has nothing to put in it and the sibling
+    // MySQL schema (which does carry `required[]`) leaves it out. Keeping this
+    // `T` would force every IAM_ROLE request to send an empty username and
+    // password pair.
+    ("ClickPipeMutatePostgresSource", "credentials"),
     // Deprecated roles and opt-in pre-hashed keys must stay off the wire when unused.
     ("ApiKeyPostRequest", "roles"),
     ("ApiKeyPostRequest", "hashData"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -418,6 +418,9 @@ POSTGRES INPUT RULES:
   or one --table-mapping-json.
   --auth IAM_ROLE requires --iam-role. With basic auth, --iam-role is rejected
   instead of being silently ignored.
+  --auth basic requires --username and --password. With IAM_ROLE auth they are
+  rejected instead of being silently ignored: the role ARN is the whole
+  credential.
   --replication-slot-name is valid only with --replication-mode cdc_only.
 
 POSTGRES TABLE MAPPINGS:
@@ -901,13 +904,13 @@ pub struct PostgresCreateArgs {
     #[arg(long)]
     pub pg_database: String,
 
-    /// Username
-    #[arg(long)]
-    pub username: String,
+    /// Username (basic auth only; invalid with --auth IAM_ROLE)
+    #[arg(long, required_unless_present = "iam_role")]
+    pub username: Option<String>,
 
-    /// Password
-    #[arg(long)]
-    pub password: String,
+    /// Password (basic auth only; invalid with --auth IAM_ROLE)
+    #[arg(long, required_unless_present = "iam_role")]
+    pub password: Option<String>,
 
     /// Table mappings as schema.table:target_table (repeatable)
     ///
@@ -2858,6 +2861,20 @@ fn validate_postgres_create_args(
             "--iam-role cannot be used with --auth basic; use --auth IAM_ROLE",
         ));
     }
+    // IAM_ROLE authentication has no username or password: the role ARN is the
+    // whole credential. Reject the pair rather than silently dropping it, the
+    // same way basic auth rejects --iam-role.
+    if args.auth == "IAM_ROLE" && (args.username.is_some() || args.password.is_some()) {
+        return Err(CloudError::new(
+            "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic",
+        ));
+    }
+    // Clap enforces this for parsed input; hand-built args reach it here.
+    if args.auth == "basic" && (args.username.is_none() || args.password.is_none()) {
+        return Err(CloudError::new(
+            "--auth basic requires --username <USERNAME> and --password <PASSWORD>",
+        ));
+    }
     if args.replication_slot_name.is_some() && args.replication_mode != "cdc_only" {
         return Err(CloudError::new(
             "--replication-slot-name can only be used with --replication-mode cdc_only",
@@ -2931,12 +2948,20 @@ fn build_postgres_request(
         .as_deref()
         .map(std::fs::read_to_string)
         .transpose()?;
+    // `validate_postgres_create_args` has already tied the pair to the auth
+    // mode: basic auth has both flags, IAM_ROLE has neither. So the pair being
+    // absent means IAM_ROLE, where `iamRole` is the whole credential and the
+    // `credentials` object must stay off the wire entirely.
+    let credentials = match (args.username.as_deref(), args.password.as_deref()) {
+        (Some(username), Some(password)) => Some(PLAIN {
+            username: username.to_string(),
+            password: password.to_string(),
+        }),
+        _ => None,
+    };
     let source = ClickPipeMutatePostgresSource {
         r#type: Some(parse_enum(&args.postgres_type)?),
-        credentials: PLAIN {
-            username: args.username.clone(),
-            password: args.password.clone(),
-        },
+        credentials,
         host: args.host.clone(),
         port: i64::from(args.port),
         database: args.pg_database.clone(),
@@ -5072,8 +5097,8 @@ mod tests {
         assert_eq!(args.host, "postgres.example");
         assert_eq!(args.port, 5433);
         assert_eq!(args.pg_database, "source-db");
-        assert_eq!(args.username, "user");
-        assert_eq!(args.password, "password");
+        assert_eq!(args.username.as_deref(), Some("user"));
+        assert_eq!(args.password.as_deref(), Some("password"));
         assert_eq!(args.table_mappings, ["public.one:one", "public.two:two"]);
         assert_eq!(args.postgres_type, "neon");
         assert_eq!(args.replication_mode, "cdc_only");
@@ -5336,6 +5361,83 @@ mod tests {
     }
 
     #[test]
+    fn postgres_iam_role_auth_does_not_require_username_or_password() {
+        // IAM_ROLE authentication has no username or password: the role ARN is
+        // the whole credential, so clap must not demand the pair.
+        let mut args = vec![
+            "create",
+            "postgres",
+            "svc-1",
+            "--name",
+            "pipe-1",
+            "--host",
+            "postgres.example",
+            "--pg-database",
+            "source-db",
+            "--table-mapping",
+            "public.events:events",
+            "--auth",
+            "IAM_ROLE",
+            "--iam-role",
+            "arn:aws:iam::123456789012:role/clickpipe",
+        ];
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Postgres(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected postgres create");
+        };
+        assert_eq!(parsed.username, None);
+        assert_eq!(parsed.password, None);
+        assert_eq!(parsed.auth, "IAM_ROLE");
+
+        // The pair is rejected rather than silently dropped, the same way
+        // basic auth rejects --iam-role.
+        args.extend(["--username", "user", "--password", "password"]);
+        let command = parse_clickpipe(&args);
+        assert_eq!(
+            command.postgres_create_validation_error().as_deref(),
+            Some("--username and --password cannot be used with --auth IAM_ROLE; use --auth basic")
+        );
+    }
+
+    #[test]
+    fn postgres_basic_auth_still_requires_username_and_password() {
+        for omitted in ["--username", "--password"] {
+            let args: Vec<&str> = [
+                "create",
+                "postgres",
+                "svc-1",
+                "--name",
+                "pipe-1",
+                "--host",
+                "postgres.example",
+                "--pg-database",
+                "source-db",
+                "--table-mapping",
+                "public.events:events",
+                "--username",
+                "user",
+                "--password",
+                "password",
+            ]
+            .into_iter()
+            .collect();
+            let position = args.iter().position(|arg| *arg == omitted).unwrap();
+            let mut args = args;
+            args.drain(position..position + 2);
+
+            let error = clickpipe_parse_error(&args);
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "omitting {omitted} should be a usage error"
+            );
+            assert!(error.to_string().contains(omitted), "{error}");
+        }
+    }
+
+    #[test]
     fn postgres_cross_value_relationships_have_specific_validation_errors() {
         let mut basic_with_role = postgres_cli_args(Some("public.events:events"));
         basic_with_role.extend(["--iam-role", "arn:aws:iam::123456789012:role/clickpipe"]);
@@ -5409,6 +5511,17 @@ mod tests {
         assert!(help.contains("or one --table-mapping-json"), "{help}");
         assert!(
             help.contains("--auth IAM_ROLE requires --iam-role"),
+            "{help}"
+        );
+        assert!(
+            help.contains("--auth basic requires --username and --password"),
+            "{help}"
+        );
+        assert!(
+            help.contains(
+                "the role ARN is the whole
+  credential"
+            ),
             "{help}"
         );
         assert!(help.contains("silently ignored"), "{help}");
@@ -5488,6 +5601,10 @@ mod tests {
             "`USAGE` on each mapped schema",
             "https://clickhouse.com/docs/integrations/clickpipes/postgres/source/generic",
             "https://clickhouse.com/docs/integrations/clickpipes/networking/static-ips",
+            // IAM role authentication takes no username or password.
+            "`--username` and `--password` are basic-auth only",
+            "no `credentials` object is sent",
+            "--auth IAM_ROLE --iam-role \"$POSTGRES_IAM_ROLE_ARN\"",
         ] {
             assert!(
                 postgres.contains(expected),
@@ -5497,7 +5614,7 @@ mod tests {
 
         assert_eq!(
             postgres.matches("--publication-name clickpipes").count(),
-            5,
+            6,
             "every PostgreSQL example must use the publication created in the prerequisites"
         );
     }
@@ -7133,8 +7250,8 @@ mod tests {
             host: "postgres.example".into(),
             port: 5432,
             pg_database: "source-db".into(),
-            username: "user".into(),
-            password: "password".into(),
+            username: Some("user".into()),
+            password: Some("password".into()),
             table_mappings: vec!["public.events:events".into()],
             table_mappings_json: vec![],
             postgres_type: "postgres".into(),
@@ -7184,8 +7301,9 @@ mod tests {
         let source = request.source.postgres.as_ref().expect("postgres source");
         assert_eq!(source.r#type.as_ref().unwrap().to_string(), "postgres");
         assert_eq!(source.authentication.to_string(), "basic");
-        assert_eq!(source.credentials.username, "user");
-        assert_eq!(source.credentials.password, "password");
+        let credentials = source.credentials.as_ref().expect("basic credentials");
+        assert_eq!(credentials.username, "user");
+        assert_eq!(credentials.password, "password");
         assert_eq!(source.host, "postgres.example");
         assert_eq!(source.port, 5432);
         assert_eq!(source.database, "source-db");
@@ -7227,8 +7345,10 @@ mod tests {
         args.host = "rds.example".into();
         args.port = 65535;
         args.pg_database = "production".into();
-        args.username = "iam-user".into();
-        args.password = "iam-password".into();
+        // IAM_ROLE auth has no username or password: the role ARN is the whole
+        // credential, so the `credentials` object is omitted entirely.
+        args.username = None;
+        args.password = None;
         args.table_mappings = vec![
             "public.users:users_raw".into(),
             "audit.events:audit_events".into(),
@@ -7268,8 +7388,7 @@ mod tests {
         let source = request.source.postgres.as_ref().expect("postgres source");
         assert_eq!(source.r#type.as_ref().unwrap().to_string(), "rdspostgres");
         assert_eq!(source.authentication.to_string(), "IAM_ROLE");
-        assert_eq!(source.credentials.username, "iam-user");
-        assert_eq!(source.credentials.password, "iam-password");
+        assert_eq!(source.credentials, None);
         assert_eq!(source.host, "rds.example");
         assert_eq!(source.port, 65535);
         assert_eq!(source.database, "production");

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -905,11 +905,11 @@ pub struct PostgresCreateArgs {
     pub pg_database: String,
 
     /// Username (basic auth only; invalid with --auth IAM_ROLE)
-    #[arg(long, required_unless_present = "iam_role")]
+    #[arg(long, requires = "password")]
     pub username: Option<String>,
 
     /// Password (basic auth only; invalid with --auth IAM_ROLE)
-    #[arg(long, required_unless_present = "iam_role")]
+    #[arg(long, requires = "username")]
     pub password: Option<String>,
 
     /// Table mappings as schema.table:target_table (repeatable)
@@ -2869,7 +2869,9 @@ fn validate_postgres_create_args(
             "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic",
         ));
     }
-    // Clap enforces this for parsed input; hand-built args reach it here.
+    // clap joins --username and --password with `requires`, so half a pair is
+    // already a usage error; this owns the "basic auth needs the pair at all"
+    // rule, which clap cannot express because it depends on --auth's value.
     if args.auth == "basic" && (args.username.is_none() || args.password.is_none()) {
         return Err(CloudError::new(
             "--auth basic requires --username <USERNAME> and --password <PASSWORD>",
@@ -2939,7 +2941,8 @@ fn build_postgres_request(
     args: &PostgresCreateArgs,
 ) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostRequest> {
     use clickhouse_cloud_api::models::{
-        ClickPipeMutatePostgresSource, ClickPipePostRequest, ClickPipePostSource, PLAIN,
+        ClickPipeMutatePostgresSource, ClickPipeMutatePostgresSourceAuthentication,
+        ClickPipePostRequest, ClickPipePostSource, PLAIN,
     };
 
     let table_mappings = validate_postgres_create_args(args)?;
@@ -2948,16 +2951,28 @@ fn build_postgres_request(
         .as_deref()
         .map(std::fs::read_to_string)
         .transpose()?;
-    // `validate_postgres_create_args` has already tied the pair to the auth
-    // mode: basic auth has both flags, IAM_ROLE has neither. So the pair being
-    // absent means IAM_ROLE, where `iamRole` is the whole credential and the
-    // `credentials` object must stay off the wire entirely.
-    let credentials = match (args.username.as_deref(), args.password.as_deref()) {
-        (Some(username), Some(password)) => Some(PLAIN {
-            username: username.to_string(),
-            password: password.to_string(),
-        }),
-        _ => None,
+    // Match the parsed authentication mode, not the raw `--auth` string, so a
+    // new mode added to the library enum is a compile error here rather than a
+    // silent credential-less create.
+    let authentication: ClickPipeMutatePostgresSourceAuthentication = parse_enum(&args.auth)?;
+    let credentials = match &authentication {
+        // `validate_postgres_create_args` has already required the pair for
+        // basic auth, so `zip` yields `Some` for every invocation that reaches
+        // here.
+        ClickPipeMutatePostgresSourceAuthentication::Basic => args
+            .username
+            .as_deref()
+            .zip(args.password.as_deref())
+            .map(|(username, password)| PLAIN {
+                username: username.to_string(),
+                password: password.to_string(),
+            }),
+        // The role ARN is the whole credential: the `credentials` object must
+        // stay off the wire entirely.
+        ClickPipeMutatePostgresSourceAuthentication::IAM_ROLE => None,
+        // Unreachable for parsed input, since --auth is restricted to
+        // DB_AUTHS; an unknown mode has no credential shape to send.
+        ClickPipeMutatePostgresSourceAuthentication::Unknown(_) => None,
     };
     let source = ClickPipeMutatePostgresSource {
         r#type: Some(parse_enum(&args.postgres_type)?),
@@ -2967,7 +2982,7 @@ fn build_postgres_request(
         database: args.pg_database.clone(),
         disable_tls: false,
         skip_cert_verification: false,
-        authentication: parse_enum(&args.auth)?,
+        authentication,
         iam_role: args.iam_role.clone(),
         tls_host: args.tls_host.clone(),
         ca_certificate,
@@ -3750,17 +3765,18 @@ mod tests {
             "postgres.example",
             "--pg-database",
             "source-db",
-            "--username",
-            "user",
-            "--password",
-            "password",
             "--table-mapping",
             "public.events:events",
             flag,
             value,
         ];
+        // Each auth mode gets only its own credential flags: the CLI rejects
+        // --username/--password with IAM_ROLE, so pairing them here would
+        // assert an invocation the CLI refuses to run.
         if flag == "--auth" && value == "IAM_ROLE" {
             args.extend(["--iam-role", "arn:aws:iam::123456789012:role/clickpipe"]);
+        } else {
+            args.extend(["--username", "user", "--password", "password"]);
         }
         parse_clickpipe(&args);
     }
@@ -5402,7 +5418,77 @@ mod tests {
     }
 
     #[test]
+    fn postgres_iam_role_only_error_names_the_role_flag_and_not_the_pair() {
+        // --username/--password used to be `required_unless_present =
+        // "iam_role"`, so `--auth IAM_ROLE` on its own made clap demand all
+        // three flags, and following that advice landed on the "cannot be
+        // used with --auth IAM_ROLE" rejection. Only --iam-role is missing.
+        let args = vec![
+            "create",
+            "postgres",
+            "svc-1",
+            "--name",
+            "pipe-1",
+            "--host",
+            "postgres.example",
+            "--pg-database",
+            "source-db",
+            "--table-mapping",
+            "public.events:events",
+            "--auth",
+            "IAM_ROLE",
+        ];
+        let error = clickpipe_parse_error(&args);
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        let message = error.to_string();
+        assert!(message.contains("--iam-role"), "{message}");
+        assert!(!message.contains("--username"), "{message}");
+        assert!(!message.contains("--password"), "{message}");
+    }
+
+    #[test]
+    fn postgres_basic_auth_without_any_credentials_is_a_validation_error() {
+        // clap only pairs the two flags now, so neither being present parses
+        // cleanly and `validate_postgres_create_args` owns the basic-auth
+        // rule: it depends on --auth's value, which clap cannot express.
+        let args = vec![
+            "create",
+            "postgres",
+            "svc-1",
+            "--name",
+            "pipe-1",
+            "--host",
+            "postgres.example",
+            "--pg-database",
+            "source-db",
+            "--table-mapping",
+            "public.events:events",
+        ];
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::Postgres(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected postgres create");
+        };
+        assert_eq!(parsed.auth, "basic");
+        assert_eq!(parsed.username, None);
+        assert_eq!(parsed.password, None);
+
+        let command = parse_clickpipe(&args);
+        assert_eq!(
+            command.postgres_create_validation_error().as_deref(),
+            Some("--auth basic requires --username <USERNAME> and --password <PASSWORD>")
+        );
+    }
+
+    #[test]
     fn postgres_basic_auth_still_requires_username_and_password() {
+        // The two flags are joined with clap `requires`, the same pairing the
+        // Kafka credential flags use (issue #606), so half a pair is a usage
+        // error naming the missing half rather than the whole set.
         for omitted in ["--username", "--password"] {
             let args: Vec<&str> = [
                 "create",
@@ -5517,13 +5603,7 @@ mod tests {
             help.contains("--auth basic requires --username and --password"),
             "{help}"
         );
-        assert!(
-            help.contains(
-                "the role ARN is the whole
-  credential"
-            ),
-            "{help}"
-        );
+        assert!(help.contains("the role ARN is the whole"), "{help}");
         assert!(help.contains("silently ignored"), "{help}");
         assert!(help.contains("--replication-mode cdc_only"), "{help}");
         assert!(
@@ -5603,6 +5683,7 @@ mod tests {
             "https://clickhouse.com/docs/integrations/clickpipes/networking/static-ips",
             // IAM role authentication takes no username or password.
             "`--username` and `--password` are basic-auth only",
+            "must be given together",
             "no `credentials` object is sent",
             "--auth IAM_ROLE --iam-role \"$POSTGRES_IAM_ROLE_ARN\"",
         ] {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3344,6 +3344,38 @@ fn postgres_args_minimal() -> Vec<String> {
     .collect()
 }
 
+/// The minimal create argument set for IAM_ROLE authentication: no
+/// `--username`/`--password`, because the role ARN is the whole credential.
+fn postgres_args_iam_role() -> Vec<String> {
+    [
+        "clickpipe",
+        "create",
+        "postgres",
+        "svc-id",
+        "--name",
+        "t",
+        "--host",
+        "pg",
+        "--port",
+        "5432",
+        "--pg-database",
+        "test",
+        "--table-mapping",
+        "public.t:t",
+        "--replication-mode",
+        "cdc",
+        "--org-id",
+        "org",
+        "--auth",
+        "IAM_ROLE",
+        "--iam-role",
+        "arn:aws:iam::123:role/x",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
 #[tokio::test]
 async fn postgres_invalid_inputs_exit_as_usage_errors_before_auth_file_or_network() {
     let mock = MockServer::start().await;
@@ -3565,16 +3597,63 @@ async fn postgres_tls_host_serializes_when_provided() {
 #[tokio::test]
 async fn postgres_iam_role_serializes_when_provided() {
     let mock = start_mock_clickpipes_api().await;
-    let mut args = postgres_args_minimal();
-    args.push("--auth".into());
-    args.push("IAM_ROLE".into());
-    args.push("--iam-role".into());
-    args.push("arn:aws:iam::123:role/x".into());
+    let args = postgres_args_iam_role();
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let body = invoke_cli_capture_body(&mock, &arg_refs).await;
     assert_eq!(
         body["source"]["postgres"]["iamRole"], "arn:aws:iam::123:role/x",
         "iamRole should round-trip the user-provided value"
+    );
+    assert_eq!(body["source"]["postgres"]["authentication"], "IAM_ROLE");
+}
+
+#[tokio::test]
+async fn postgres_iam_role_create_omits_the_credentials_object() {
+    // IAM_ROLE authentication has no username or password: the role ARN is the
+    // whole credential, so `credentials` must be absent from the wire rather
+    // than sent as an empty username/password pair.
+    let mock = start_mock_clickpipes_api().await;
+    let args = postgres_args_iam_role();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+    assert!(
+        body["source"]["postgres"].get("credentials").is_none(),
+        "credentials must not be sent for IAM_ROLE auth, got {}",
+        body["source"]["postgres"]
+    );
+}
+
+#[tokio::test]
+async fn postgres_basic_auth_create_sends_the_credentials_object() {
+    let mock = start_mock_clickpipes_api().await;
+    let args = postgres_args_minimal();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+    assert_eq!(body["source"]["postgres"]["credentials"]["username"], "u");
+    assert_eq!(body["source"]["postgres"]["credentials"]["password"], "p");
+    assert_eq!(body["source"]["postgres"]["authentication"], "basic");
+}
+
+#[tokio::test]
+async fn postgres_credentials_with_iam_role_auth_are_rejected() {
+    let mock = MockServer::start().await;
+    let mut args = postgres_args_iam_role();
+    args.push("--username".into());
+    args.push("u".into());
+    args.push("--password".into());
+    args.push("p".into());
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let output = invoke_cli_with_cloud_credentials(&mock, &arg_refs);
+    // Reported as a usage error against the owning command, the same way
+    // `--iam-role` with basic auth is: clap cannot express "forbidden for this
+    // value of another argument", so the check runs after parsing.
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic"
+        ),
+        "{stderr}"
     );
 }
 


### PR DESCRIPTION
## What

`clickhousectl cloud clickpipe create postgres ... --auth IAM_ROLE --iam-role arn:...` failed before it ever reached the API, with clap reporting "the following required arguments were not provided: --username --password". IAM role authentication has no username or password, so an RDS or Aurora Postgres pipe could not be created at all.

Two layers forced the pair, and both are fixed:

- `PostgresCreateArgs.username` and `.password` are now `Option<String>` joined to each other with clap `requires`, so the pair is all-or-nothing and neither flag is conditionally required. Passing either one with `--auth IAM_ROLE` is now rejected instead of being silently dropped, mirroring the existing guard that rejects `--iam-role` with basic auth.
- `ClickPipeMutatePostgresSource.credentials` in the API library is now `Option<PLAIN>` with `skip_serializing_if`, so `build_postgres_request` can leave the `credentials` object off the wire entirely for IAM_ROLE instead of sending an empty username and password pair.

## Why the API library changed too

The CLI cannot omit a field the library models as non-`Option`. `credentials` was a bare `PLAIN`, so every Postgres pipe request carried a username and password whatever the auth mode said.

The vendored OpenAPI snapshot has no `required[]` array at all on `ClickPipeMutatePostgresSource`, so the analyzer resolves requiredness from the description convention and `credentials` (which has no description) reads as required. That is why the field needs an `optionality_exemptions` entry, sitting next to the `caCertificate`, `iamRole` and `tlsHost` entries that are in exactly the same position for exactly the same reason: an empty value fails server-side validation for sources that do not use the field. The spec documents `iamRole` as "required for IAM_ROLE authentication", and the sibling `ClickPipeMutateMySQLSource` schema does carry a `required[]` array which omits `credentials`, so MySQL already models it as `Option<PLAIN>`. This brings Postgres to the same shape. The exemption was verified to be load-bearing: removing it produces `FieldOptionalityMismatch [/components/schemas/ClickPipeMutatePostgresSource/properties/credentials]`.

## Behaviour after the fix

- `--auth IAM_ROLE --iam-role arn:...` with no credentials succeeds and sends a body with `iamRole` and no `credentials` key under `source.postgres`.
- `--auth basic` (the default) still requires both `--username` and `--password`, still a clap usage error listing the missing flag.
- `--auth IAM_ROLE` with `--username`/`--password` exits 2 with "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic", the same shape as the existing "--iam-role cannot be used with --auth basic; use --auth IAM_ROLE".
- Basic auth request bodies are unchanged.

Live acceptance of an omitted `credentials` object for an IAM_ROLE pipe was not tested, because it needs an RDS or Aurora fixture with an attached IAM role. The spec says the field is optional and MySQL already treats it that way. If the control plane turns out to require a placeholder object, that is a spec defect to raise upstream rather than something to model around here.

## Tests

- Library: `serialize_clickpipe_mutate_postgres_source_omits_absent_credentials` in `crates/clickhouse-cloud-api/tests/models_test.rs` asserts that `credentials: None` omits the key while `authentication` and `iamRole` still serialize, and that basic auth still sends the pair verbatim.
- Request builder: the maximal `build_postgres_request` test now uses IAM_ROLE with no credentials and asserts `credentials == None` plus `iam_role == Some(..)`; the minimal basic-auth test asserts the pair is unchanged.
- Clap: `postgres_iam_role_auth_does_not_require_username_or_password` covers IAM_ROLE parsing without credentials and the rejection of the pair; `postgres_basic_auth_still_requires_username_and_password` covers each flag being omitted under basic auth as a `MissingRequiredArgument` error.
- Help and README text pins updated in `postgres_help_documents_input_tls_and_source_requirements` and `readme_documents_postgres_tls_and_cdc_prerequisites`.
- Subprocess and wiremock in `crates/clickhousectl/tests/cli_request_shape_test.rs`: `postgres_iam_role_create_omits_the_credentials_object`, `postgres_basic_auth_create_sends_the_credentials_object`, and `postgres_credentials_with_iam_role_auth_are_rejected` (exit 2).

The credential flags are paired with clap `requires` rather than made conditionally required, matching the Kafka precedent from issue #606. `required_unless_present = "iam_role"` made `--auth IAM_ROLE` on its own demand `--username`, `--password` and `--iam-role` all at once, and following that advice then hit the "cannot be used with --auth IAM_ROLE" rejection. With the pairing, `--auth IAM_ROLE` alone names only `--iam-role`, half a pair names its missing half, and the basic-auth rule is owned by the `validate_postgres_create_args` check that was previously unreachable. Three tests cover this: `postgres_iam_role_only_error_names_the_role_flag_and_not_the_pair` asserts the IAM_ROLE-only usage error names `--iam-role` and mentions neither credential flag, `postgres_basic_auth_without_any_credentials_is_a_validation_error` asserts that omitting both flags under basic auth reaches the "--auth basic requires --username <USERNAME> and --password <PASSWORD>" message (previously uncovered), and `postgres_basic_auth_still_requires_username_and_password` keeps the half-pair cases as clap `MissingRequiredArgument` errors naming the omitted flag. `build_postgres_request` now matches exhaustively on the parsed `ClickPipeMutatePostgresSourceAuthentication` instead of comparing `--auth` as a string, so a new authentication mode in the library enum is a compile error here rather than a pipe created with no credentials.

`ClickPipePatchPostgresSource.credentials` is still a non-`Option` `PLAIN`; it has no construction site in the CLI, so it is left alone.

Verified with:

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings
cargo test -p clickhousectl
cargo test -p clickhouse-cloud-api --lib --test spec_coverage_test
cargo test -p clickhouse-cloud-api --test models_test
cargo check --workspace --all-features
python3 -m unittest discover -s scripts/tests -p 'test_*.py'
```

The same clap shape exists on `clickpipe create mysql`; that CLI-only follow-up is tracked as #670.

## Stacking

Part of a stacked PR chain: based on `fix/663-postgres-update-name`, not `main`.

Fixes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
