### PR TITLE
Summarise PEM certificates in human output instead of dumping the body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Local clap definitions live in `src/local/cli.rs`. Cloud clap definitions, handl
        print_human(&data)?;
    }
    ```
-   List views stay as `tabled` tables, and short action confirmations (e.g. "Service X starting") stay as plain `println!`.
+   List views stay as `tabled` tables, and short action confirmations (e.g. "Service X starting") stay as plain `println!`. Human output through `print_human` also summarises a PEM-framed string (a certificate, a key) instead of printing its body, so a hand-written `println!` line or a `tabled` cell bypasses that and dumps the whole PEM.
 
    Every field of a library response type is `Option` (see Request and response models), so never `unwrap()`/`expect()` one. Render absence with `crate::cloud::output::or_absent` (`-`) or `ABSENT` in `tabled` cells and plain output, and have `--filter`-style predicates treat an absent field as non-matching. `print_human` and `--json` serialize the model and need no per-field work.
 8. Add `Cli::try_parse_from` coverage next to the domain command definition for the new command's body-related flags, asserting parsed values.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tabled",
  "tar",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -1331,12 +1331,6 @@ clickhousectl cloud clickpipe schema-discover <service-id> pubsub \
 
 Add `--json` (or run as a coding agent) for machine-readable output.
 
-Human-readable output summarises any PEM certificate or key a pipe returns, such
-as `source.postgres.caCertificate`, as a one-line
-`<PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint AB:CD:...>` (the fingerprint
-`openssl x509 -fingerprint -sha256` prints for the first block) instead of
-printing the ~1.5 KB body; `--json` still returns the certificate verbatim.
-
 ### Members
 
 Role IDs used by member, invitation, and API-key commands currently come from the ClickHouse Cloud Console or API.
@@ -1389,6 +1383,8 @@ clickhousectl cloud --json service get <service-id>
 ```
 
 `clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, and any tool that sets the standard `AGENT` env var) and emits JSON to stdout automatically without setting `--json`. Protocol-oriented commands retain their natural output: `cloud org prometheus` and `cloud service prometheus` always emit raw Prometheus exposition text and silently ignore `--json`, `cloud service query` uses a ClickHouse format such as `JSONEachRow`, and Postgres runtime configuration is JSON already.
+
+Human-readable detail views (`cloud clickpipe get` and every other `get`-style command) never print PEM-framed material. Each well-formed PEM block in a value is replaced, where it stands, by a one-line summary of that block: `<PEM CERTIFICATE, SHA-256 fingerprint AB:CD:...>` for a certificate, certificate request or CRL, using the fingerprint `openssl x509 -fingerprint -sha256` prints for that block, and `<PEM EC PRIVATE KEY, 121 bytes>` for any other label, because a private key is reported by size and never fingerprinted. Text around the blocks, such as a bundle's header comments, is kept as it was. This affects human output only: `--json` still returns the value verbatim, and `cloud postgres certs get` deliberately still prints the raw PEM, since emitting the certificate is that command's purpose.
 
 Local runtime failures also use structured output when `local --json` is set or a coding agent is detected. The CLI writes exactly one error object to stderr and preserves the documented exit code:
 

--- a/README.md
+++ b/README.md
@@ -1331,6 +1331,12 @@ clickhousectl cloud clickpipe schema-discover <service-id> pubsub \
 
 Add `--json` (or run as a coding agent) for machine-readable output.
 
+Human-readable output summarises any PEM certificate or key a pipe returns, such
+as `source.postgres.caCertificate`, as a one-line
+`<PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint AB:CD:...>` (the fingerprint
+`openssl x509 -fingerprint -sha256` prints for the first block) instead of
+printing the ~1.5 KB body; `--json` still returns the certificate verbatim.
+
 ### Members
 
 Role IDs used by member, invitation, and API-key commands currently come from the ClickHouse Cloud Console or API.

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -54,6 +54,7 @@ crossterm = "0.29.0"
 rand = "0.10.1"
 dotenvy = "0.15.7"
 tempfile = "3.27.0"
+sha2 = "0.11.0"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -205,11 +205,111 @@ fn is_scalar(value: &Value) -> bool {
 
 fn scalar_string(value: &Value) -> Option<String> {
     match value {
-        Value::String(s) => Some(s.clone()),
+        // The single place a string scalar becomes human text, so eliding here
+        // covers object fields, nested objects and arrays of strings alike.
+        Value::String(s) => Some(pem_summary(s).unwrap_or_else(|| s.clone())),
         Value::Number(n) => Some(n.to_string()),
         Value::Bool(b) => Some(b.to_string()),
         _ => None,
     }
+}
+
+// ── PEM elision in human output (issue #665) ─────────────────────────────
+//
+// A Postgres ClickPipe's `source.postgres.caCertificate` is a whole PEM block:
+// roughly 1.5 KB of base64 that scrolls the rest of `clickpipe get` off the
+// screen while telling the reader nothing. Human output therefore renders a
+// PEM-framed string as a one-line summary. `--json` is untouched: it
+// serializes the model directly, so a caller that needs the certificate still
+// gets the bytes verbatim.
+//
+// The test is the value's *format*, not its key name. A client certificate, a
+// private key, or a certificate nested anywhere else in any response gets the
+// same treatment with no per-field allowlist to keep in sync, and a string
+// that merely happens to carry PEM framing is exactly what should be elided.
+
+/// The framing prefix that opens an RFC 7468 block.
+const PEM_BEGIN: &str = "-----BEGIN ";
+/// The five-dash run that closes a framing line and opens an `END` marker.
+const PEM_DASHES: &str = "-----";
+
+/// One RFC 7468 block: its label and the raw text between the framing lines.
+struct PemBlock<'a> {
+    label: &'a str,
+    body: &'a str,
+}
+
+/// Split `text` into the RFC 7468 blocks it contains, stopping at the first
+/// unterminated or unlabelled frame. Only well-formed `BEGIN`/`END` pairs with
+/// matching labels count as blocks.
+fn pem_blocks(text: &str) -> Vec<PemBlock<'_>> {
+    let mut blocks = Vec::new();
+    let mut rest = text;
+    while let Some(begin) = rest.find(PEM_BEGIN) {
+        let after_begin = &rest[begin + PEM_BEGIN.len()..];
+        let Some(label_len) = after_begin.find(PEM_DASHES) else {
+            break;
+        };
+        let label = &after_begin[..label_len];
+        if label.is_empty() {
+            break;
+        }
+        let after_label = &after_begin[label_len + PEM_DASHES.len()..];
+        let end_marker = format!("-----END {label}-----");
+        let Some(body_len) = after_label.find(&end_marker) else {
+            break;
+        };
+        blocks.push(PemBlock {
+            label,
+            body: &after_label[..body_len],
+        });
+        rest = &after_label[body_len + end_marker.len()..];
+    }
+    blocks
+}
+
+/// Decode a block body to its DER bytes, or `None` when the base64 is not
+/// decodable (an encrypted key with RFC 1421 headers, a truncated paste).
+fn pem_body_der(body: &str) -> Option<Vec<u8>> {
+    let base64: String = body.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+    let der = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &base64).ok()?;
+    if der.is_empty() { None } else { Some(der) }
+}
+
+/// SHA-256 of `der` as colon-separated uppercase hex, the form
+/// `openssl x509 -fingerprint -sha256` prints.
+fn sha256_fingerprint(der: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(der)
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Summarize a PEM text for human output, or return `None` when `value` is not
+/// PEM and should be printed as-is.
+///
+/// The body is never part of the result. The fingerprint identifies the *first*
+/// block, which is the leaf certificate of a chain; when that block's base64
+/// does not decode the summary reports the text's size instead, so the value is
+/// still accounted for without printing it.
+fn pem_summary(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if !trimmed.starts_with(PEM_BEGIN) {
+        return None;
+    }
+    let blocks = pem_blocks(trimmed);
+    let first = blocks.first()?;
+    let count = blocks.len();
+    let label = first.label;
+    Some(match pem_body_der(first.body) {
+        Some(der) => format!(
+            "<PEM: {count} {label} block(s), SHA-256 fingerprint {}>",
+            sha256_fingerprint(&der)
+        ),
+        None => format!("<PEM: {count} {label} block(s), {} bytes>", trimmed.len()),
+    })
 }
 
 /// Render any value at `indent`. The first line emitted (if any) is the natural
@@ -457,6 +557,154 @@ mod tests {
                 }
             })
         );
+    }
+
+    // ── PEM elision (issue #665) ───────────────────────────────────────────
+
+    /// A real self-signed EC certificate. Its SHA-256 fingerprint below was
+    /// taken from `openssl x509 -fingerprint -sha256`, so the assertion pins
+    /// the CLI's output against the tool a user would reach for to check it.
+    const PEM_FIXTURE: &str = "\
+-----BEGIN CERTIFICATE-----
+MIIBjDCCATOgAwIBAgIUajES1wl65zexYYPuWX8ShldYw4YwCgYIKoZIzj0EAwIw
+HDEaMBgGA1UEAwwRY2hjdGwtcGVtLWZpeHR1cmUwHhcNMjYwOTAyMTc1NDI3WhcN
+NDYwODI4MTc1NDI3WjAcMRowGAYDVQQDDBFjaGN0bC1wZW0tZml4dHVyZTBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABNTPygUG2umVvTqod5jJXCgp1o9qwrx2wLf7
+p+2PyHYm5ZdIS+kqT25Xm2SGM3th4dB43l3fd5kF0g6CzvGNt42jUzBRMB0GA1Ud
+DgQWBBQcL9JNezOJ8vzT0lR1Pj4sMoH2STAfBgNVHSMEGDAWgBQcL9JNezOJ8vzT
+0lR1Pj4sMoH2STAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIAhv
+iLjfMqcnJ10gmKoyEIMDDRJP2UwtGRcJZU/FnaIEAiBeUmN+nJBGIq0tFHIxz1Xl
+LaBMf6qZANMrXRQaETxhIA==
+-----END CERTIFICATE-----
+";
+
+    /// `openssl x509 -in fixture.crt -noout -fingerprint -sha256`.
+    const PEM_FIXTURE_FINGERPRINT: &str = "5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8";
+
+    /// A distinctive run from the middle of the fixture's base64 body: if this
+    /// ever appears in human output, the certificate was not elided.
+    const PEM_FIXTURE_BODY_MARKER: &str =
+        "ByqGSM49AgEGCCqGSM49AwEHA0IABNTPygUG2umVvTqod5jJXCgp1o9qwrx2wLf7";
+
+    #[test]
+    fn pem_summary_reports_count_label_and_openssl_fingerprint() {
+        assert_eq!(
+            pem_summary(PEM_FIXTURE).unwrap(),
+            format!("<PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>")
+        );
+    }
+
+    #[test]
+    fn pem_summary_never_contains_the_body() {
+        let summary = pem_summary(PEM_FIXTURE).unwrap();
+        assert!(
+            !summary.contains(PEM_FIXTURE_BODY_MARKER),
+            "body leaked: {summary}"
+        );
+        assert!(!summary.contains("-----BEGIN"), "framing leaked: {summary}");
+    }
+
+    #[test]
+    fn pem_summary_counts_concatenated_blocks_and_fingerprints_the_first() {
+        // A chain: leaf then issuer. The count reports both, the fingerprint
+        // identifies the leaf.
+        let chain = format!("{PEM_FIXTURE}{PEM_FIXTURE}");
+        assert_eq!(
+            pem_summary(&chain).unwrap(),
+            format!("<PEM: 2 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>")
+        );
+    }
+
+    #[test]
+    fn pem_summary_uses_the_blocks_own_label() {
+        // Elision is not certificate-specific: a private key that somehow
+        // reached human output is summarized the same way, body withheld.
+        // `AQIDBA==` is the four bytes 01 02 03 04; the fingerprint is their
+        // SHA-256, so the expected hex is a constant.
+        let key = "-----BEGIN PRIVATE KEY-----\nAQIDBA==\n-----END PRIVATE KEY-----";
+        const FINGERPRINT_OF_01020304: &str = "9F:64:A7:47:E1:B9:7F:13:1F:AB:B6:B4:47:29:6C:9B:6F:02:01:E7:9F:B3:C5:35:6E:6C:77:E8:9B:6A:80:6A";
+        assert_eq!(
+            pem_summary(key).unwrap(),
+            format!("<PEM: 1 PRIVATE KEY block(s), SHA-256 fingerprint {FINGERPRINT_OF_01020304}>")
+        );
+    }
+
+    #[test]
+    fn pem_summary_tolerates_surrounding_whitespace() {
+        let padded = format!("\n  {}\n\n", PEM_FIXTURE.trim());
+        assert!(
+            pem_summary(&padded)
+                .unwrap()
+                .starts_with("<PEM: 1 CERTIFICATE block(s),")
+        );
+    }
+
+    #[test]
+    fn pem_summary_falls_back_to_a_byte_count_when_the_body_is_not_base64() {
+        let broken = "-----BEGIN CERTIFICATE-----\n**not base64**\n-----END CERTIFICATE-----";
+        assert_eq!(broken.len(), 68);
+        assert_eq!(
+            pem_summary(broken).unwrap(),
+            "<PEM: 1 CERTIFICATE block(s), 68 bytes>"
+        );
+    }
+
+    #[test]
+    fn pem_summary_leaves_non_pem_strings_alone() {
+        for value in [
+            "",
+            "running",
+            "us-east-1",
+            // Framing that never closes is not a block.
+            "-----BEGIN CERTIFICATE-----\nAQIDBA==\n",
+            // A mismatched END label does not close the BEGIN.
+            "-----BEGIN CERTIFICATE-----\nAQIDBA==\n-----END PRIVATE KEY-----",
+            // An unlabelled frame is not a block.
+            "-----BEGIN -----\nAQIDBA==\n-----END -----",
+            // PEM further in is not the value's format; only a leading frame
+            // makes the whole string a certificate.
+            "see attached: -----BEGIN CERTIFICATE-----\nAQIDBA==\n-----END CERTIFICATE-----",
+        ] {
+            assert_eq!(pem_summary(value), None, "unexpectedly elided {value:?}");
+        }
+    }
+
+    #[test]
+    fn render_elides_a_certificate_field_and_keeps_its_siblings() {
+        let v = json!({
+            "source": {
+                "postgres": {
+                    "host": "db.example.com",
+                    "caCertificate": PEM_FIXTURE,
+                    "database": "postgres",
+                }
+            }
+        });
+        let rendered = render_to_string(&v);
+        assert_eq!(
+            rendered,
+            format!(
+                "source:\n  postgres:\n    host: db.example.com\n    caCertificate: <PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>\n    database: postgres"
+            )
+        );
+        assert!(
+            !rendered.contains("-----BEGIN"),
+            "certificate body rendered: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_elides_certificates_inside_arrays_and_bullets() {
+        let v = json!({
+            "trustChain": [PEM_FIXTURE, PEM_FIXTURE],
+            "endpoints": [{ "clientCertificate": PEM_FIXTURE }],
+        });
+        let rendered = render_to_string(&v);
+        assert!(
+            !rendered.contains("-----BEGIN"),
+            "body rendered: {rendered}"
+        );
+        assert_eq!(rendered.matches("<PEM: 1 CERTIFICATE block(s)").count(), 3);
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -205,8 +205,9 @@ fn is_scalar(value: &Value) -> bool {
 
 fn scalar_string(value: &Value) -> Option<String> {
     match value {
-        // The single place a string scalar becomes human text, so eliding here
-        // covers object fields, nested objects and arrays of strings alike.
+        // The single place a string scalar becomes human text, so summarizing
+        // PEM here covers object fields, nested objects and arrays of strings
+        // alike.
         Value::String(s) => Some(pem_summary(s).unwrap_or_else(|| s.clone())),
         Value::Number(n) => Some(n.to_string()),
         Value::Bool(b) => Some(b.to_string()),
@@ -214,56 +215,109 @@ fn scalar_string(value: &Value) -> Option<String> {
     }
 }
 
-// ── PEM elision in human output (issue #665) ─────────────────────────────
+// ── PEM summaries in human output (issue #665) ────────────────────────────
 //
 // A Postgres ClickPipe's `source.postgres.caCertificate` is a whole PEM block:
 // roughly 1.5 KB of base64 that scrolls the rest of `clickpipe get` off the
-// screen while telling the reader nothing. Human output therefore renders a
-// PEM-framed string as a one-line summary. `--json` is untouched: it
-// serializes the model directly, so a caller that needs the certificate still
-// gets the bytes verbatim.
+// screen while telling the reader nothing. Human output therefore replaces
+// every well-formed RFC 7468 block *in place* with a one-line summary of that
+// block, keeping whatever text surrounds it — a bundle's header comments, an
+// `openssl x509 -text` dump, prose between two blocks — so nothing the value
+// carried is silently dropped. `--json` is untouched: it serializes the model
+// directly, so a caller that needs the certificate still gets the bytes
+// verbatim.
 //
 // The test is the value's *format*, not its key name. A client certificate, a
 // private key, or a certificate nested anywhere else in any response gets the
-// same treatment with no per-field allowlist to keep in sync, and a string
-// that merely happens to carry PEM framing is exactly what should be elided.
+// same treatment with no per-field allowlist to keep in sync.
 
 /// The framing prefix that opens an RFC 7468 block.
 const PEM_BEGIN: &str = "-----BEGIN ";
-/// The five-dash run that closes a framing line and opens an `END` marker.
+/// The five-dash run that opens and closes every framing line.
 const PEM_DASHES: &str = "-----";
+/// The longest label treated as a label. RFC 7468 sets no limit; this one, with
+/// [`is_pem_label`], bounds how much of its own text a hostile value can paste
+/// into a summary line.
+const PEM_LABEL_MAX_LEN: usize = 64;
+/// The labels whose body is an X.509 structure, and so the only labels this
+/// module fingerprints: the digest is the one `openssl x509`, `openssl req` or
+/// `openssl crl` prints with `-fingerprint -sha256`, so a reader can check the
+/// value against the file they hold. Every other label — a private key above
+/// all — is reported by size only. A stable identifier of secret material left
+/// in scrollback is not something any caller needs.
+const PEM_CERTIFICATE_LABELS: &[&str] = &[
+    "CERTIFICATE",
+    "TRUSTED CERTIFICATE",
+    "CERTIFICATE REQUEST",
+    "NEW CERTIFICATE REQUEST",
+    "X509 CRL",
+];
 
-/// One RFC 7468 block: its label and the raw text between the framing lines.
+/// One well-formed RFC 7468 block found inside a string.
 struct PemBlock<'a> {
+    /// Byte range of the whole block, both framing lines included, in the
+    /// string it was found in. Summarizing substitutes over exactly this span.
+    span: std::ops::Range<usize>,
     label: &'a str,
+    /// The raw text between the framing lines, base64 and any line breaks or
+    /// RFC 1421 headers included. Never printed.
     body: &'a str,
 }
 
-/// Split `text` into the RFC 7468 blocks it contains, stopping at the first
-/// unterminated or unlabelled frame. Only well-formed `BEGIN`/`END` pairs with
-/// matching labels count as blocks.
+/// RFC 7468 section 3's `label`, tightened for terminal output.
+///
+/// The grammar is `label = [ labelchar *( ["-" / SP ] labelchar ) ]` with
+/// `labelchar = %x21-2C / %x2E-7E`: printable ASCII except the hyphen-minus the
+/// framing itself is made of, with single hyphens and spaces allowed between
+/// label characters. This accepts exactly that character set, rejects the empty
+/// label the grammar permits, rejects a leading or trailing hyphen or space,
+/// and caps the length.
+///
+/// The label is the one part of a block that reaches the summary line, so the
+/// bound matters: a value carrying a newline, a control character, an ANSI
+/// escape, non-ASCII bytes or a kilobyte of text where a label belongs is not a
+/// block at all, and the string is then printed unchanged as it always was.
+fn is_pem_label(label: &str) -> bool {
+    !label.is_empty()
+        && label.len() <= PEM_LABEL_MAX_LEN
+        && label.chars().all(|c| c == ' ' || c.is_ascii_graphic())
+        && !label.starts_with([' ', '-'])
+        && !label.ends_with([' ', '-'])
+}
+
+/// Find every well-formed RFC 7468 block in `text`, in order.
+///
+/// A block is a `BEGIN` frame with a valid label followed by an `END` frame
+/// carrying the same label. A frame that fails either test is not a block: the
+/// scan steps past that `-----BEGIN ` and keeps looking, so one malformed frame
+/// cannot hide the blocks after it.
 fn pem_blocks(text: &str) -> Vec<PemBlock<'_>> {
     let mut blocks = Vec::new();
-    let mut rest = text;
-    while let Some(begin) = rest.find(PEM_BEGIN) {
-        let after_begin = &rest[begin + PEM_BEGIN.len()..];
-        let Some(label_len) = after_begin.find(PEM_DASHES) else {
-            break;
+    let mut cursor = 0;
+    while let Some(offset) = text[cursor..].find(PEM_BEGIN) {
+        let begin = cursor + offset;
+        let label_start = begin + PEM_BEGIN.len();
+        // Whatever this frame turns out to be, never look at it again.
+        cursor = label_start;
+        let Some(label_len) = text[label_start..].find(PEM_DASHES) else {
+            continue;
         };
-        let label = &after_begin[..label_len];
-        if label.is_empty() {
-            break;
+        let label = &text[label_start..label_start + label_len];
+        if !is_pem_label(label) {
+            continue;
         }
-        let after_label = &after_begin[label_len + PEM_DASHES.len()..];
-        let end_marker = format!("-----END {label}-----");
-        let Some(body_len) = after_label.find(&end_marker) else {
-            break;
+        let body_start = label_start + label_len + PEM_DASHES.len();
+        let end_marker = format!("{PEM_DASHES}END {label}{PEM_DASHES}");
+        let Some(body_len) = text[body_start..].find(&end_marker) else {
+            continue;
         };
+        let body_end = body_start + body_len;
         blocks.push(PemBlock {
+            span: begin..body_end + end_marker.len(),
             label,
-            body: &after_label[..body_len],
+            body: &text[body_start..body_end],
         });
-        rest = &after_label[body_len + end_marker.len()..];
+        cursor = body_end + end_marker.len();
     }
     blocks
 }
@@ -287,29 +341,65 @@ fn sha256_fingerprint(der: &[u8]) -> String {
         .join(":")
 }
 
-/// Summarize a PEM text for human output, or return `None` when `value` is not
-/// PEM and should be printed as-is.
+/// Summarize one block as `<PEM {label}, …>`.
 ///
-/// The body is never part of the result. The fingerprint identifies the *first*
-/// block, which is the leaf certificate of a chain; when that block's base64
-/// does not decode the summary reports the text's size instead, so the value is
-/// still accounted for without printing it.
+/// A certificate-family block is identified by the SHA-256 fingerprint of its
+/// own DER, so each block of a bundle is checkable on its own terms and a
+/// mixed bundle never mislabels one block with another's label. Anything else,
+/// and a certificate whose base64 does not decode, is reported as the size of
+/// the block's body text. The body itself is never part of the result.
+fn pem_block_summary(block: &PemBlock<'_>) -> String {
+    let label = block.label;
+    if PEM_CERTIFICATE_LABELS.contains(&label)
+        && let Some(der) = pem_body_der(block.body)
+    {
+        return format!(
+            "<PEM {label}, SHA-256 fingerprint {}>",
+            sha256_fingerprint(&der)
+        );
+    }
+    format!("<PEM {label}, {} bytes>", block.body.len())
+}
+
+/// Whether `blocks` account for all of `value` apart from whitespace.
+fn pem_blocks_are_the_whole_value(value: &str, blocks: &[PemBlock<'_>]) -> bool {
+    let mut cursor = 0;
+    for block in blocks {
+        if !value[cursor..block.span.start].trim().is_empty() {
+            return false;
+        }
+        cursor = block.span.end;
+    }
+    value[cursor..].trim().is_empty()
+}
+
+/// Summarize the PEM blocks in `value` for human output, or return `None` when
+/// `value` holds no well-formed block and should be printed as-is.
+///
+/// A value that is nothing but blocks and whitespace — the common case, a
+/// single certificate or a chain — becomes one line of comma-separated
+/// summaries. Any other value keeps its text and has each block replaced where
+/// it stood, since text a bundle carries around its blocks (a `cacert.pem`
+/// header, an `openssl x509 -text` dump, a byte-order mark) is the reader's to
+/// keep and rendered as-is before this existed.
 fn pem_summary(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    if !trimmed.starts_with(PEM_BEGIN) {
+    let blocks = pem_blocks(value);
+    if blocks.is_empty() {
         return None;
     }
-    let blocks = pem_blocks(trimmed);
-    let first = blocks.first()?;
-    let count = blocks.len();
-    let label = first.label;
-    Some(match pem_body_der(first.body) {
-        Some(der) => format!(
-            "<PEM: {count} {label} block(s), SHA-256 fingerprint {}>",
-            sha256_fingerprint(&der)
-        ),
-        None => format!("<PEM: {count} {label} block(s), {} bytes>", trimmed.len()),
-    })
+    let summaries = blocks.iter().map(pem_block_summary);
+    if pem_blocks_are_the_whole_value(value, &blocks) {
+        return Some(summaries.collect::<Vec<_>>().join(", "));
+    }
+    let mut summarized = String::new();
+    let mut cursor = 0;
+    for (block, summary) in blocks.iter().zip(summaries) {
+        summarized.push_str(&value[cursor..block.span.start]);
+        summarized.push_str(&summary);
+        cursor = block.span.end;
+    }
+    summarized.push_str(&value[cursor..]);
+    Some(summarized)
 }
 
 /// Render any value at `indent`. The first line emitted (if any) is the natural
@@ -559,7 +649,7 @@ mod tests {
         );
     }
 
-    // ── PEM elision (issue #665) ───────────────────────────────────────────
+    // ── PEM summaries (issue #665) ─────────────────────────────────────────
 
     /// A real self-signed EC certificate. Its SHA-256 fingerprint below was
     /// taken from `openssl x509 -fingerprint -sha256`, so the assertion pins
@@ -582,16 +672,25 @@ LaBMf6qZANMrXRQaETxhIA==
     const PEM_FIXTURE_FINGERPRINT: &str = "5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8";
 
     /// A distinctive run from the middle of the fixture's base64 body: if this
-    /// ever appears in human output, the certificate was not elided.
+    /// ever appears in human output, the certificate was not summarized.
     const PEM_FIXTURE_BODY_MARKER: &str =
         "ByqGSM49AgEGCCqGSM49AwEHA0IABNTPygUG2umVvTqod5jJXCgp1o9qwrx2wLf7";
 
+    /// A private key over the four bytes `01 02 03 04`, whose SHA-256 is the
+    /// constant below. Its presence in a summary would mean a key was
+    /// fingerprinted.
+    const PEM_KEY_FIXTURE: &str =
+        "-----BEGIN EC PRIVATE KEY-----\nAQIDBA==\n-----END EC PRIVATE KEY-----\n";
+    const FINGERPRINT_OF_01020304: &str = "9F:64:A7:47:E1:B9:7F:13:1F:AB:B6:B4:47:29:6C:9B:6F:02:01:E7:9F:B3:C5:35:6E:6C:77:E8:9B:6A:80:6A";
+
+    /// The summary [`PEM_FIXTURE`] renders as, wherever it appears.
+    fn fixture_summary() -> String {
+        format!("<PEM CERTIFICATE, SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>")
+    }
+
     #[test]
-    fn pem_summary_reports_count_label_and_openssl_fingerprint() {
-        assert_eq!(
-            pem_summary(PEM_FIXTURE).unwrap(),
-            format!("<PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>")
-        );
+    fn pem_summary_reports_the_label_and_the_openssl_fingerprint() {
+        assert_eq!(pem_summary(PEM_FIXTURE).unwrap(), fixture_summary());
     }
 
     #[test]
@@ -601,52 +700,132 @@ LaBMf6qZANMrXRQaETxhIA==
             !summary.contains(PEM_FIXTURE_BODY_MARKER),
             "body leaked: {summary}"
         );
-        assert!(!summary.contains("-----BEGIN"), "framing leaked: {summary}");
+        assert!(!summary.contains(PEM_DASHES), "framing leaked: {summary}");
     }
 
     #[test]
-    fn pem_summary_counts_concatenated_blocks_and_fingerprints_the_first() {
-        // A chain: leaf then issuer. The count reports both, the fingerprint
-        // identifies the leaf.
-        let chain = format!("{PEM_FIXTURE}{PEM_FIXTURE}");
+    fn pem_summary_puts_a_whitespace_separated_chain_on_one_line() {
+        // The common case: nothing but blocks, so the reader gets one line
+        // with one summary per certificate of the chain.
+        let chain = format!("{PEM_FIXTURE}\n{PEM_FIXTURE}\n{PEM_FIXTURE}");
+        let summary = pem_summary(&chain).unwrap();
+        let expected = fixture_summary();
+        assert_eq!(summary, format!("{expected}, {expected}, {expected}"));
+        assert!(!summary.contains('\n'), "chain spans lines: {summary}");
+    }
+
+    #[test]
+    fn pem_summary_never_fingerprints_a_key_in_a_mixed_bundle() {
+        // Each block is summarized on its own terms: the certificate by its
+        // own fingerprint, the key by size and never by digest.
+        let bundle = format!("{PEM_FIXTURE}{PEM_KEY_FIXTURE}");
+        let summary = pem_summary(&bundle).unwrap();
         assert_eq!(
-            pem_summary(&chain).unwrap(),
-            format!("<PEM: 2 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>")
+            summary,
+            format!("{}, <PEM EC PRIVATE KEY, 10 bytes>", fixture_summary())
+        );
+        assert!(
+            !summary.contains(FINGERPRINT_OF_01020304),
+            "the key was fingerprinted: {summary}"
         );
     }
 
     #[test]
-    fn pem_summary_uses_the_blocks_own_label() {
-        // Elision is not certificate-specific: a private key that somehow
-        // reached human output is summarized the same way, body withheld.
-        // `AQIDBA==` is the four bytes 01 02 03 04; the fingerprint is their
-        // SHA-256, so the expected hex is a constant.
-        let key = "-----BEGIN PRIVATE KEY-----\nAQIDBA==\n-----END PRIVATE KEY-----";
-        const FINGERPRINT_OF_01020304: &str = "9F:64:A7:47:E1:B9:7F:13:1F:AB:B6:B4:47:29:6C:9B:6F:02:01:E7:9F:B3:C5:35:6E:6C:77:E8:9B:6A:80:6A";
-        assert_eq!(
-            pem_summary(key).unwrap(),
-            format!("<PEM: 1 PRIVATE KEY block(s), SHA-256 fingerprint {FINGERPRINT_OF_01020304}>")
+    fn pem_summary_keeps_text_before_a_block() {
+        // A `cacert.pem`-style bundle: header comments, then the block. The
+        // comments are the reader's to keep; only the block is summarized.
+        let bundle = format!(
+            "## Bundle of CA Root Certificates\n## Certificate data from Mozilla\n\n{PEM_FIXTURE}"
         );
+        assert_eq!(
+            pem_summary(&bundle).unwrap(),
+            format!(
+                "## Bundle of CA Root Certificates\n## Certificate data from Mozilla\n\n{}\n",
+                fixture_summary()
+            )
+        );
+    }
+
+    #[test]
+    fn pem_summary_keeps_text_between_two_blocks() {
+        let bundle = format!(
+            "{}\nissued by the internal CA\n{}\n",
+            PEM_FIXTURE.trim(),
+            PEM_FIXTURE.trim()
+        );
+        let expected = fixture_summary();
+        assert_eq!(
+            pem_summary(&bundle).unwrap(),
+            format!("{expected}\nissued by the internal CA\n{expected}\n")
+        );
+    }
+
+    #[test]
+    fn pem_summary_keeps_a_byte_order_mark() {
+        // A BOM is not whitespace, so the value is not blocks-only: the mark
+        // survives and the block is still summarized where it stood.
+        let bom_prefixed = format!("\u{feff}{PEM_FIXTURE}");
+        assert_eq!(
+            pem_summary(&bom_prefixed).unwrap(),
+            format!("\u{feff}{}\n", fixture_summary())
+        );
+    }
+
+    #[test]
+    fn a_frame_whose_label_is_not_a_label_is_not_a_block() {
+        // The label is the only part of a block that reaches the summary line.
+        // A newline, a control character or an unbounded run of text where a
+        // label belongs must not produce a summary at all: no synthesized
+        // line, nothing of the value's own injected into one.
+        let long_label = "A".repeat(200);
+        for value in [
+            "-----BEGIN CERTIFICATE\nx-----\nAQIDBA==\n-----END CERTIFICATE\nx-----".to_string(),
+            "-----BEGIN \u{1b}[31mCERTIFICATE-----\nAQIDBA==\n-----END \u{1b}[31mCERTIFICATE-----"
+                .to_string(),
+            format!("-----BEGIN {long_label}-----\nAQIDBA==\n-----END {long_label}-----"),
+        ] {
+            assert_eq!(
+                pem_summary(&value),
+                None,
+                "unexpectedly summarized {value:?}"
+            );
+            let rendered = render_to_string(&json!({ "caCertificate": value }));
+            assert!(
+                !rendered.contains("<PEM"),
+                "synthesized a summary: {rendered}"
+            );
+            assert_eq!(rendered, format!("caCertificate: {value}"));
+        }
+    }
+
+    #[test]
+    fn pem_summary_handles_crlf_line_endings() {
+        let crlf = PEM_FIXTURE.replace('\n', "\r\n");
+        assert_eq!(pem_summary(&crlf).unwrap(), fixture_summary());
     }
 
     #[test]
     fn pem_summary_tolerates_surrounding_whitespace() {
         let padded = format!("\n  {}\n\n", PEM_FIXTURE.trim());
-        assert!(
-            pem_summary(&padded)
-                .unwrap()
-                .starts_with("<PEM: 1 CERTIFICATE block(s),")
-        );
+        assert_eq!(pem_summary(&padded).unwrap(), fixture_summary());
     }
 
     #[test]
     fn pem_summary_falls_back_to_a_byte_count_when_the_body_is_not_base64() {
         let broken = "-----BEGIN CERTIFICATE-----\n**not base64**\n-----END CERTIFICATE-----";
-        assert_eq!(broken.len(), 68);
-        assert_eq!(
-            pem_summary(broken).unwrap(),
-            "<PEM: 1 CERTIFICATE block(s), 68 bytes>"
-        );
+        assert_eq!(pem_summary(broken).unwrap(), "<PEM CERTIFICATE, 16 bytes>");
+    }
+
+    #[test]
+    fn pem_summary_reports_rfc_1421_headers_as_a_byte_count_only() {
+        // An encrypted key carries `Proc-Type`/`DEK-Info` headers before the
+        // base64, so the body does not decode. The count stands in for it and
+        // no header text reaches the summary.
+        let encrypted = "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,0123456789ABCDEF\n\nAQIDBA==\n-----END RSA PRIVATE KEY-----";
+        let summary = pem_summary(encrypted).unwrap();
+        assert_eq!(summary, "<PEM RSA PRIVATE KEY, 73 bytes>");
+        assert!(!summary.contains("Proc-Type"), "header leaked: {summary}");
+        assert!(!summary.contains("DEK-Info"), "header leaked: {summary}");
     }
 
     #[test]
@@ -661,16 +840,19 @@ LaBMf6qZANMrXRQaETxhIA==
             "-----BEGIN CERTIFICATE-----\nAQIDBA==\n-----END PRIVATE KEY-----",
             // An unlabelled frame is not a block.
             "-----BEGIN -----\nAQIDBA==\n-----END -----",
-            // PEM further in is not the value's format; only a leading frame
-            // makes the whole string a certificate.
-            "see attached: -----BEGIN CERTIFICATE-----\nAQIDBA==\n-----END CERTIFICATE-----",
+            // No space after `BEGIN`, so there is no frame at all.
+            "-----BEGIN-----\nAQIDBA==\n-----END-----",
         ] {
-            assert_eq!(pem_summary(value), None, "unexpectedly elided {value:?}");
+            assert_eq!(
+                pem_summary(value),
+                None,
+                "unexpectedly summarized {value:?}"
+            );
         }
     }
 
     #[test]
-    fn render_elides_a_certificate_field_and_keeps_its_siblings() {
+    fn render_summarizes_a_certificate_field_and_keeps_its_siblings() {
         let v = json!({
             "source": {
                 "postgres": {
@@ -684,27 +866,25 @@ LaBMf6qZANMrXRQaETxhIA==
         assert_eq!(
             rendered,
             format!(
-                "source:\n  postgres:\n    host: db.example.com\n    caCertificate: <PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint {PEM_FIXTURE_FINGERPRINT}>\n    database: postgres"
+                "source:\n  postgres:\n    host: db.example.com\n    caCertificate: {}\n    database: postgres",
+                fixture_summary()
             )
         );
         assert!(
-            !rendered.contains("-----BEGIN"),
+            !rendered.contains(PEM_BEGIN),
             "certificate body rendered: {rendered}"
         );
     }
 
     #[test]
-    fn render_elides_certificates_inside_arrays_and_bullets() {
+    fn render_summarizes_certificates_inside_arrays_and_bullets() {
         let v = json!({
             "trustChain": [PEM_FIXTURE, PEM_FIXTURE],
             "endpoints": [{ "clientCertificate": PEM_FIXTURE }],
         });
         let rendered = render_to_string(&v);
-        assert!(
-            !rendered.contains("-----BEGIN"),
-            "body rendered: {rendered}"
-        );
-        assert_eq!(rendered.matches("<PEM: 1 CERTIFICATE block(s)").count(), 3);
+        assert!(!rendered.contains(PEM_BEGIN), "body rendered: {rendered}");
+        assert_eq!(rendered.matches(&fixture_summary()).count(), 3);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -11663,3 +11663,89 @@ async fn reverse_private_endpoint_help_explains_how_pipes_reference_it() {
     assert!(help.contains("reached the Ready status"), "{help}");
     assert!(help.contains("PendingAcceptance"), "{help}");
 }
+
+// ── PEM certificates are elided from human output (issue #665) ─────────────
+//
+// A Postgres ClickPipe's `source.postgres.caCertificate` is a whole PEM block.
+// Rendered verbatim it pushed every other field of `clickpipe get` off the
+// screen. Human output summarizes it; `--json` still carries the bytes, so a
+// caller that needs the certificate has not lost anything.
+
+/// A real self-signed EC certificate, the same fixture the `cloud::output`
+/// unit tests use. The fingerprint came from
+/// `openssl x509 -noout -fingerprint -sha256`.
+const CA_CERTIFICATE_PEM: &str = "\
+-----BEGIN CERTIFICATE-----
+MIIBjDCCATOgAwIBAgIUajES1wl65zexYYPuWX8ShldYw4YwCgYIKoZIzj0EAwIw
+HDEaMBgGA1UEAwwRY2hjdGwtcGVtLWZpeHR1cmUwHhcNMjYwOTAyMTc1NDI3WhcN
+NDYwODI4MTc1NDI3WjAcMRowGAYDVQQDDBFjaGN0bC1wZW0tZml4dHVyZTBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABNTPygUG2umVvTqod5jJXCgp1o9qwrx2wLf7
+p+2PyHYm5ZdIS+kqT25Xm2SGM3th4dB43l3fd5kF0g6CzvGNt42jUzBRMB0GA1Ud
+DgQWBBQcL9JNezOJ8vzT0lR1Pj4sMoH2STAfBgNVHSMEGDAWgBQcL9JNezOJ8vzT
+0lR1Pj4sMoH2STAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIAhv
+iLjfMqcnJ10gmKoyEIMDDRJP2UwtGRcJZU/FnaIEAiBeUmN+nJBGIq0tFHIxz1Xl
+LaBMf6qZANMrXRQaETxhIA==
+-----END CERTIFICATE-----
+";
+
+const CA_CERTIFICATE_SUMMARY: &str = "caCertificate: <PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint 5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8>";
+
+fn postgres_source_with_certificate() -> Value {
+    serde_json::json!({
+        "postgres": {
+            "host": "db.example.com",
+            "port": 5432,
+            "database": "postgres",
+            "caCertificate": CA_CERTIFICATE_PEM,
+        }
+    })
+}
+
+#[tokio::test]
+async fn clickpipe_get_human_output_summarizes_the_ca_certificate() {
+    let mock = MockServer::start().await;
+    mount_clickpipe_get(&mock, postgres_source_with_certificate()).await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &["clickpipe", "get", "svc-id", "pipe-id", "--org-id", "org"],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(CA_CERTIFICATE_SUMMARY),
+        "certificate not summarized:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("-----BEGIN"),
+        "certificate body dumped:\n{stdout}"
+    );
+    // The point of eliding is that the surrounding fields stay readable.
+    assert!(stdout.contains("host: db.example.com"), "{stdout}");
+    assert!(stdout.contains("name: test-pipe"), "{stdout}");
+}
+
+#[tokio::test]
+async fn clickpipe_get_json_output_keeps_the_full_ca_certificate() {
+    let mock = MockServer::start().await;
+    mount_clickpipe_get(&mock, postgres_source_with_certificate()).await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["clickpipe", "get", "svc-id", "pipe-id", "--org-id", "org"],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pipe: Value = serde_json::from_str(stdout.trim()).expect("stdout should be JSON");
+    assert_eq!(
+        pipe["source"]["postgres"]["caCertificate"],
+        Value::String(CA_CERTIFICATE_PEM.to_string()),
+        "--json must carry the certificate verbatim: {stdout}"
+    );
+    assert!(
+        stdout.contains("-----BEGIN CERTIFICATE-----"),
+        "--json must not elide: {stdout}"
+    );
+}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -11668,8 +11668,9 @@ async fn reverse_private_endpoint_help_explains_how_pipes_reference_it() {
 //
 // A Postgres ClickPipe's `source.postgres.caCertificate` is a whole PEM block.
 // Rendered verbatim it pushed every other field of `clickpipe get` off the
-// screen. Human output summarizes it; `--json` still carries the bytes, so a
-// caller that needs the certificate has not lost anything.
+// screen. Human output replaces each block with a one-line summary of that
+// block; `--json` still carries the bytes, so a caller that needs the
+// certificate has not lost anything.
 
 /// A real self-signed EC certificate, the same fixture the `cloud::output`
 /// unit tests use. The fingerprint came from
@@ -11688,7 +11689,7 @@ LaBMf6qZANMrXRQaETxhIA==
 -----END CERTIFICATE-----
 ";
 
-const CA_CERTIFICATE_SUMMARY: &str = "caCertificate: <PEM: 1 CERTIFICATE block(s), SHA-256 fingerprint 5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8>";
+const CA_CERTIFICATE_SUMMARY: &str = "caCertificate: <PEM CERTIFICATE, SHA-256 fingerprint 5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8>";
 
 fn postgres_source_with_certificate() -> Value {
     serde_json::json!({


### PR DESCRIPTION
## What

`clickhousectl cloud clickpipe get` renders a Postgres pipe's `source.postgres.caCertificate` through `print_human`, which printed the whole PEM block: roughly 1.5 KB of base64 that pushed every other field of the pipe off the screen. Human output now replaces each well-formed PEM block with a one-line summary of that block:

```
source:
  postgres:
    host: db.example.com
    caCertificate: <PEM CERTIFICATE, SHA-256 fingerprint 5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8>
    database: postgres
```

The summary is keyed on the value's format, not on the field name. `print_human` turns a JSON string scalar into text in exactly one place (`scalar_string`), so the work lives there and covers object fields, nested objects, arrays of strings and array bullets, and client certificates and private keys as well as CA certificates, with no per-field allowlist to keep in sync as the API grows new certificate fields.

Each block is summarised on its own terms, in place, and the text around the blocks is kept exactly as it was. A certificate-family block (`CERTIFICATE`, `TRUSTED CERTIFICATE`, `CERTIFICATE REQUEST`, `NEW CERTIFICATE REQUEST`, `X509 CRL`) is identified by the SHA-256 of its own base64-decoded DER as colon-separated uppercase hex, which is the form `openssl x509 -fingerprint -sha256` prints, so every block of a chain can be checked against the file the user holds. Every other label renders as `<PEM EC PRIVATE KEY, 121 bytes>` and is never fingerprinted: a stable identifier of secret material left in scrollback is not something any caller needs. A certificate whose base64 does not decode, an encrypted key with RFC 1421 headers or a truncated paste, falls back to the same byte count over that block's body. The body itself is never part of the result on any path.

When the value is nothing but blocks and whitespace, which is the common case of a single certificate or a chain, the per-block summaries are joined with commas on one line. Any other value keeps its own text and has each block replaced where it stood.

The block label is the only part of a block that reaches the summary line, so it is validated against RFC 7468 section 3's `label` production: non-empty, at most 64 characters, printable ASCII or space, and no leading or trailing space or hyphen. A frame carrying a newline, a control character, an ANSI escape, non-ASCII bytes or a kilobyte of text where a label belongs is not a block at all, and the scan steps past that `-----BEGIN ` and keeps looking rather than stopping, so one malformed frame cannot hide the blocks after it.

## Why

`--json` is untouched and keeps the certificate verbatim, so nothing is lost: an agent or script that needs the bytes reads them from JSON, and the human reading `clickpipe get` gets a screen they can scan. `cloud postgres certs get` is deliberately unchanged, since printing the PEM to stdout is that command's entire purpose and it does not go through `print_human`.

Summarising in place, rather than replacing the whole value, is what makes the behaviour honest about real inputs. A bundle with header comments before the first block (curl's `cacert.pem`), an `openssl x509 -text` dump, a byte-order mark, or prose between two blocks is common, and any of those either escaped elision entirely or lost its surrounding text under a whole-value approach. Per-block labels also mean a certificate followed by a key is described as what it is instead of claiming to be two certificates, and the byte-count fallback now counts the block it could not identify instead of the entire string.

`clickpipe list`, `stop`, `start` and `resync` render name, id and state only, so they never showed a certificate; the fix is in the one human path that did.

`sha2` is a new direct dependency of `clickhousectl` (it was already in `Cargo.lock` transitively). `base64` was already a direct dependency. No `pem` crate: the framing parse is small and the label rules are the part that needed care.

## Behaviour after the fix

- Human output for the test fixture: `caCertificate: <PEM CERTIFICATE, SHA-256 fingerprint 5A:6D:67:FD:14:1B:1E:61:4A:F4:E2:7D:F1:F8:67:E2:75:85:DF:92:E3:66:31:85:75:AB:2C:C3:F4:8C:9A:D8>`
- `--json` output: the full PEM, byte for byte, as the API returned it.
- A three-certificate chain renders as one line with three summaries joined by commas.
- A certificate followed by a private key renders as `<PEM CERTIFICATE, SHA-256 fingerprint ...>, <PEM EC PRIVATE KEY, 10 bytes>`, with no digest of the key.
- A bundle with header comments keeps the comments and replaces only the block.
- A non-PEM string, framing that never closes, an `END` label that does not match its `BEGIN`, an unlabelled frame, and a frame whose label is not a label all render exactly as before.
- README documents this in the shared JSON and output section, since it applies to every human detail view rather than only to pipes, and states that `cloud postgres certs get` still prints raw PEM on purpose. AGENTS.md notes it on the `print_human` step of "Adding a command", including that a hand-written `println!` or a `tabled` cell bypasses it.

## Tests

- Unit tests in `crates/clickhousectl/src/cloud/output.rs` over a committed self-signed EC certificate fixture: the summary matches the fingerprint `openssl x509 -noout -fingerprint -sha256` reports for it; a whitespace-separated three-certificate chain is one line with three summaries; a mixed certificate plus key bundle summarises the key by size and is asserted not to contain the SHA-256 of the key's body; header text before a block and prose between two blocks are preserved with the blocks substituted in place; a byte-order mark survives; CRLF framing is still summarised; an encrypted key with `Proc-Type` and `DEK-Info` headers falls back to a byte count with no header text in the summary; an undecodable certificate body falls back to a byte count over that block; non-PEM strings, unterminated framing, a mismatched `END` label and an unlabelled frame are left alone; the body and the framing never appear in a summary.
- Label validation tests: a label containing a newline, a label containing an ESC byte, and a 200-character label each produce no summary, and the rendered output is asserted to equal the raw string with no `<PEM` anywhere, so nothing is synthesised and nothing of the value is injected into a summary line.
- Render-level unit tests: a nested `caCertificate` renders the summary line with its siblings intact and no line contains `-----BEGIN`; certificates inside a scalar array and under an array bullet are summarised too.
- Subprocess plus wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs`: `clickpipe get` against a mocked Postgres pipe carrying a PEM `caCertificate` prints the summary and no `-----BEGIN` in human mode, and returns the certificate verbatim under `--json`.
- Verification commands:
  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
  - `cargo test -p clickhousectl`

## Stacking

Part of a stacked PR chain: based on `fix/662-clickpipe-postgres-iam-role-credentials`, not `main`.

Fixes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
