### PR TITLE
Report a well-formed but unknown id as not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ clickhousectl cloud --debug service list
 
 Manage ClickHouse, Postgres, and other ClickHouse Cloud resources via the API.
 
+Any command that reads or deletes a cloud resource by identifier reports an identifier no resource has as not found. The API answers `400 BAD_REQUEST: Invalid ... id` for a syntactically valid UUID that resolves to nothing, so the CLI re-presents that as `No such service: <id> (organization <org-id>)` and keeps the server's own text as a trailing detail. In `--json` mode the failure carries the stable code `resource_not_found` and the `list` command for the same scope. An identifier that is not a well-formed UUID keeps the API's `invalid` message unchanged, because there it is both true and the more useful answer.
+
 ### Organizations
 
 ```bash
@@ -1471,8 +1473,6 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `postgres_error` | A Postgres validation or state error; the message carries its recovery guidance |
 | `io_error` | A local filesystem, metadata, or serialization operation failed |
 | `local_error` | A redacted fallback for failures whose text cannot be rendered safely |
-
-Cloud failures use their own codes rather than this local schema. A by-id read (`cloud service get`, `cloud postgres get`, `cloud org get`) that names a well-formed UUID no resource has is reported as not found instead of as the API's `BAD_REQUEST: Invalid ... id`, keeping the server's own text as a trailing detail, and in `--json` mode it carries the stable code `resource_not_found` plus the matching `list` command for the same scope. A malformed identifier keeps the API's `invalid` message unchanged, because there that is both true and the more useful answer.
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -1472,6 +1472,8 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | `io_error` | A local filesystem, metadata, or serialization operation failed |
 | `local_error` | A redacted fallback for failures whose text cannot be rendered safely |
 
+Cloud failures use their own codes rather than this local schema. A by-id read (`cloud service get`, `cloud postgres get`, `cloud org get`) that names a well-formed UUID no resource has is reported as not found instead of as the API's `BAD_REQUEST: Invalid ... id`, keeping the server's own text as a trailing detail, and in `--json` mode it carries the stable code `resource_not_found` plus the matching `list` command for the same scope. A malformed identifier keeps the API's `invalid` message unchanged, because there that is both true and the more useful answer.
+
 ### Exit codes
 
 Usage errors and cancelled actions use distinct exit codes.

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -373,14 +373,14 @@ impl AuthSource {
     }
 }
 
-// ── by-identifier reads (issue #666) ───────────────────────────────────────
+// ── by-identifier requests (issue #666) ───────────────────────────────────
 //
 // The API answers HTTP 400 `Invalid <thing> id string:"<id>"` for a
 // syntactically valid UUID that resolves to nothing, so `cloud postgres get
 // 00000000-0000-0000-0000-000000000000` reported a bad request rather than a
 // missing resource. The fix is structural, not textual: nothing here reads the
 // response prose (the message interpolates the id, so it could never become a
-// typed library variant either). A GET-by-identifier request has exactly one
+// typed library variant either). A by-identifier request has exactly one
 // class of user-controlled input — the identifiers the CLI itself formatted
 // into the URL path — so when every one of those is a well-formed UUID, "the
 // identifier is invalid" is not what happened.
@@ -407,46 +407,82 @@ impl ResourceKind {
     }
 
     /// The command that lists what does exist, for the structured detail.
-    /// Carries an organization id at most, which the message already names.
-    fn list_command(self, org_id: Option<&str>) -> String {
+    /// Takes the organization the request was scoped to, which the message
+    /// already names.
+    fn list_command(self, org_id: &str) -> String {
         let base = match self {
             ResourceKind::Service => "clickhousectl cloud service list",
             ResourceKind::PostgresService => "clickhousectl cloud postgres list",
             ResourceKind::Organization => "clickhousectl cloud org list",
         };
-        match (self, org_id) {
+        match self {
             // The organization *is* the identifier being looked up, so the
             // command that lists the alternatives takes no scope flag.
-            (ResourceKind::Organization, _) | (_, None) => base.to_string(),
-            (_, Some(org_id)) => format!("{base} --org-id {org_id}"),
+            ResourceKind::Organization => base.to_string(),
+            _ => format!("{base} --org-id {org_id}"),
         }
     }
 }
 
-/// The identifiers a by-identifier read put into its request path.
+/// The identifiers a by-identifier request put into its request path.
+///
+/// Built only through [`ResourceLookup::in_org`] and
+/// [`ResourceLookup::organization`], so the kind and the organization id
+/// cannot disagree: an organization lookup is always scoped to itself, and
+/// every other kind is always scoped to the organization it was read from.
 pub struct ResourceLookup<'a> {
-    pub kind: ResourceKind,
+    kind: ResourceKind,
     /// The resource's own identifier, as the user supplied it.
-    pub id: &'a str,
+    id: &'a str,
     /// The organization the request was scoped to. Equal to `id` for an
     /// organization lookup, whose only path identifier is the organization.
-    pub org_id: Option<&'a str>,
+    org_id: &'a str,
 }
 
-impl ResourceLookup<'_> {
+impl<'a> ResourceLookup<'a> {
+    /// A resource looked up inside an organization: both identifiers are in
+    /// the request path.
+    pub fn in_org(kind: ResourceKind, id: &'a str, org_id: &'a str) -> Self {
+        Self { kind, id, org_id }
+    }
+
+    /// An organization looked up by its own identifier, which is therefore
+    /// also the only scope the request had.
+    pub fn organization(id: &'a str) -> Self {
+        Self {
+            kind: ResourceKind::Organization,
+            id,
+            org_id: id,
+        }
+    }
+
+    /// Whether the API rejected a request whose every path identifier is a
+    /// well-formed UUID, which is how it answers "no such resource" for a
+    /// request that has no other user-controlled input (#666).
+    ///
+    /// The single implementation of that judgement: both
+    /// [`CloudClient::convert_error_for_lookup`] and the callers that turn
+    /// the rejection into an absent resource read it from here.
+    pub fn rejected_well_formed_ids(&self, err: &clickhouse_cloud_api::Error) -> bool {
+        matches!(err, clickhouse_cloud_api::Error::Api { status: 400, .. })
+            && self
+                .identifiers()
+                .all(|id| uuid::Uuid::parse_str(id).is_ok())
+    }
+
     /// Every identifier the CLI formatted into the request path.
     fn identifiers(&self) -> impl Iterator<Item = &str> {
-        std::iter::once(self.id).chain(self.org_id)
+        [self.id, self.org_id].into_iter()
     }
 
     /// The trailing scope clause, when the request was scoped to something
     /// other than the resource being looked up.
     fn scope_clause(&self) -> String {
-        match self.org_id {
-            // Skipped when the organization is the resource, so the message
-            // never reads "organization X (organization X)".
-            Some(org_id) if org_id != self.id => format!(" (organization {org_id})"),
-            _ => String::new(),
+        match self.kind {
+            // Keyed on the kind, not on the two ids being equal, so the
+            // message never reads "organization X (organization X)".
+            ResourceKind::Organization => String::new(),
+            _ => format!(" (organization {})", self.org_id),
         }
     }
 }
@@ -579,11 +615,12 @@ impl CloudClient {
         self.convert_error_with_organization(err, Some(org_id))
     }
 
-    /// Re-present a by-identifier read's failure as a not-found when the API
-    /// rejected identifiers that are all well-formed UUIDs (#666).
+    /// Re-present a by-identifier request's failure as a not-found when the
+    /// API rejected identifiers that are all well-formed UUIDs (#666).
     ///
     /// The discriminator is structural: the HTTP status the library reported,
-    /// plus `Uuid::parse_str` over inputs the CLI already held. No part of it
+    /// plus `Uuid::parse_str` over inputs the CLI already held, both read
+    /// through [`ResourceLookup::rejected_well_formed_ids`]. No part of it
     /// comes from the response message, which is appended verbatim so nothing
     /// the server said is lost.
     ///
@@ -596,12 +633,8 @@ impl CloudClient {
         err: clickhouse_cloud_api::Error,
         lookup: ResourceLookup<'_>,
     ) -> CloudError {
-        let rejected_well_formed_ids =
-            matches!(&err, clickhouse_cloud_api::Error::Api { status: 400, .. })
-                && lookup
-                    .identifiers()
-                    .all(|id| uuid::Uuid::parse_str(id).is_ok());
-        let error = self.convert_error_with_organization(err, lookup.org_id);
+        let rejected_well_formed_ids = lookup.rejected_well_formed_ids(&err);
+        let error = self.convert_error_with_organization(err, Some(lookup.org_id));
         if !rejected_well_formed_ids {
             return error;
         }
@@ -967,11 +1000,7 @@ mod tests {
     fn lookup_400_over_well_formed_ids_reads_as_a_missing_service() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("service", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::Service,
-                id: NIL_UUID,
-                org_id: Some(ORG_UUID),
-            },
+            ResourceLookup::in_org(ResourceKind::Service, NIL_UUID, ORG_UUID),
         );
         assert_eq!(
             err.message,
@@ -988,11 +1017,7 @@ mod tests {
     fn lookup_400_over_well_formed_ids_reads_as_a_missing_postgres_service() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("Postgres service", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::PostgresService,
-                id: NIL_UUID,
-                org_id: Some(ORG_UUID),
-            },
+            ResourceLookup::in_org(ResourceKind::PostgresService, NIL_UUID, ORG_UUID),
         );
         assert_eq!(
             err.message,
@@ -1010,11 +1035,7 @@ mod tests {
     fn lookup_400_over_a_well_formed_id_reads_as_a_missing_organization() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("organization", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::Organization,
-                id: NIL_UUID,
-                org_id: Some(NIL_UUID),
-            },
+            ResourceLookup::organization(NIL_UUID),
         );
         assert_eq!(
             err.message,
@@ -1027,17 +1048,40 @@ mod tests {
         assert!(!err.message.contains("(organization"));
     }
 
+    /// The organization parenthetical is keyed on the kind, not on the two
+    /// identifiers happening to be equal: an organization lookup never names
+    /// an organization as the scope it was read from, however it was built.
+    #[test]
+    fn an_organization_lookup_never_names_a_scope() {
+        let client = test_client();
+        for lookup in [
+            ResourceLookup::organization(NIL_UUID),
+            ResourceLookup::in_org(ResourceKind::Organization, NIL_UUID, ORG_UUID),
+        ] {
+            let err =
+                client.convert_error_for_lookup(invalid_id_400("organization", NIL_UUID), lookup);
+            assert_eq!(
+                err.message,
+                format!(
+                    "No such organization: {NIL_UUID}. \
+                     The API rejected the identifier: \
+                     BAD_REQUEST: Invalid organization id string:\"{NIL_UUID}\""
+                )
+            );
+            assert_eq!(
+                err.details.as_deref().unwrap().command.as_deref(),
+                Some("clickhousectl cloud org list")
+            );
+        }
+    }
+
     /// Only the message changes: the server did answer 400, so the telemetry
     /// classification must stay exactly what the status says (#450).
     #[test]
     fn lookup_refinement_keeps_the_failure_classification() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("service", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::Service,
-                id: NIL_UUID,
-                org_id: Some(ORG_UUID),
-            },
+            ResourceLookup::in_org(ResourceKind::Service, NIL_UUID, ORG_UUID),
         );
         assert_eq!(
             err.failure,
@@ -1052,11 +1096,7 @@ mod tests {
         let client = test_client();
         let err = client.convert_error_for_lookup(
             invalid_id_400("Postgres service", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::PostgresService,
-                id: NIL_UUID,
-                org_id: Some(ORG_UUID),
-            },
+            ResourceLookup::in_org(ResourceKind::PostgresService, NIL_UUID, ORG_UUID),
         );
         let details = err.details.as_deref().expect("a structured detail");
         assert_eq!(details.code, CloudErrorCode::ResourceNotFound);
@@ -1071,11 +1111,7 @@ mod tests {
         // An organization lookup has no scope flag to suggest.
         let err = client.convert_error_for_lookup(
             invalid_id_400("organization", NIL_UUID),
-            ResourceLookup {
-                kind: ResourceKind::Organization,
-                id: NIL_UUID,
-                org_id: Some(NIL_UUID),
-            },
+            ResourceLookup::organization(NIL_UUID),
         );
         assert_eq!(
             err.details.as_deref().unwrap().command.as_deref(),
@@ -1089,11 +1125,7 @@ mod tests {
     fn lookup_400_over_a_malformed_id_is_left_alone() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("service", "not-a-uuid"),
-            ResourceLookup {
-                kind: ResourceKind::Service,
-                id: "not-a-uuid",
-                org_id: Some(ORG_UUID),
-            },
+            ResourceLookup::in_org(ResourceKind::Service, "not-a-uuid", ORG_UUID),
         );
         assert_eq!(
             err.message,
@@ -1108,11 +1140,7 @@ mod tests {
     fn lookup_400_with_a_malformed_organization_is_left_alone() {
         let err = test_client().convert_error_for_lookup(
             invalid_id_400("organization", "org-1"),
-            ResourceLookup {
-                kind: ResourceKind::Service,
-                id: NIL_UUID,
-                org_id: Some("org-1"),
-            },
+            ResourceLookup::in_org(ResourceKind::Service, NIL_UUID, "org-1"),
         );
         assert_eq!(
             err.message,
@@ -1126,11 +1154,7 @@ mod tests {
     #[test]
     fn lookup_leaves_every_other_status_unchanged() {
         let client = test_client();
-        let lookup = || ResourceLookup {
-            kind: ResourceKind::Service,
-            id: NIL_UUID,
-            org_id: Some(ORG_UUID),
-        };
+        let lookup = || ResourceLookup::in_org(ResourceKind::Service, NIL_UUID, ORG_UUID);
 
         let err = client.convert_error_for_lookup(
             clickhouse_cloud_api::Error::Api {

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1,4 +1,4 @@
-use crate::cloud::output::CloudErrorDetail;
+use crate::cloud::output::{CloudErrorCode, CloudErrorDetail};
 use crate::dotenv::DotenvVars;
 use crate::failure::{ApiFailure, FailureKind, FailureStage};
 use std::env;
@@ -373,6 +373,84 @@ impl AuthSource {
     }
 }
 
+// ── by-identifier reads (issue #666) ───────────────────────────────────────
+//
+// The API answers HTTP 400 `Invalid <thing> id string:"<id>"` for a
+// syntactically valid UUID that resolves to nothing, so `cloud postgres get
+// 00000000-0000-0000-0000-000000000000` reported a bad request rather than a
+// missing resource. The fix is structural, not textual: nothing here reads the
+// response prose (the message interpolates the id, so it could never become a
+// typed library variant either). A GET-by-identifier request has exactly one
+// class of user-controlled input — the identifiers the CLI itself formatted
+// into the URL path — so when every one of those is a well-formed UUID, "the
+// identifier is invalid" is not what happened.
+//
+// A malformed identifier keeps the server's answer verbatim: there, "invalid"
+// is both true and the more useful thing to say.
+
+/// Which resource a by-identifier read was looking up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceKind {
+    Service,
+    PostgresService,
+    Organization,
+}
+
+impl ResourceKind {
+    /// The noun the not-found message names the resource with.
+    const fn noun(self) -> &'static str {
+        match self {
+            ResourceKind::Service => "service",
+            ResourceKind::PostgresService => "Postgres service",
+            ResourceKind::Organization => "organization",
+        }
+    }
+
+    /// The command that lists what does exist, for the structured detail.
+    /// Carries an organization id at most, which the message already names.
+    fn list_command(self, org_id: Option<&str>) -> String {
+        let base = match self {
+            ResourceKind::Service => "clickhousectl cloud service list",
+            ResourceKind::PostgresService => "clickhousectl cloud postgres list",
+            ResourceKind::Organization => "clickhousectl cloud org list",
+        };
+        match (self, org_id) {
+            // The organization *is* the identifier being looked up, so the
+            // command that lists the alternatives takes no scope flag.
+            (ResourceKind::Organization, _) | (_, None) => base.to_string(),
+            (_, Some(org_id)) => format!("{base} --org-id {org_id}"),
+        }
+    }
+}
+
+/// The identifiers a by-identifier read put into its request path.
+pub struct ResourceLookup<'a> {
+    pub kind: ResourceKind,
+    /// The resource's own identifier, as the user supplied it.
+    pub id: &'a str,
+    /// The organization the request was scoped to. Equal to `id` for an
+    /// organization lookup, whose only path identifier is the organization.
+    pub org_id: Option<&'a str>,
+}
+
+impl ResourceLookup<'_> {
+    /// Every identifier the CLI formatted into the request path.
+    fn identifiers(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.id).chain(self.org_id)
+    }
+
+    /// The trailing scope clause, when the request was scoped to something
+    /// other than the resource being looked up.
+    fn scope_clause(&self) -> String {
+        match self.org_id {
+            // Skipped when the organization is the resource, so the message
+            // never reads "organization X (organization X)".
+            Some(org_id) if org_id != self.id => format!(" (organization {org_id})"),
+            _ => String::new(),
+        }
+    }
+}
+
 pub struct CloudClient {
     lib_client: clickhouse_cloud_api::Client,
     auth_mode: AuthMode,
@@ -499,6 +577,54 @@ impl CloudClient {
         org_id: &str,
     ) -> CloudError {
         self.convert_error_with_organization(err, Some(org_id))
+    }
+
+    /// Re-present a by-identifier read's failure as a not-found when the API
+    /// rejected identifiers that are all well-formed UUIDs (#666).
+    ///
+    /// The discriminator is structural: the HTTP status the library reported,
+    /// plus `Uuid::parse_str` over inputs the CLI already held. No part of it
+    /// comes from the response message, which is appended verbatim so nothing
+    /// the server said is lost.
+    ///
+    /// Conversion still goes through [`Self::convert_error_with_organization`],
+    /// so the telemetry classification (#450) is inherited unchanged and
+    /// carried across the rewrite: the server did answer 400, and only the
+    /// user-facing message changes.
+    pub fn convert_error_for_lookup(
+        &self,
+        err: clickhouse_cloud_api::Error,
+        lookup: ResourceLookup<'_>,
+    ) -> CloudError {
+        let rejected_well_formed_ids =
+            matches!(&err, clickhouse_cloud_api::Error::Api { status: 400, .. })
+                && lookup
+                    .identifiers()
+                    .all(|id| uuid::Uuid::parse_str(id).is_ok());
+        let error = self.convert_error_with_organization(err, lookup.org_id);
+        if !rejected_well_formed_ids {
+            return error;
+        }
+        let message = format!(
+            "No such {}: {}{}. The API rejected the identifier: {}",
+            lookup.kind.noun(),
+            lookup.id,
+            lookup.scope_clause(),
+            error.message,
+        );
+        CloudError {
+            message: message.clone(),
+            ..error
+        }
+        .with_details(CloudErrorDetail {
+            code: CloudErrorCode::ResourceNotFound,
+            message,
+            host: None,
+            port: None,
+            command: Some(lookup.kind.list_command(lookup.org_id)),
+            api_key_id: None,
+            ip_access_list: None,
+        })
     }
 
     /// The single boundary where a typed library error becomes a
@@ -816,6 +942,226 @@ mod tests {
             "org-1",
         );
         assert_eq!(err.message, "Service svc-1 not found");
+    }
+
+    // ── by-identifier reads (issue #666) ──────────────────────────────────
+    //
+    // The API answers 400 with "Invalid <thing> id" for a well-formed UUID
+    // that resolves to nothing. These pin the refinement to its two
+    // structural inputs — the status and whether the CLI's own path
+    // identifiers parse as UUIDs — and pin that nothing else moves.
+
+    /// A well-formed UUID that resolves to nothing. All-zero is still a
+    /// syntactically valid UUID, so it must count as well-formed.
+    const NIL_UUID: &str = "00000000-0000-0000-0000-000000000000";
+    const ORG_UUID: &str = "00000000-0000-4000-8000-000000000001";
+
+    fn invalid_id_400(thing: &str, id: &str) -> clickhouse_cloud_api::Error {
+        clickhouse_cloud_api::Error::Api {
+            status: 400,
+            message: format!("BAD_REQUEST: Invalid {thing} id string:\"{id}\""),
+        }
+    }
+
+    #[test]
+    fn lookup_400_over_well_formed_ids_reads_as_a_missing_service() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("service", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::Service,
+                id: NIL_UUID,
+                org_id: Some(ORG_UUID),
+            },
+        );
+        assert_eq!(
+            err.message,
+            format!(
+                "No such service: {NIL_UUID} (organization {ORG_UUID}). \
+                 The API rejected the identifier: \
+                 BAD_REQUEST: Invalid service id string:\"{NIL_UUID}\""
+            )
+        );
+        assert_eq!(err.kind, CloudErrorKind::Generic);
+    }
+
+    #[test]
+    fn lookup_400_over_well_formed_ids_reads_as_a_missing_postgres_service() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("Postgres service", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::PostgresService,
+                id: NIL_UUID,
+                org_id: Some(ORG_UUID),
+            },
+        );
+        assert_eq!(
+            err.message,
+            format!(
+                "No such Postgres service: {NIL_UUID} (organization {ORG_UUID}). \
+                 The API rejected the identifier: \
+                 BAD_REQUEST: Invalid Postgres service id string:\"{NIL_UUID}\""
+            )
+        );
+    }
+
+    /// The organization is itself the identifier being looked up, so the
+    /// message must not repeat it as request scope.
+    #[test]
+    fn lookup_400_over_a_well_formed_id_reads_as_a_missing_organization() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("organization", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::Organization,
+                id: NIL_UUID,
+                org_id: Some(NIL_UUID),
+            },
+        );
+        assert_eq!(
+            err.message,
+            format!(
+                "No such organization: {NIL_UUID}. \
+                 The API rejected the identifier: \
+                 BAD_REQUEST: Invalid organization id string:\"{NIL_UUID}\""
+            )
+        );
+        assert!(!err.message.contains("(organization"));
+    }
+
+    /// Only the message changes: the server did answer 400, so the telemetry
+    /// classification must stay exactly what the status says (#450).
+    #[test]
+    fn lookup_refinement_keeps_the_failure_classification() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("service", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::Service,
+                id: NIL_UUID,
+                org_id: Some(ORG_UUID),
+            },
+        );
+        assert_eq!(
+            err.failure,
+            Some(ApiFailure::with_status(FailureKind::Http4xx, 400))
+        );
+    }
+
+    /// `--json` gets a stable code plus the command that lists what does
+    /// exist, and the same text human mode prints.
+    #[test]
+    fn lookup_refinement_carries_a_structured_detail() {
+        let client = test_client();
+        let err = client.convert_error_for_lookup(
+            invalid_id_400("Postgres service", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::PostgresService,
+                id: NIL_UUID,
+                org_id: Some(ORG_UUID),
+            },
+        );
+        let details = err.details.as_deref().expect("a structured detail");
+        assert_eq!(details.code, CloudErrorCode::ResourceNotFound);
+        assert_eq!(details.message, err.message);
+        assert_eq!(
+            details.command.as_deref(),
+            Some(format!("clickhousectl cloud postgres list --org-id {ORG_UUID}").as_str())
+        );
+        assert_eq!(details.api_key_id, None);
+        assert_eq!(details.ip_access_list, None);
+
+        // An organization lookup has no scope flag to suggest.
+        let err = client.convert_error_for_lookup(
+            invalid_id_400("organization", NIL_UUID),
+            ResourceLookup {
+                kind: ResourceKind::Organization,
+                id: NIL_UUID,
+                org_id: Some(NIL_UUID),
+            },
+        );
+        assert_eq!(
+            err.details.as_deref().unwrap().command.as_deref(),
+            Some("clickhousectl cloud org list")
+        );
+    }
+
+    /// A malformed identifier keeps the server's answer: "invalid" is then
+    /// both true and more useful than "no such service".
+    #[test]
+    fn lookup_400_over_a_malformed_id_is_left_alone() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("service", "not-a-uuid"),
+            ResourceLookup {
+                kind: ResourceKind::Service,
+                id: "not-a-uuid",
+                org_id: Some(ORG_UUID),
+            },
+        );
+        assert_eq!(
+            err.message,
+            "BAD_REQUEST: Invalid service id string:\"not-a-uuid\""
+        );
+        assert!(err.details.is_none());
+    }
+
+    /// Every path identifier has to parse, not just the resource's own: a
+    /// malformed organization is as plausible a cause of the 400.
+    #[test]
+    fn lookup_400_with_a_malformed_organization_is_left_alone() {
+        let err = test_client().convert_error_for_lookup(
+            invalid_id_400("organization", "org-1"),
+            ResourceLookup {
+                kind: ResourceKind::Service,
+                id: NIL_UUID,
+                org_id: Some("org-1"),
+            },
+        );
+        assert_eq!(
+            err.message,
+            "BAD_REQUEST: Invalid organization id string:\"org-1\""
+        );
+        assert!(err.details.is_none());
+    }
+
+    /// Any other status is somebody else's story. A 404 keeps the existing
+    /// organization-scope enrichment, and a 5xx is untouched.
+    #[test]
+    fn lookup_leaves_every_other_status_unchanged() {
+        let client = test_client();
+        let lookup = || ResourceLookup {
+            kind: ResourceKind::Service,
+            id: NIL_UUID,
+            org_id: Some(ORG_UUID),
+        };
+
+        let err = client.convert_error_for_lookup(
+            clickhouse_cloud_api::Error::Api {
+                status: 404,
+                message: "NOT_FOUND".into(),
+            },
+            lookup(),
+        );
+        assert_eq!(
+            err.message,
+            format!("NOT_FOUND: request scoped to organization {ORG_UUID}")
+        );
+        assert!(err.details.is_none());
+
+        let err = client.convert_error_for_lookup(
+            clickhouse_cloud_api::Error::Api {
+                status: 500,
+                message: "Internal Server Error".into(),
+            },
+            lookup(),
+        );
+        assert_eq!(err.message, "Internal Server Error");
+        assert!(err.details.is_none());
+
+        // A non-API failure has no status to reason from at all.
+        let err = client.convert_error_for_lookup(
+            clickhouse_cloud_api::Error::AuthMismatch("nope".into()),
+            lookup(),
+        );
+        assert!(err.details.is_none());
+        assert!(!err.message.starts_with("No such"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,6 +1,4 @@
-use crate::cloud::client::{
-    CloudClient, CloudError, ResourceKind, ResourceLookup, Result as CloudResult,
-};
+use crate::cloud::client::{CloudClient, CloudError, ResourceLookup, Result as CloudResult};
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
@@ -763,14 +761,7 @@ impl CloudClient {
         let response = self.api().organization_get(org_id).await.map_err(|error| {
             // A read by identifier: a 400 over a well-formed UUID is a
             // missing organization, not a bad request (#666).
-            self.convert_error_for_lookup(
-                error,
-                ResourceLookup {
-                    kind: ResourceKind::Organization,
-                    id: org_id,
-                    org_id: Some(org_id),
-                },
-            )
+            self.convert_error_for_lookup(error, ResourceLookup::organization(org_id))
         })?;
         Self::unwrap_response(response)
     }

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,4 +1,6 @@
-use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::client::{
+    CloudClient, CloudError, ResourceKind, ResourceLookup, Result as CloudResult,
+};
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
@@ -758,11 +760,18 @@ impl CloudClient {
         &self,
         org_id: &str,
     ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Organization> {
-        let response = self
-            .api()
-            .organization_get(org_id)
-            .await
-            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        let response = self.api().organization_get(org_id).await.map_err(|error| {
+            // A read by identifier: a 400 over a well-formed UUID is a
+            // missing organization, not a bad request (#666).
+            self.convert_error_for_lookup(
+                error,
+                ResourceLookup {
+                    kind: ResourceKind::Organization,
+                    id: org_id,
+                    org_id: Some(org_id),
+                },
+            )
+        })?;
         Self::unwrap_response(response)
     }
 

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -102,6 +102,10 @@ pub enum CloudErrorCode {
     /// rejecting the replacement for the whole readiness window. The repair
     /// is committed; rerunning it would rotate a key that may be fine (#658).
     QueryKeyRepairUnverified,
+    /// A by-identifier read named a resource that does not exist: the API
+    /// rejected an identifier that is, structurally, a well-formed UUID
+    /// (#666). `command` lists what does exist in the same scope.
+    ResourceNotFound,
 }
 
 impl CloudErrorCode {
@@ -116,6 +120,7 @@ impl CloudErrorCode {
         Self::QueryKeyRejected,
         Self::QueryKeyUnverified,
         Self::QueryKeyRepairUnverified,
+        Self::ResourceNotFound,
     ];
 }
 
@@ -620,6 +625,7 @@ mod tests {
                 "query_key_rejected",
                 "query_key_unverified",
                 "query_key_repair_unverified",
+                "resource_not_found",
             ]
         );
     }

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -71,10 +71,6 @@ pub(crate) fn print_line(line: impl std::fmt::Display) {
 /// API sends: the vocabulary is this enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-// The shared `Query` prefix is part of the wire value (`query_timeout`,
-// `query_key_*`), which names the command family the code belongs to; it is
-// not a Rust naming accident to strip.
-#[allow(clippy::enum_variant_names)]
 pub enum CloudErrorCode {
     /// The Query API gateway stopped waiting for the statement (#644).
     QueryTimeout,

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -495,9 +495,11 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Every Postgres path reports an empty body the same way the rest of the
+/// cloud surface does, so moving one onto a `CloudClient` wrapper cannot
+/// change the message a caller sees.
 fn unwrap_api<T>(resp: ApiResponse<T>) -> CloudResult<T> {
-    resp.result
-        .ok_or_else(|| CloudError::new("API response was missing a result body"))
+    CloudClient::unwrap_response(resp)
 }
 
 fn parse_pg_size(value: &str) -> CloudResult<clickhouse_cloud_api::models::PgSize> {
@@ -1477,11 +1479,7 @@ impl CloudClient {
                 // missing Postgres service, not a bad request (#666).
                 self.convert_error_for_lookup(
                     error,
-                    ResourceLookup {
-                        kind: ResourceKind::PostgresService,
-                        id: postgres_id,
-                        org_id: Some(org_id),
-                    },
+                    ResourceLookup::in_org(ResourceKind::PostgresService, postgres_id, org_id),
                 )
             })?;
         Self::unwrap_response(response)

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,4 +1,6 @@
-use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::client::{
+    CloudClient, CloudError, ResourceKind, ResourceLookup, Result as CloudResult,
+};
 use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::{ArgGroup, Subcommand};
@@ -927,12 +929,7 @@ pub async fn postgres_get(
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let resp = client
-        .api()
-        .postgres_service_get(&org_id, postgres_id)
-        .await
-        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
-    let svc = unwrap_api(resp)?;
+    let svc = client.get_postgres_service(&org_id, postgres_id).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&svc)?);
@@ -1475,7 +1472,18 @@ impl CloudClient {
             .api()
             .postgres_service_get(org_id, postgres_id)
             .await
-            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+            .map_err(|error| {
+                // A read by identifier: a 400 over well-formed UUIDs is a
+                // missing Postgres service, not a bad request (#666).
+                self.convert_error_for_lookup(
+                    error,
+                    ResourceLookup {
+                        kind: ResourceKind::PostgresService,
+                        id: postgres_id,
+                        org_id: Some(org_id),
+                    },
+                )
+            })?;
         Self::unwrap_response(response)
     }
 

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1,6 +1,8 @@
 use crate::cloud::api_keys::{cleanup_service_query_key, service_query_key_cleanup};
 use crate::cloud::backups::BackupConfigCommands;
-use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::client::{
+    CloudClient, CloudError, ResourceKind, ResourceLookup, Result as CloudResult,
+};
 use crate::cloud::credentials;
 use crate::cloud::output::{
     ABSENT, CloudErrorCode, CloudErrorDetail, eprint_line, or_absent, print_human, print_line,
@@ -3049,7 +3051,18 @@ impl CloudClient {
             .api()
             .instance_get(org_id, service_id)
             .await
-            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+            .map_err(|error| {
+                // A read by identifier: a 400 over well-formed UUIDs is a
+                // missing service, not a bad request (#666).
+                self.convert_error_for_lookup(
+                    error,
+                    ResourceLookup {
+                        kind: ResourceKind::Service,
+                        id: service_id,
+                        org_id: Some(org_id),
+                    },
+                )
+            })?;
         Self::unwrap_response(response)
     }
 

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -2153,7 +2153,7 @@ async fn probe_repaired_query_key(
                 org_id,
                 service_id,
                 api_key_id,
-                &format!("could not read the state of service {service_id} ({error})"),
+                &format!("could not read service {service_id}: {error}"),
             ));
         }
     };
@@ -3056,11 +3056,7 @@ impl CloudClient {
                 // missing service, not a bad request (#666).
                 self.convert_error_for_lookup(
                     error,
-                    ResourceLookup {
-                        kind: ResourceKind::Service,
-                        id: service_id,
-                        org_id: Some(org_id),
-                    },
+                    ResourceLookup::in_org(ResourceKind::Service, service_id, org_id),
                 )
             })?;
         Self::unwrap_response(response)
@@ -3071,10 +3067,17 @@ impl CloudClient {
         org_id: &str,
         service_id: &str,
     ) -> crate::cloud::client::Result<Option<Service>> {
+        let lookup = ResourceLookup::in_org(ResourceKind::Service, service_id, org_id);
         match self.api().instance_get(org_id, service_id).await {
             Ok(response) => Self::unwrap_response(response).map(Some),
             Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Ok(None),
-            Err(error) => Err(self.convert_error_for_organization(error, org_id)),
+            // The API answers 400 rather than 404 for a well-formed id no
+            // service has, and this GET has no other user-controlled input,
+            // so that rejection is its way of saying the same thing (#666).
+            // Without this, `service delete --force` aborted on an id
+            // `service get` reports as missing.
+            Err(error) if lookup.rejected_well_formed_ids(&error) => Ok(None),
+            Err(error) => Err(self.convert_error_for_lookup(error, lookup)),
         }
     }
 
@@ -3100,7 +3103,15 @@ impl CloudClient {
             .api()
             .instance_delete(org_id, service_id)
             .await
-            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+            .map_err(|error| {
+                // A delete by identifier carries the same single class of
+                // user input as the read, so the same 400 means the same
+                // thing (#666).
+                self.convert_error_for_lookup(
+                    error,
+                    ResourceLookup::in_org(ResourceKind::Service, service_id, org_id),
+                )
+            })?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -11750,3 +11750,193 @@ async fn clickpipe_get_json_output_keeps_the_full_ca_certificate() {
         "--json must not elide: {stdout}"
     );
 }
+
+// ── A well-formed but unknown id reads as not found (issue #666) ───────────
+//
+// The API answers HTTP 400 `Invalid <thing> id string:"<id>"` for a
+// syntactically valid UUID that resolves to nothing, so a by-id read reported
+// a bad request instead of a missing resource. The refinement is structural
+// (the status, plus whether the identifiers the CLI put in the path parse as
+// UUIDs), so a malformed id must still get the server's own answer.
+
+/// A well-formed UUID that no resource has. All-zero is still a syntactically
+/// valid UUID.
+const UNKNOWN_UUID: &str = "00000000-0000-0000-0000-000000000000";
+const LOOKUP_ORG_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+/// The 400 the API really answers for a well-formed id it cannot resolve.
+async fn mount_invalid_id_400(mock: &MockServer, api_path: String, thing: &str, id: &str) {
+    Mock::given(method("GET"))
+        .and(path(api_path))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "status": 400,
+            "error": format!("BAD_REQUEST: Invalid {thing} id string:\"{id}\""),
+            "requestId": "stub-invalid-id",
+        })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn postgres_get_unknown_well_formed_id_reads_as_not_found() {
+    let mock = MockServer::start().await;
+    mount_invalid_id_400(
+        &mock,
+        format!("/v1/organizations/{LOOKUP_ORG_ID}/postgres/{UNKNOWN_UUID}"),
+        "Postgres service",
+        UNKNOWN_UUID,
+    )
+    .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &["postgres", "get", UNKNOWN_UUID, "--org-id", LOOKUP_ORG_ID],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: No such Postgres service: {UNKNOWN_UUID} (organization {LOOKUP_ORG_ID}). \
+             The API rejected the identifier: \
+             BAD_REQUEST: Invalid Postgres service id string:\"{UNKNOWN_UUID}\"\n"
+        )
+    );
+}
+
+#[tokio::test]
+async fn service_get_unknown_well_formed_id_reads_as_not_found() {
+    let mock = MockServer::start().await;
+    mount_invalid_id_400(
+        &mock,
+        format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{UNKNOWN_UUID}"),
+        "service",
+        UNKNOWN_UUID,
+    )
+    .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &["service", "get", UNKNOWN_UUID, "--org-id", LOOKUP_ORG_ID],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: No such service: {UNKNOWN_UUID} (organization {LOOKUP_ORG_ID}). \
+             The API rejected the identifier: \
+             BAD_REQUEST: Invalid service id string:\"{UNKNOWN_UUID}\"\n"
+        )
+    );
+}
+
+#[tokio::test]
+async fn org_get_unknown_well_formed_id_reads_as_not_found() {
+    let mock = MockServer::start().await;
+    mount_invalid_id_400(
+        &mock,
+        format!("/v1/organizations/{UNKNOWN_UUID}"),
+        "organization",
+        UNKNOWN_UUID,
+    )
+    .await;
+
+    let output = invoke_cli_human(&mock, &["org", "get", UNKNOWN_UUID]);
+
+    assert_eq!(output.status.code(), Some(1));
+    // The organization is the identifier being looked up, so it is not
+    // repeated as request scope.
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: No such organization: {UNKNOWN_UUID}. \
+             The API rejected the identifier: \
+             BAD_REQUEST: Invalid organization id string:\"{UNKNOWN_UUID}\"\n"
+        )
+    );
+}
+
+#[tokio::test]
+async fn by_id_read_not_found_carries_the_resource_not_found_code_in_json_mode() {
+    for (api_path, thing, args, expected_command) in [
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/postgres/{UNKNOWN_UUID}"),
+            "Postgres service",
+            vec!["postgres", "get", UNKNOWN_UUID, "--org-id", LOOKUP_ORG_ID],
+            format!("clickhousectl cloud postgres list --org-id {LOOKUP_ORG_ID}"),
+        ),
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{UNKNOWN_UUID}"),
+            "service",
+            vec!["service", "get", UNKNOWN_UUID, "--org-id", LOOKUP_ORG_ID],
+            format!("clickhousectl cloud service list --org-id {LOOKUP_ORG_ID}"),
+        ),
+        (
+            format!("/v1/organizations/{UNKNOWN_UUID}"),
+            "organization",
+            vec!["org", "get", UNKNOWN_UUID],
+            "clickhousectl cloud org list".to_string(),
+        ),
+    ] {
+        let mock = MockServer::start().await;
+        mount_invalid_id_400(&mock, api_path, thing, UNKNOWN_UUID).await;
+
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_eq!(output.status.code(), Some(1), "args {args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let error: Value =
+            serde_json::from_str(stderr.trim()).unwrap_or_else(|_| panic!("not JSON: {stderr}"));
+        assert_eq!(error["error"]["code"], "resource_not_found", "{stderr}");
+        assert_eq!(
+            error["error"]["command"],
+            Value::String(expected_command),
+            "{stderr}"
+        );
+        // The JSON message is the same text human mode prints, server detail
+        // and all.
+        let message = error["error"]["message"].as_str().expect("a message");
+        assert!(message.starts_with("No such "), "{stderr}");
+        assert!(
+            message.ends_with(&format!(
+                "BAD_REQUEST: Invalid {thing} id string:\"{UNKNOWN_UUID}\""
+            )),
+            "{stderr}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn by_id_read_keeps_the_servers_message_for_a_malformed_id() {
+    const MALFORMED_ID: &str = "not-a-uuid";
+    for (api_path, thing, args) in [
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/postgres/{MALFORMED_ID}"),
+            "Postgres service",
+            vec!["postgres", "get", MALFORMED_ID, "--org-id", LOOKUP_ORG_ID],
+        ),
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{MALFORMED_ID}"),
+            "service",
+            vec!["service", "get", MALFORMED_ID, "--org-id", LOOKUP_ORG_ID],
+        ),
+        (
+            format!("/v1/organizations/{MALFORMED_ID}"),
+            "organization",
+            vec!["org", "get", MALFORMED_ID],
+        ),
+    ] {
+        let mock = MockServer::start().await;
+        mount_invalid_id_400(&mock, api_path, thing, MALFORMED_ID).await;
+
+        let output = invoke_cli_human(&mock, &args);
+
+        assert_eq!(output.status.code(), Some(1), "args {args:?}");
+        // "Invalid" is the truth here, and more useful than "no such".
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr),
+            format!("Error: BAD_REQUEST: Invalid {thing} id string:\"{MALFORMED_ID}\"\n"),
+        );
+    }
+}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -7303,7 +7303,7 @@ async fn repair_skips_verification_when_the_service_state_cannot_be_read() {
     let stderr = stderr_without_notes(&output);
     assert!(
         stderr.contains(&format!(
-            "Note: could not read the state of service {QUERY_TEST_SERVICE_ID}"
+            "Note: could not read service {QUERY_TEST_SERVICE_ID}:"
         )),
         "{stderr}"
     );
@@ -11765,14 +11765,18 @@ const UNKNOWN_UUID: &str = "00000000-0000-0000-0000-000000000000";
 const LOOKUP_ORG_ID: &str = "00000000-0000-4000-8000-000000000001";
 
 /// The 400 the API really answers for a well-formed id it cannot resolve.
+fn invalid_id_400_response(thing: &str, id: &str) -> ResponseTemplate {
+    ResponseTemplate::new(400).set_body_json(serde_json::json!({
+        "status": 400,
+        "error": format!("BAD_REQUEST: Invalid {thing} id string:\"{id}\""),
+        "requestId": "stub-invalid-id",
+    }))
+}
+
 async fn mount_invalid_id_400(mock: &MockServer, api_path: String, thing: &str, id: &str) {
     Mock::given(method("GET"))
         .and(path(api_path))
-        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
-            "status": 400,
-            "error": format!("BAD_REQUEST: Invalid {thing} id string:\"{id}\""),
-            "requestId": "stub-invalid-id",
-        })))
+        .respond_with(invalid_id_400_response(thing, id))
         .mount(mock)
         .await;
 }
@@ -11939,4 +11943,129 @@ async fn by_id_read_keeps_the_servers_message_for_a_malformed_id() {
             format!("Error: BAD_REQUEST: Invalid {thing} id string:\"{MALFORMED_ID}\"\n"),
         );
     }
+}
+
+/// `--json` mode must not invent a code for a failure the CLI did not
+/// classify: a malformed id keeps the API's prose, as it does in human mode.
+#[tokio::test]
+async fn by_id_read_in_json_mode_keeps_the_servers_message_for_a_malformed_id() {
+    const MALFORMED_ID: &str = "not-a-uuid";
+    for (api_path, thing, args) in [
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/postgres/{MALFORMED_ID}"),
+            "Postgres service",
+            vec!["postgres", "get", MALFORMED_ID, "--org-id", LOOKUP_ORG_ID],
+        ),
+        (
+            format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{MALFORMED_ID}"),
+            "service",
+            vec!["service", "get", MALFORMED_ID, "--org-id", LOOKUP_ORG_ID],
+        ),
+        (
+            format!("/v1/organizations/{MALFORMED_ID}"),
+            "organization",
+            vec!["org", "get", MALFORMED_ID],
+        ),
+    ] {
+        let mock = MockServer::start().await;
+        mount_invalid_id_400(&mock, api_path, thing, MALFORMED_ID).await;
+
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_eq!(output.status.code(), Some(1), "args {args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            stderr,
+            format!("Error: BAD_REQUEST: Invalid {thing} id string:\"{MALFORMED_ID}\"\n"),
+        );
+        assert!(
+            !stderr.contains("\"code\""),
+            "no structured code for an unclassified failure: {stderr}"
+        );
+    }
+}
+
+/// A `service delete` for an id no service has, with the organization id also
+/// a well-formed UUID so every path identifier passes the structural test.
+fn invoke_unknown_service_delete(mock: &MockServer, force: bool) -> std::process::Output {
+    let mut args = vec!["service", "delete", UNKNOWN_UUID, "--org-id", LOOKUP_ORG_ID];
+    if force {
+        args.push("--force");
+    }
+    invoke_cli_human(mock, &args)
+}
+
+/// `--force` reads the service first to decide whether to stop it. That read
+/// must treat the 400 the way it treats a 404 (see
+/// `forced_service_delete_surfaces_not_found_for_an_absent_service`): carry
+/// on to the delete, rather than aborting on an id `service get` reports as
+/// missing.
+#[tokio::test]
+async fn forced_service_delete_proceeds_when_the_read_rejects_a_well_formed_id() {
+    let mock = MockServer::start().await;
+    let service_path = format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{UNKNOWN_UUID}");
+    Mock::given(method("GET"))
+        .and(path(service_path.clone()))
+        .respond_with(invalid_id_400_response("service", UNKNOWN_UUID))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(service_path.clone()))
+        .respond_with(invalid_id_400_response("service", UNKNOWN_UUID))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_unknown_service_delete(&mock, true);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: No such service: {UNKNOWN_UUID} (organization {LOOKUP_ORG_ID}). \
+             The API rejected the identifier: \
+             BAD_REQUEST: Invalid service id string:\"{UNKNOWN_UUID}\"\n"
+        )
+    );
+    // The read did not abort the command: the delete was still attempted.
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![
+            ("GET".to_string(), service_path.clone()),
+            ("DELETE".to_string(), service_path),
+        ]
+    );
+}
+
+/// Without `--force` there is no read at all, so the delete's own 400 is what
+/// has to be refined.
+#[tokio::test]
+async fn service_delete_reports_a_well_formed_unknown_id_as_not_found() {
+    let mock = MockServer::start().await;
+    let service_path = format!("/v1/organizations/{LOOKUP_ORG_ID}/services/{UNKNOWN_UUID}");
+    Mock::given(method("DELETE"))
+        .and(path(service_path.clone()))
+        .respond_with(invalid_id_400_response("service", UNKNOWN_UUID))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_unknown_service_delete(&mock, false);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: No such service: {UNKNOWN_UUID} (organization {LOOKUP_ORG_ID}). \
+             The API rejected the identifier: \
+             BAD_REQUEST: Invalid service id string:\"{UNKNOWN_UUID}\"\n"
+        )
+    );
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("DELETE".to_string(), service_path)]
+    );
 }


### PR DESCRIPTION
## What

`cloud postgres get 00000000-0000-0000-0000-000000000000` printed `Error: BAD_REQUEST: Invalid Postgres service id string:"0000..."` and exited 1. `cloud service get` and `cloud org get` behaved the same way. The API answers HTTP 400 for a syntactically valid UUID that resolves to nothing, so a missing resource was reported as a malformed request.

Every command that reads or deletes one of those resources by identifier now re-presents that failure as a not-found, keeping the server's own text as the trailing detail. The refinement is applied by `CloudClient::convert_error_for_lookup` in `src/cloud/client.rs`, and the call sites are the three get wrappers (`get_service`, `get_postgres_service`, `get_organization`), the read behind `service delete --force` (`get_service_if_exists`), and `delete_service`.

A `ResourceLookup` describes the identifiers the CLI put into the request path. It is built only through `ResourceLookup::in_org(kind, id, org_id)` and `ResourceLookup::organization(id)`, with private fields, so the kind and the organization id cannot disagree: an organization lookup is always scoped to itself, and every other kind is always scoped to the organization it was read from. `ResourceLookup::rejected_well_formed_ids` is the single implementation of the judgement, read both by `convert_error_for_lookup` and by `get_service_if_exists`.

## Why

There is no message to read here. CLAUDE.md forbids deriving a category from response prose, and the library `Error` contract says a distinguishable failure gets a variant rather than a recognisable message. The API's text is prose with the id interpolated into it, so it could never become a typed variant either.

The refinement is therefore structural and lives in the CLI. A by-identifier request has exactly one class of user-controlled input: the identifiers the CLI itself formatted into the URL path. When the API answers 400 and every one of those parses with `uuid::Uuid::parse_str`, "the identifier is invalid" is not what happened. The two structural inputs are the status the library reported and whether those ids parse. Nothing reads the response body.

That reasoning covers a delete by identifier exactly as it covers a read, which is why `delete_service` is included: it sends no body and takes no other user input. It also covers the read behind `--force`, where the API's 400 for a well-formed id is the same answer as its 404, so treating it as an absent service is what keeps `service delete --force` consistent with `service get` on the same id. Nothing else was widened, and `service_delete_error`, which still sniffs a `CONFLICT:` prefix, is tracked separately.

Conversion still runs through `convert_error_with_organization`, so the telemetry classification (#450) is the faithful `http_4xx` for status 400 and is carried across the rewrite with `..error`. Only the user-facing message changes, and no telemetry vocabulary is derived from the id or the message. Every other status is left alone, including the existing organization-scope enrichment on a bare 404.

`CloudErrorDetail` already carries a `code`, so a code fitted without contortion: `resource_not_found`, added to `CloudErrorCode` and to the existing stable-codes test. Its `command` is the matching `list` for the scope, which carries an organization id at most and nothing the message did not already name. Both the scope parenthetical in the message and that command key on the resource kind, not on the two identifiers being string-equal.

Two smaller inconsistencies the refinement exposed are fixed with it. `postgres get` was one of the pre-modularization paths that called `client.api()` directly, so it moves onto the `get_postgres_service` wrapper; to keep that move behaviour-preserving, the module's `unwrap_api` helper now delegates to `CloudClient::unwrap_response`, so every Postgres path reports an empty body the way the rest of the cloud surface does. And the repair verification's skip note reads `could not read service <id>: <error>` rather than nesting the refined message inside parentheses.

## Behaviour after the fix

A well-formed identifier no resource has, on a read:

```
Error: No such Postgres service: 00000000-0000-0000-0000-000000000000 (organization 00000000-0000-4000-8000-000000000001). The API rejected the identifier: BAD_REQUEST: Invalid Postgres service id string:"00000000-0000-0000-0000-000000000000"
```

The same identifier on a delete, with and without `--force`. With `--force` the read no longer aborts the command, so the delete is still attempted and its own answer is what the user sees:

```
Error: No such service: 00000000-0000-0000-0000-000000000000 (organization 00000000-0000-4000-8000-000000000001). The API rejected the identifier: BAD_REQUEST: Invalid service id string:"00000000-0000-0000-0000-000000000000"
```

A malformed identifier is untouched, in human and in `--json` mode, because there the API's "invalid" answer is both true and the more useful thing to say:

```
Error: BAD_REQUEST: Invalid Postgres service id string:"not-a-uuid"
```

`--json` mode carries the same message as human mode under the new stable cloud code, plus the command that lists what does exist in the same scope:

```json
{
  "error": {
    "code": "resource_not_found",
    "message": "No such organization: 00000000-0000-0000-0000-000000000000. The API rejected the identifier: BAD_REQUEST: Invalid organization id string:\"00000000-0000-0000-0000-000000000000\"",
    "command": "clickhousectl cloud org list"
  }
}
```

## Tests

- Unit tests next to the existing `convert_error_*` tests in `src/cloud/client.rs`: the not-found message for each of the three kinds with the server text appended, the nil UUID counted as well formed, the organization never naming an organization as its own scope however the lookup was built, the `failure` classification still `http_4xx` at status 400, the structured detail and its command, a malformed resource id left alone, a malformed organization id left alone even when the resource id parses, and 404, 500 and a non-API error unchanged.
- Subprocess and wiremock tests in `crates/clickhousectl/tests/cli_request_shape_test.rs` against a mocked 400 `Invalid ... id` body: exact stderr and exit 1 for human `postgres get`, `service get` and `org get` with a nil UUID; the `resource_not_found` code and command in `--json` mode for all three; the raw server message preserved for `not-a-uuid` on all three in human mode and in `--json` mode, where the failure stays prose with no `code`; `service delete --force` on a nil UUID whose read answers 400 still issuing the delete and reporting the refined message, mirroring the existing 404 test's request shape; and `service delete` without `--force`, where the delete's own 400 is refined and no read is made at all.
- The repair verification test that pinned the old skip note is updated to the new wording.
- No telemetry test: none of these paths records a `FailureStage`, so no failure fields reach a payload today and there is nothing for the existing harness to assert. Giving them a stage would be a separate change. The classification itself is pinned by the unit test.
- Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`, and `cargo test -p clickhousectl`. The API library is unchanged, so its suites were not affected.

## Stacking

Part of a stacked PR chain: based on `fix/665-elide-pem-in-human-output`, not `main`.

Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
