### PR TITLE
Stop requiring `--username`/`--password` for IAM_ROLE MySQL ClickPipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,15 @@ clickhousectl cloud clickpipe create mysql <service-id> \
   --table-mapping "mydb.users:mydb_users" \
   --server-id 4242
 
+# From an RDS or Aurora MySQL with IAM role authentication (CDC)
+# IAM_ROLE auth takes no --username/--password: the role ARN is the credential
+clickhousectl cloud clickpipe create mysql <service-id> \
+  --name my-rds-mysql-pipe \
+  --host mysql.abcdefg.us-east-1.rds.amazonaws.com \
+  --mysql-type rdsmysql \
+  --auth IAM_ROLE --iam-role "$MYSQL_IAM_ROLE_ARN" \
+  --table-mapping "mydb.users:mydb_users"
+
 # From MongoDB (CDC)
 clickhousectl cloud clickpipe create mongodb <service-id> \
   --name my-mongo-pipe \
@@ -1213,6 +1222,19 @@ must be between 10 and 600, and `--filter` takes a Pub/Sub CEL subscription
 filter of at most 256 characters. Both are checked before the request is sent.
 
 Use `clickhousectl cloud clickpipe create <source> --help` for the full list of options per source type.
+
+#### MySQL ClickPipe authentication
+
+`clickpipe create mysql` authenticates with either a username and password
+(the default `--auth basic`) or an AWS IAM role on an RDS or Aurora MySQL
+source (`--auth IAM_ROLE`).
+
+`--auth IAM_ROLE` requires `--iam-role`; the CLI rejects `--iam-role` with
+basic auth rather than silently ignoring it. `--username` and `--password` are
+basic-auth only and must be given together: they are required for the default
+`--auth basic`, and rejected with `--auth IAM_ROLE`, where the role ARN is the
+whole credential and no `credentials` object is sent. Each rule is a usage
+error (exit code 2) before any request is made.
 
 #### Reverse private endpoints (PrivateLink, Private Service Connect)
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -62,11 +62,15 @@ impl CloudArgs {
             )
     }
 
-    pub fn postgres_clickpipe_validation_error(&self) -> Option<String> {
+    /// The `clickpipe create <source>` validation message and the source
+    /// subcommand it belongs to, if the flags cannot describe the chosen
+    /// `--auth`. Covers both database sources whose credential flags depend on
+    /// `--auth`'s value: `postgres` and `mysql`.
+    pub fn clickpipe_create_validation_error(&self) -> Option<(&'static str, String)> {
         let CloudCommands::ClickPipe { command } = &self.command else {
             return None;
         };
-        command.postgres_create_validation_error()
+        command.clickpipe_create_validation_error()
     }
 
     /// The `clickpipe reverse-private-endpoint create` validation message, if

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -501,7 +501,16 @@ DOCUMENTATION:
     Postgres(PostgresCreateArgs),
 
     /// Create a ClickPipe from MySQL
-    #[command(name = "mysql")]
+    #[command(
+        name = "mysql",
+        after_help = "\
+MYSQL INPUT RULES:
+  --auth basic requires --username and --password, which must be given
+  together.
+  --auth IAM_ROLE requires --iam-role, and rejects --username and --password
+  instead of silently ignoring them: the role ARN is the whole credential.
+  --iam-role is rejected with --auth basic instead of being silently ignored."
+    )]
     MySQL(MySqlCreateArgs),
 
     /// Create a ClickPipe from MongoDB
@@ -1053,11 +1062,11 @@ pub struct MySqlCreateArgs {
     #[arg(long, default_value = "3306")]
     pub port: u16,
 
-    /// Username (basic auth only; invalid with --auth IAM_ROLE)
+    /// Username (required with --auth basic; invalid with --auth IAM_ROLE)
     #[arg(long, requires = "password")]
     pub username: Option<String>,
 
-    /// Password (basic auth only; invalid with --auth IAM_ROLE)
+    /// Password (required with --auth basic; invalid with --auth IAM_ROLE)
     #[arg(long, requires = "username")]
     pub password: Option<String>,
 
@@ -5753,13 +5762,89 @@ mod tests {
     }
 
     #[test]
+    fn mysql_help_documents_input_rules() {
+        // The credential pair is `Option` so IAM_ROLE auth can omit it, which
+        // takes it out of the usage line; the help text is what tells a user
+        // basic auth still needs both flags.
+        let error = clickpipe_parse_error(&["create", "mysql", "--help"]);
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+
+        assert!(help.contains("MYSQL INPUT RULES:"), "{help}");
+        assert!(
+            help.contains("--auth basic requires --username and --password"),
+            "{help}"
+        );
+        assert!(help.contains("must be given"), "{help}");
+        assert!(
+            help.contains("--auth IAM_ROLE requires --iam-role"),
+            "{help}"
+        );
+        assert!(help.contains("rejects --username and --password"), "{help}");
+        assert!(
+            help.contains("the role ARN is the whole credential"),
+            "{help}"
+        );
+        assert!(
+            help.contains("--iam-role is rejected with --auth basic"),
+            "{help}"
+        );
+        assert!(help.contains("silently ignored"), "{help}");
+        for flag in [
+            "--username <USERNAME>",
+            "--password <PASSWORD>",
+            "--iam-role <IAM_ROLE>",
+        ] {
+            assert!(help.contains(flag), "missing `{flag}`:\n{help}");
+        }
+    }
+
+    /// `main` formats the `clickpipe create` usage error against the source
+    /// subcommand named by `clickpipe_create_validation_error`, so every name
+    /// that hook can return has to resolve in the real clap command tree.
+    #[test]
+    fn every_clickpipe_create_validation_source_resolves_to_a_subcommand() {
+        use clap::CommandFactory;
+
+        // One failing invocation per source whose flag relationships are
+        // validated after parsing. The match in
+        // `clickpipe_create_validation_error` is exhaustive, so a new source
+        // that gains checks has to be added here too.
+        let mut postgres = postgres_cli_args(Some("public.events:events"));
+        postgres.extend(["--iam-role", "arn:aws:iam::123456789012:role/clickpipe"]);
+        let sources: Vec<&'static str> = [postgres, mysql_create_cli_args()]
+            .iter()
+            .map(|args| {
+                parse_clickpipe(args)
+                    .clickpipe_create_validation_error()
+                    .unwrap_or_else(|| panic!("expected a validation error for: {args:?}"))
+                    .0
+            })
+            .collect();
+        assert_eq!(sources, ["postgres", "mysql"]);
+
+        let mut command = Cli::command();
+        let create = command
+            .find_subcommand_mut("cloud")
+            .and_then(|cloud| cloud.find_subcommand_mut("clickpipe"))
+            .and_then(|clickpipe| clickpipe.find_subcommand_mut("create"))
+            .expect("clickpipe create command must exist");
+        for source in sources {
+            assert!(
+                create.find_subcommand(source).is_some(),
+                "`clickpipe create {source}` must exist for the usage error to name it"
+            );
+        }
+    }
+
+    #[test]
     fn readme_documents_postgres_tls_and_cdc_prerequisites() {
         let readme = include_str!("../../../../README.md");
         let postgres = readme
             .split_once("### ClickPipes")
             .expect("ClickPipes section")
             .1
-            .split_once("#### Discovering a source schema")
+            .split_once("#### MySQL ClickPipe authentication")
             .expect("next ClickPipes section")
             .0;
 
@@ -5808,10 +5893,10 @@ mod tests {
 
         for expected in [
             "`--auth IAM_ROLE` requires `--iam-role`",
-            "rejects `--iam-role` with\nbasic auth",
-            "`--username` and `--password` are\nbasic-auth only and must be given together",
+            "rejects `--iam-role` with",
+            "basic-auth only and must be given together",
             "no `credentials` object is sent",
-            "usage\nerror (exit code 2)",
+            "(exit code 2) before any request is made",
         ] {
             assert!(mysql.contains(expected), "missing `{expected}`:\n{mysql}");
         }
@@ -5820,7 +5905,10 @@ mod tests {
         let examples = readme
             .split_once("# From MySQL (CDC)")
             .expect("MySQL create example")
-            .1;
+            .1
+            .split_once("# From MongoDB (CDC)")
+            .expect("next create example")
+            .0;
         for expected in [
             "clickhousectl cloud clickpipe create mysql <service-id>",
             "--auth IAM_ROLE --iam-role \"$MYSQL_IAM_ROLE_ARN\"",

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -286,17 +286,33 @@ impl ClickPipeCommands {
         }
     }
 
-    pub(crate) fn postgres_create_validation_error(&self) -> Option<String> {
-        let ClickPipeCommands::Create {
-            command: ClickPipeCreateCommands::Postgres(args),
-        } = self
-        else {
+    /// The `clickpipe create` validation message for a database source whose
+    /// flags cannot describe the chosen `--auth`, paired with the source
+    /// subcommand the usage error belongs to. clap cannot express "forbidden
+    /// for this value of another argument", so these checks run after parsing.
+    pub(crate) fn clickpipe_create_validation_error(&self) -> Option<(&'static str, String)> {
+        let ClickPipeCommands::Create { command } = self else {
             return None;
         };
 
-        validate_postgres_create_args(args)
-            .err()
-            .map(|error| error.message)
+        // Exhaustive so a new database source has to decide whether its flag
+        // relationships need checking here.
+        let (source, error) = match command {
+            ClickPipeCreateCommands::Postgres(args) => {
+                ("postgres", validate_postgres_create_args(args).err())
+            }
+            ClickPipeCreateCommands::MySQL(args) => {
+                ("mysql", validate_mysql_create_args(args).err())
+            }
+            ClickPipeCreateCommands::ObjectStorage(_)
+            | ClickPipeCreateCommands::Kafka(_)
+            | ClickPipeCreateCommands::Kinesis(_)
+            | ClickPipeCreateCommands::MongoDB(_)
+            | ClickPipeCreateCommands::BigQuery(_)
+            | ClickPipeCreateCommands::PubSub(_) => return None,
+        };
+
+        error.map(|error| (source, error.message))
     }
 
     pub(crate) fn reverse_private_endpoint_create_validation_error(&self) -> Option<String> {
@@ -1037,13 +1053,13 @@ pub struct MySqlCreateArgs {
     #[arg(long, default_value = "3306")]
     pub port: u16,
 
-    /// Username
-    #[arg(long)]
-    pub username: String,
+    /// Username (basic auth only; invalid with --auth IAM_ROLE)
+    #[arg(long, requires = "password")]
+    pub username: Option<String>,
 
-    /// Password
-    #[arg(long)]
-    pub password: String,
+    /// Password (basic auth only; invalid with --auth IAM_ROLE)
+    #[arg(long, requires = "username")]
+    pub password: Option<String>,
 
     /// Table mappings as schema.table:target_table (repeatable)
     #[arg(long = "table-mapping")]
@@ -1081,8 +1097,8 @@ pub struct MySqlCreateArgs {
     )]
     pub auth: String,
 
-    /// IAM role ARN
-    #[arg(long)]
+    /// IAM role ARN (required with --auth IAM_ROLE; invalid with basic auth)
+    #[arg(long, required_if_eq("auth", "IAM_ROLE"))]
     pub iam_role: Option<String>,
 
     /// TLS hostname
@@ -3054,23 +3070,58 @@ async fn clickpipe_create_postgres(
     Ok(())
 }
 
-async fn clickpipe_create_mysql(
-    client: &CloudClient,
+/// Check the `clickpipe create mysql` flag relationships clap cannot express,
+/// because each one depends on the value of `--auth` rather than its presence.
+fn validate_mysql_create_args(args: &MySqlCreateArgs) -> CloudResult<()> {
+    // Clap enforces this for parsed input via `required_if_eq`; hand-built
+    // args reach it here.
+    if args.auth == "IAM_ROLE" && args.iam_role.is_none() {
+        return Err(CloudError::new(
+            "--auth IAM_ROLE requires --iam-role <IAM_ROLE>",
+        ));
+    }
+    if args.auth == "basic" && args.iam_role.is_some() {
+        return Err(CloudError::new(
+            "--iam-role cannot be used with --auth basic; use --auth IAM_ROLE",
+        ));
+    }
+    // IAM_ROLE authentication has no username or password: the role ARN is the
+    // whole credential. Reject the pair rather than silently dropping it, the
+    // same way basic auth rejects --iam-role.
+    if args.auth == "IAM_ROLE" && (args.username.is_some() || args.password.is_some()) {
+        return Err(CloudError::new(
+            "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic",
+        ));
+    }
+    // clap joins --username and --password with `requires`, so half a pair is
+    // already a usage error; this owns the "basic auth needs the pair at all"
+    // rule, which clap cannot express because it depends on --auth's value.
+    if args.auth == "basic" && (args.username.is_none() || args.password.is_none()) {
+        return Err(CloudError::new(
+            "--auth basic requires --username <USERNAME> and --password <PASSWORD>",
+        ));
+    }
+
+    Ok(())
+}
+
+fn build_mysql_request(
     args: &MySqlCreateArgs,
-    json: bool,
-) -> CloudResult<()> {
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostRequest> {
     use clickhouse_cloud_api::models::{
-        ClickPipeMutateMySQLSource, ClickPipeMySQLPipeSettings, ClickPipeMySQLPipeTableMapping,
-        ClickPipePostRequest, ClickPipePostSource, PLAIN,
+        ClickPipeMutateMySQLSource, ClickPipeMutateMySQLSourceAuthentication,
+        ClickPipeMySQLPipeSettings, ClickPipeMySQLPipeTableMapping, ClickPipePostRequest,
+        ClickPipePostSource, PLAIN,
     };
 
-    let org_id = resolve_org_id(client, args.org_id.as_deref()).await?;
+    validate_mysql_create_args(args)?;
     let mappings = parse_db_table_mappings(&args.table_mappings)?;
 
-    let ca_certificate = match args.ca_certificate.as_deref() {
-        Some(path) => Some(std::fs::read_to_string(path)?),
-        None => None,
-    };
+    let ca_certificate = args
+        .ca_certificate
+        .as_deref()
+        .map(std::fs::read_to_string)
+        .transpose()?;
 
     let table_mappings = mappings
         .into_iter()
@@ -3084,15 +3135,35 @@ async fn clickpipe_create_mysql(
         )
         .collect();
 
+    // Match the parsed authentication mode, not the raw `--auth` string, so a
+    // new mode added to the library enum is a compile error here rather than a
+    // silent credential-less create.
+    let authentication: ClickPipeMutateMySQLSourceAuthentication = parse_enum(&args.auth)?;
+    let credentials = match &authentication {
+        // `validate_mysql_create_args` has already required the pair for basic
+        // auth, so `zip` yields `Some` for every invocation that reaches here.
+        ClickPipeMutateMySQLSourceAuthentication::Basic => args
+            .username
+            .as_deref()
+            .zip(args.password.as_deref())
+            .map(|(username, password)| PLAIN {
+                username: username.to_string(),
+                password: password.to_string(),
+            }),
+        // The role ARN is the whole credential: the `credentials` object must
+        // stay off the wire entirely.
+        ClickPipeMutateMySQLSourceAuthentication::IAM_ROLE => None,
+        // Unreachable for parsed input, since --auth is restricted to
+        // DB_AUTHS; an unknown mode has no credential shape to send.
+        ClickPipeMutateMySQLSourceAuthentication::Unknown(_) => None,
+    };
+
     let source = ClickPipeMutateMySQLSource {
         r#type: Some(parse_enum(&args.mysql_type)?),
-        credentials: Some(PLAIN {
-            username: args.username.clone(),
-            password: args.password.clone(),
-        }),
+        credentials,
         host: args.host.clone(),
         port: i64::from(args.port),
-        authentication: Some(parse_enum(&args.auth)?),
+        authentication: Some(authentication),
         iam_role: args.iam_role.clone(),
         tls_host: args.tls_host.clone(),
         ca_certificate,
@@ -3111,7 +3182,7 @@ async fn clickpipe_create_mysql(
         table_mappings,
     };
 
-    let request = ClickPipePostRequest {
+    Ok(ClickPipePostRequest {
         name: args.name.clone(),
         source: ClickPipePostSource {
             mysql: Some(source),
@@ -3124,7 +3195,16 @@ async fn clickpipe_create_mysql(
             build_destination_roles(&args.destination_roles.roles),
         ),
         ..Default::default()
-    };
+    })
+}
+
+async fn clickpipe_create_mysql(
+    client: &CloudClient,
+    args: &MySqlCreateArgs,
+    json: bool,
+) -> CloudResult<()> {
+    let request = build_mysql_request(args)?;
+    let org_id = resolve_org_id(client, args.org_id.as_deref()).await?;
 
     let clickpipe = client
         .create_clickpipe(&org_id, &args.service_id, &request)
@@ -3455,6 +3535,14 @@ mod tests {
         *command
     }
 
+    /// The `clickpipe create` validation message for a parsed command,
+    /// dropping the source subcommand the usage error is reported against.
+    fn clickpipe_validation_message(command: &ClickPipeCommands) -> Option<String> {
+        command
+            .clickpipe_create_validation_error()
+            .map(|(_, message)| message)
+    }
+
     fn assert_rejected(args: &[&str]) {
         assert!(
             Cli::try_parse_from(
@@ -3782,7 +3870,7 @@ mod tests {
     }
 
     fn assert_mysql_value(flag: &str, value: &str) {
-        parse_clickpipe(&[
+        let mut args = vec![
             "create",
             "mysql",
             "svc-1",
@@ -3790,13 +3878,18 @@ mod tests {
             "pipe-1",
             "--host",
             "mysql.example",
-            "--username",
-            "user",
-            "--password",
-            "password",
             flag,
             value,
-        ]);
+        ];
+        // Each auth mode gets only its own credential flags: the CLI rejects
+        // --username/--password with IAM_ROLE, so pairing them here would
+        // assert an invocation the CLI refuses to run.
+        if flag == "--auth" && value == "IAM_ROLE" {
+            args.extend(["--iam-role", "arn:aws:iam::123456789012:role/clickpipe"]);
+        } else {
+            args.extend(["--username", "user", "--password", "password"]);
+        }
+        parse_clickpipe(&args);
     }
 
     fn assert_mongodb_value(flag: &str, value: &str) {
@@ -5353,10 +5446,12 @@ mod tests {
         let command = parse_clickpipe(&cli_args);
         assert_eq!(
             command
-                .postgres_create_validation_error()
-                .as_deref()
-                .map(|message| message.contains("--table-mapping-json #1: invalid JSON")),
-            Some(true)
+                .clickpipe_create_validation_error()
+                .map(|(source, message)| (
+                    source,
+                    message.contains("--table-mapping-json #1: invalid JSON")
+                )),
+            Some(("postgres", true))
         );
     }
 
@@ -5412,7 +5507,7 @@ mod tests {
         args.extend(["--username", "user", "--password", "password"]);
         let command = parse_clickpipe(&args);
         assert_eq!(
-            command.postgres_create_validation_error().as_deref(),
+            clickpipe_validation_message(&command).as_deref(),
             Some("--username and --password cannot be used with --auth IAM_ROLE; use --auth basic")
         );
     }
@@ -5479,7 +5574,7 @@ mod tests {
 
         let command = parse_clickpipe(&args);
         assert_eq!(
-            command.postgres_create_validation_error().as_deref(),
+            clickpipe_validation_message(&command).as_deref(),
             Some("--auth basic requires --username <USERNAME> and --password <PASSWORD>")
         );
     }
@@ -5529,7 +5624,7 @@ mod tests {
         basic_with_role.extend(["--iam-role", "arn:aws:iam::123456789012:role/clickpipe"]);
         let command = parse_clickpipe(&basic_with_role);
         assert_eq!(
-            command.postgres_create_validation_error().as_deref(),
+            clickpipe_validation_message(&command).as_deref(),
             Some("--iam-role cannot be used with --auth basic; use --auth IAM_ROLE")
         );
 
@@ -5543,7 +5638,7 @@ mod tests {
             ]);
             let command = parse_clickpipe(&args);
             assert_eq!(
-                command.postgres_create_validation_error().as_deref(),
+                clickpipe_validation_message(&command).as_deref(),
                 Some("--replication-slot-name can only be used with --replication-mode cdc_only")
             );
         }
@@ -5701,6 +5796,44 @@ mod tests {
     }
 
     #[test]
+    fn readme_documents_mysql_iam_role_authentication() {
+        let readme = include_str!("../../../../README.md");
+        let mysql = readme
+            .split_once("#### MySQL ClickPipe authentication")
+            .expect("MySQL ClickPipe authentication section")
+            .1
+            .split_once("#### Reverse private endpoints")
+            .expect("next ClickPipes section")
+            .0;
+
+        for expected in [
+            "`--auth IAM_ROLE` requires `--iam-role`",
+            "rejects `--iam-role` with\nbasic auth",
+            "`--username` and `--password` are\nbasic-auth only and must be given together",
+            "no `credentials` object is sent",
+            "usage\nerror (exit code 2)",
+        ] {
+            assert!(mysql.contains(expected), "missing `{expected}`:\n{mysql}");
+        }
+
+        // The example the section describes is in the create block above it.
+        let examples = readme
+            .split_once("# From MySQL (CDC)")
+            .expect("MySQL create example")
+            .1;
+        for expected in [
+            "clickhousectl cloud clickpipe create mysql <service-id>",
+            "--auth IAM_ROLE --iam-role \"$MYSQL_IAM_ROLE_ARN\"",
+            "--mysql-type rdsmysql",
+        ] {
+            assert!(
+                examples.contains(expected),
+                "missing `{expected}`:\n{examples}"
+            );
+        }
+    }
+
+    #[test]
     fn readme_documents_the_json_table_mapping_form() {
         let readme = include_str!("../../../../README.md");
         let mappings = readme
@@ -5819,10 +5952,6 @@ mod tests {
             "mysql.example",
             "--port",
             "3307",
-            "--username",
-            "user",
-            "--password",
-            "password",
             "--table-mapping",
             "source.one:one",
             "--table-mapping",
@@ -5855,8 +5984,9 @@ mod tests {
         assert_eq!(args.name, "pipe-1");
         assert_eq!(args.host, "mysql.example");
         assert_eq!(args.port, 3307);
-        assert_eq!(args.username, "user");
-        assert_eq!(args.password, "password");
+        // IAM_ROLE authentication takes the role ARN, not a credential pair.
+        assert_eq!(args.username, None);
+        assert_eq!(args.password, None);
         assert_eq!(args.table_mappings, ["source.one:one", "source.two:two"]);
         assert_eq!(args.mysql_type, "mariadb");
         assert_eq!(args.replication_mode, "cdc_only");
@@ -5891,6 +6021,8 @@ mod tests {
             panic!("expected mysql create");
         };
         assert_eq!(args.port, 3306);
+        assert_eq!(args.username.as_deref(), Some("user"));
+        assert_eq!(args.password.as_deref(), Some("password"));
         assert!(args.table_mappings.is_empty());
         assert_eq!(args.mysql_type, "mysql");
         assert_eq!(args.replication_mode, "cdc");
@@ -5921,6 +6053,145 @@ mod tests {
                 invalid,
             ]);
         }
+    }
+
+    /// Minimal `clickpipe create mysql` invocation, before any auth flags.
+    fn mysql_create_cli_args() -> Vec<&'static str> {
+        vec![
+            "create",
+            "mysql",
+            "svc-1",
+            "--name",
+            "pipe-1",
+            "--host",
+            "mysql.example",
+            "--table-mapping",
+            "source.events:events",
+        ]
+    }
+
+    #[test]
+    fn mysql_iam_role_auth_does_not_require_username_or_password() {
+        // IAM_ROLE authentication has no username or password: the role ARN is
+        // the whole credential, so clap must not demand the pair.
+        let mut args = mysql_create_cli_args();
+        args.extend([
+            "--auth",
+            "IAM_ROLE",
+            "--iam-role",
+            "arn:aws:iam::123456789012:role/clickpipe",
+        ]);
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::MySQL(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected mysql create");
+        };
+        assert_eq!(parsed.username, None);
+        assert_eq!(parsed.password, None);
+        assert_eq!(parsed.auth, "IAM_ROLE");
+        assert_eq!(
+            parsed.iam_role.as_deref(),
+            Some("arn:aws:iam::123456789012:role/clickpipe")
+        );
+        assert_eq!(clickpipe_validation_message(&parse_clickpipe(&args)), None);
+
+        // The pair is rejected rather than silently dropped, the same way
+        // basic auth rejects --iam-role.
+        args.extend(["--username", "user", "--password", "password"]);
+        assert_eq!(
+            parse_clickpipe(&args).clickpipe_create_validation_error(),
+            Some((
+                "mysql",
+                "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic"
+                    .to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn mysql_iam_role_only_error_names_the_role_flag_and_not_the_pair() {
+        // `--auth IAM_ROLE` on its own must ask for --iam-role only: asking for
+        // the credential pair would send the user into the "cannot be used with
+        // --auth IAM_ROLE" rejection.
+        let mut args = mysql_create_cli_args();
+        args.extend(["--auth", "IAM_ROLE"]);
+        let error = clickpipe_parse_error(&args);
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        let message = error.to_string();
+        assert!(message.contains("--iam-role"), "{message}");
+        assert!(!message.contains("--username"), "{message}");
+        assert!(!message.contains("--password"), "{message}");
+    }
+
+    #[test]
+    fn mysql_basic_auth_without_any_credentials_is_a_validation_error() {
+        // clap only pairs the two flags, so neither being present parses
+        // cleanly and `validate_mysql_create_args` owns the basic-auth rule:
+        // it depends on --auth's value, which clap cannot express.
+        let args = mysql_create_cli_args();
+        let ClickPipeCommands::Create {
+            command: ClickPipeCreateCommands::MySQL(parsed),
+        } = parse_clickpipe(&args)
+        else {
+            panic!("expected mysql create");
+        };
+        assert_eq!(parsed.auth, "basic");
+        assert_eq!(parsed.username, None);
+        assert_eq!(parsed.password, None);
+
+        assert_eq!(
+            parse_clickpipe(&args).clickpipe_create_validation_error(),
+            Some((
+                "mysql",
+                "--auth basic requires --username <USERNAME> and --password <PASSWORD>".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn mysql_basic_auth_still_requires_username_and_password() {
+        // The two flags are joined with clap `requires`, so half a pair is a
+        // usage error naming the missing half rather than the whole set.
+        for omitted in ["--username", "--password"] {
+            let mut args = mysql_create_cli_args();
+            args.extend(["--username", "user", "--password", "password"]);
+            let position = args.iter().position(|arg| *arg == omitted).unwrap();
+            args.drain(position..position + 2);
+
+            let error = clickpipe_parse_error(&args);
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "omitting {omitted} should be a usage error"
+            );
+            assert!(error.to_string().contains(omitted), "{error}");
+        }
+    }
+
+    #[test]
+    fn mysql_iam_role_with_basic_auth_is_a_validation_error() {
+        // The reverse of the credential rule, and the guard MySQL previously
+        // lacked entirely: basic auth has no use for a role ARN.
+        let mut args = mysql_create_cli_args();
+        args.extend([
+            "--username",
+            "user",
+            "--password",
+            "password",
+            "--iam-role",
+            "arn:aws:iam::123456789012:role/clickpipe",
+        ]);
+        assert_eq!(
+            parse_clickpipe(&args).clickpipe_create_validation_error(),
+            Some((
+                "mysql",
+                "--iam-role cannot be used with --auth basic; use --auth IAM_ROLE".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -7868,6 +8139,183 @@ mod tests {
 
         for (args, diagnostic) in cases {
             let error = build_postgres_request(&args).unwrap_err();
+            assert!(error.message.contains(diagnostic), "{}", error.message);
+        }
+    }
+
+    fn mysql_builder_args() -> MySqlCreateArgs {
+        MySqlCreateArgs {
+            service_id: "svc-1".into(),
+            name: "pipe-1".into(),
+            host: "mysql.example".into(),
+            port: 3306,
+            username: Some("user".into()),
+            password: Some("password".into()),
+            table_mappings: vec!["source.events:events".into()],
+            mysql_type: "mysql".into(),
+            replication_mode: "cdc".into(),
+            replication_mechanism: "GTID".into(),
+            auth: "basic".into(),
+            iam_role: None,
+            tls_host: None,
+            ca_certificate: None,
+            disable_tls: false,
+            skip_cert_verification: false,
+            server_id: None,
+            destination_roles: DestinationRoleArgs::default(),
+            org_id: None,
+        }
+    }
+
+    #[test]
+    fn build_mysql_request_sends_basic_credentials() {
+        let request = build_mysql_request(&mysql_builder_args()).unwrap();
+
+        assert_eq!(request.name, "pipe-1");
+        assert_eq!(request.destination.database, "default");
+        assert_eq!(request.destination.table, None);
+        assert_eq!(request.destination.roles, None);
+        assert!(request.source.postgres.is_none());
+        assert!(request.source.kafka.is_none());
+
+        let source = request.source.mysql.as_ref().expect("mysql source");
+        assert_eq!(source.r#type.as_ref().unwrap().to_string(), "mysql");
+        assert_eq!(source.authentication.as_ref().unwrap().to_string(), "basic");
+        let credentials = source.credentials.as_ref().expect("basic credentials");
+        assert_eq!(credentials.username, "user");
+        assert_eq!(credentials.password, "password");
+        assert_eq!(source.host, "mysql.example");
+        assert_eq!(source.port, 3306);
+        assert_eq!(source.iam_role, None);
+        assert_eq!(source.tls_host, None);
+        assert_eq!(source.ca_certificate, None);
+        assert_eq!(source.disable_tls, None);
+        assert_eq!(source.skip_cert_verification, None);
+        assert_eq!(source.server_id, None);
+        assert_eq!(source.settings.replication_mode.to_string(), "cdc");
+        assert_eq!(
+            source
+                .settings
+                .replication_mechanism
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            "GTID"
+        );
+        assert_eq!(source.table_mappings.len(), 1);
+        assert_eq!(source.table_mappings[0].source_schema_name, "source");
+        assert_eq!(source.table_mappings[0].source_table, "events");
+        assert_eq!(source.table_mappings[0].target_table, "events");
+    }
+
+    #[test]
+    fn build_mysql_request_omits_the_credentials_object_for_iam_role() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca_certificate = directory.path().join("mysql-ca.pem");
+        std::fs::write(&ca_certificate, "MYSQL_CA").unwrap();
+        let mut args = mysql_builder_args();
+        args.name = "maximal-pipe".into();
+        args.host = "rds.example".into();
+        args.port = 3307;
+        // IAM_ROLE auth has no username or password: the role ARN is the whole
+        // credential, so the `credentials` object is omitted entirely.
+        args.username = None;
+        args.password = None;
+        args.table_mappings = vec!["source.users:users_raw".into(), "audit.log:audit".into()];
+        args.mysql_type = "rdsmysql".into();
+        args.replication_mode = "cdc_only".into();
+        args.replication_mechanism = "FILE_POS".into();
+        args.auth = "IAM_ROLE".into();
+        args.iam_role = Some("arn:aws:iam::123456789012:role/clickpipe".into());
+        args.tls_host = Some("database.internal".into());
+        args.ca_certificate = Some(ca_certificate.to_string_lossy().into_owned());
+        args.disable_tls = true;
+        args.skip_cert_verification = true;
+        args.server_id = Some(4_294_967_295);
+        args.destination_roles = DestinationRoleArgs {
+            roles: vec!["analytics_reader".into()],
+        };
+        args.org_id = Some("org-1".into());
+
+        let request = build_mysql_request(&args).unwrap();
+        assert_eq!(request.name, "maximal-pipe");
+        assert_eq!(
+            request.destination.roles,
+            Some(vec!["analytics_reader".to_string()])
+        );
+
+        let source = request.source.mysql.as_ref().expect("mysql source");
+        assert_eq!(source.r#type.as_ref().unwrap().to_string(), "rdsmysql");
+        assert_eq!(
+            source.authentication.as_ref().unwrap().to_string(),
+            "IAM_ROLE"
+        );
+        assert_eq!(source.credentials, None);
+        assert_eq!(
+            source.iam_role.as_deref(),
+            Some("arn:aws:iam::123456789012:role/clickpipe")
+        );
+        assert_eq!(source.host, "rds.example");
+        assert_eq!(source.port, 3307);
+        assert_eq!(source.tls_host.as_deref(), Some("database.internal"));
+        // The file contents are sent, not the path.
+        assert_eq!(source.ca_certificate.as_deref(), Some("MYSQL_CA"));
+        assert_eq!(source.disable_tls, Some(true));
+        assert_eq!(source.skip_cert_verification, Some(true));
+        assert_eq!(source.server_id, Some(4_294_967_295));
+        assert_eq!(source.settings.replication_mode.to_string(), "cdc_only");
+        assert_eq!(
+            source
+                .settings
+                .replication_mechanism
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            "FILE_POS"
+        );
+        assert_eq!(source.table_mappings.len(), 2);
+    }
+
+    #[test]
+    fn build_mysql_request_defensively_rejects_invalid_credential_combinations() {
+        let cases = [
+            {
+                let mut args = mysql_builder_args();
+                args.auth = "IAM_ROLE".into();
+                (args, "--auth IAM_ROLE requires --iam-role <IAM_ROLE>")
+            },
+            {
+                let mut args = mysql_builder_args();
+                args.iam_role = Some("arn:role".into());
+                (args, "--iam-role cannot be used with --auth basic")
+            },
+            {
+                let mut args = mysql_builder_args();
+                args.auth = "IAM_ROLE".into();
+                args.iam_role = Some("arn:role".into());
+                (
+                    args,
+                    "--username and --password cannot be used with --auth IAM_ROLE",
+                )
+            },
+            {
+                let mut args = mysql_builder_args();
+                args.username = None;
+                args.password = None;
+                (
+                    args,
+                    "--auth basic requires --username <USERNAME> and --password <PASSWORD>",
+                )
+            },
+            {
+                let mut args = mysql_builder_args();
+                args.table_mappings = vec!["source.events".into()];
+                (args, "Invalid table mapping")
+            },
+        ];
+
+        for (args, diagnostic) in cases {
+            let error = build_mysql_request(&args).unwrap_err();
             assert!(error.message.contains(diagnostic), "{}", error.message);
         }
     }

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -177,15 +177,24 @@ fn validate_post_parse(cli: &Cli, cmd: &mut clap::Command) -> std::result::Resul
     let Some((source, message)) = args.clickpipe_create_validation_error() else {
         return Ok(());
     };
-    let create_source = cmd
+    let create = cmd
         .find_subcommand_mut("cloud")
         .and_then(|cloud| cloud.find_subcommand_mut("clickpipe"))
         .and_then(|clickpipe| clickpipe.find_subcommand_mut("create"))
-        .and_then(|create| create.find_subcommand_mut(source))
-        .unwrap_or_else(|| panic!("clickpipe create {source} command must exist"));
+        .expect("clickpipe create command must exist");
+    // The usage error belongs to the source subcommand. If the returned literal
+    // ever drifts from a `#[command(name)]`, report it against `clickpipe
+    // create` instead of panicking on a valid invocation.
+    let owner = if create.find_subcommand(source).is_some() {
+        create
+            .find_subcommand_mut(source)
+            .expect("presence checked immediately above")
+    } else {
+        create
+    };
     // ArgumentConflict is intentional for invalid relationships between valid
     // values, matching existing CLI validation and preserving exit code 2.
-    Err(create_source.error(ErrorKind::ArgumentConflict, message))
+    Err(owner.error(ErrorKind::ArgumentConflict, message))
 }
 
 /// Run a successfully parsed invocation to completion and report the exit

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -172,19 +172,20 @@ fn validate_post_parse(cli: &Cli, cmd: &mut clap::Command) -> std::result::Resul
     }
 
     // clap can require --iam-role for one auth value, but cannot express the
-    // inverse conflict or condition --replication-slot-name on another value.
-    let Some(message) = args.postgres_clickpipe_validation_error() else {
+    // inverse conflict, require the credential pair only for basic auth, or
+    // condition --replication-slot-name on another value.
+    let Some((source, message)) = args.clickpipe_create_validation_error() else {
         return Ok(());
     };
-    let postgres = cmd
+    let create_source = cmd
         .find_subcommand_mut("cloud")
         .and_then(|cloud| cloud.find_subcommand_mut("clickpipe"))
         .and_then(|clickpipe| clickpipe.find_subcommand_mut("create"))
-        .and_then(|create| create.find_subcommand_mut("postgres"))
-        .expect("clickpipe create postgres command must exist");
+        .and_then(|create| create.find_subcommand_mut(source))
+        .unwrap_or_else(|| panic!("clickpipe create {source} command must exist"));
     // ArgumentConflict is intentional for invalid relationships between valid
     // values, matching existing CLI validation and preserving exit code 2.
-    Err(postgres.error(ErrorKind::ArgumentConflict, message))
+    Err(create_source.error(ErrorKind::ArgumentConflict, message))
 }
 
 /// Run a successfully parsed invocation to completion and report the exit

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3657,6 +3657,138 @@ async fn postgres_credentials_with_iam_role_auth_are_rejected() {
     );
 }
 
+/// The minimal `clickpipe create mysql` argument set for basic auth.
+fn mysql_args_minimal() -> Vec<String> {
+    [
+        "clickpipe",
+        "create",
+        "mysql",
+        "svc-id",
+        "--name",
+        "t",
+        "--host",
+        "mysql",
+        "--port",
+        "3306",
+        "--table-mapping",
+        "mydb.t:t",
+        "--replication-mode",
+        "cdc",
+        "--org-id",
+        "org",
+        "--username",
+        "u",
+        "--password",
+        "p",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// The same set for IAM_ROLE authentication: no `--username`/`--password`,
+/// because the role ARN is the whole credential.
+fn mysql_args_iam_role() -> Vec<String> {
+    [
+        "clickpipe",
+        "create",
+        "mysql",
+        "svc-id",
+        "--name",
+        "t",
+        "--host",
+        "mysql",
+        "--port",
+        "3306",
+        "--table-mapping",
+        "mydb.t:t",
+        "--replication-mode",
+        "cdc",
+        "--org-id",
+        "org",
+        "--auth",
+        "IAM_ROLE",
+        "--iam-role",
+        "arn:aws:iam::123:role/x",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+#[tokio::test]
+async fn mysql_iam_role_create_omits_the_credentials_object() {
+    // IAM_ROLE authentication has no username or password: the role ARN is the
+    // whole credential, so `credentials` must be absent from the wire rather
+    // than sent as an empty username/password pair.
+    let mock = start_mock_clickpipes_api().await;
+    let args = mysql_args_iam_role();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+    assert!(
+        body["source"]["mysql"].get("credentials").is_none(),
+        "credentials must not be sent for IAM_ROLE auth, got {}",
+        body["source"]["mysql"]
+    );
+    assert_eq!(
+        body["source"]["mysql"]["iamRole"], "arn:aws:iam::123:role/x",
+        "iamRole should round-trip the user-provided value"
+    );
+    assert_eq!(body["source"]["mysql"]["authentication"], "IAM_ROLE");
+}
+
+#[tokio::test]
+async fn mysql_basic_auth_create_sends_the_credentials_object() {
+    let mock = start_mock_clickpipes_api().await;
+    let args = mysql_args_minimal();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+    assert_eq!(body["source"]["mysql"]["credentials"]["username"], "u");
+    assert_eq!(body["source"]["mysql"]["credentials"]["password"], "p");
+    assert_eq!(body["source"]["mysql"]["authentication"], "basic");
+}
+
+#[tokio::test]
+async fn mysql_credentials_with_iam_role_auth_are_rejected() {
+    let mock = MockServer::start().await;
+    let mut args = mysql_args_iam_role();
+    args.push("--username".into());
+    args.push("u".into());
+    args.push("--password".into());
+    args.push("p".into());
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let output = invoke_cli_with_cloud_credentials(&mock, &arg_refs);
+    // Reported as a usage error against the owning command, the same way
+    // `--iam-role` with basic auth is: clap cannot express "forbidden for this
+    // value of another argument", so the check runs after parsing.
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "--username and --password cannot be used with --auth IAM_ROLE; use --auth basic"
+        ),
+        "{stderr}"
+    );
+    // The usage line names the source subcommand the flags belong to.
+    assert!(stderr.contains("clickpipe create mysql"), "{stderr}");
+}
+
+#[tokio::test]
+async fn mysql_iam_role_with_basic_auth_is_rejected() {
+    let mock = MockServer::start().await;
+    let mut args = mysql_args_minimal();
+    args.push("--iam-role".into());
+    args.push("arn:aws:iam::123:role/x".into());
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let output = invoke_cli_with_cloud_credentials(&mock, &arg_refs);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--iam-role cannot be used with --auth basic; use --auth IAM_ROLE"),
+        "{stderr}"
+    );
+}
+
 #[tokio::test]
 async fn postgres_ca_certificate_file_contents_flow_to_body() {
     use std::io::Write;


### PR DESCRIPTION
## What

`clickhousectl cloud clickpipe create mysql --auth IAM_ROLE --iam-role arn:...` failed clap validation with `the following required arguments were not provided: --username --password`, so an RDS or Aurora MySQL pipe using IAM role authentication could not be created at all. This is the MySQL twin of #662 and takes the same shape as the fix that landed there.

- `--username` and `--password` are now `Option<String>` joined to each other with clap `requires`, so the pair is all-or-nothing and half a pair is still a usage error naming the missing half.
- The "basic auth needs the pair at all" rule moves to a new `validate_mysql_create_args` check, because it depends on `--auth`'s value, which clap cannot express.
- `--iam-role` gains `required_if_eq("auth", "IAM_ROLE")`, matching the Postgres flag, so `--auth IAM_ROLE` on its own asks for the role ARN only.
- MySQL gets the reverse guard it lacked entirely: `--iam-role` with basic auth is rejected instead of being silently ignored.
- `build_mysql_request` is extracted from the handler so the request shape is unit-testable, and it matches the parsed `ClickPipeMutateMySQLSourceAuthentication` instead of comparing `--auth` as a string, so a new authentication mode in the library enum is a compile error here rather than a pipe created with no credentials.
- The post-parse validation hook is generalised to `clickpipe_create_validation_error`, returning the source subcommand alongside the message so each usage error is still reported against the command that owns the flags. Postgres behaviour is unchanged.

## Why

IAM role authentication has no username or password: the role ARN in `iamRole` is the whole credential. The old code demanded the pair and then sent `credentials: {"username": ..., "password": ...}` unconditionally, so there was no way to express an IAM_ROLE MySQL source.

No API library change was needed. `ClickPipeMutateMySQLSource.credentials` is already `Option<PLAIN>` with `skip_serializing_if`, so an IAM_ROLE request omits the object entirely rather than sending an empty pair.

## Behaviour after the fix

| Invocation | Result |
| --- | --- |
| `--auth IAM_ROLE` alone | usage error naming `--iam-role` only, exit 2 |
| `--auth IAM_ROLE --iam-role arn:x` | accepted, no `credentials` key on the wire |
| `--auth IAM_ROLE --iam-role arn:x --username u --password p` | `--username and --password cannot be used with --auth IAM_ROLE; use --auth basic`, exit 2 |
| no auth flags, no credentials | `--auth basic requires --username <USERNAME> and --password <PASSWORD>`, exit 2 |
| `--username u` only | clap `MissingRequiredArgument` naming `--password`, exit 2 |
| `--iam-role arn:x` with default basic auth | `--iam-role cannot be used with --auth basic; use --auth IAM_ROLE`, exit 2 |

## Tests

- Clap coverage next to `MySqlCreateArgs`: IAM_ROLE without credentials parses with both fields `None`; the IAM_ROLE-only error names `--iam-role` and neither credential flag; basic auth with no credentials yields the basic-auth validation message; half a pair is a clap `MissingRequiredArgument` naming the omitted flag; the pair with IAM_ROLE yields the rejection; `--iam-role` with basic auth yields the new guard. `assert_mysql_value` now gives each auth mode only its own flags, and the maximal parse test no longer pairs credentials with IAM_ROLE.
- `build_mysql_request` unit tests: minimal basic auth sends `credentials.username`/`password`, maximal IAM_ROLE sends `credentials == None` with the role ARN, certificate file contents, server ID and roles, and a defensive case list covering all four validation messages plus a malformed table mapping.
- Subprocess and wiremock coverage in `crates/clickhousectl/tests/cli_request_shape_test.rs`: `mysql_iam_role_create_omits_the_credentials_object`, `mysql_basic_auth_create_sends_the_credentials_object`, `mysql_credentials_with_iam_role_auth_are_rejected` (exit 2, usage line naming `clickpipe create mysql`) and `mysql_iam_role_with_basic_auth_is_rejected`.
- README pin test `readme_documents_mysql_iam_role_authentication` covers the new section and the IAM_ROLE example.
- `create mysql --help` now carries a `MYSQL INPUT RULES:` block for the auth rules, since the credential pair left the usage line when it became `Option`; `mysql_help_documents_input_rules` pins it, the Postgres README window now ends at the MySQL section so its shared wording cannot satisfy the Postgres assertions, and `every_clickpipe_create_validation_source_resolves_to_a_subcommand` checks every source name the post-parse hook can return against the real command tree.
- Verification commands, all clean:
  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
  - `cargo test -p clickhousectl`
- Not verified live: acceptance of an omitted `credentials` object for an IAM_ROLE MySQL pipe needs an RDS or Aurora MySQL fixture. The schema's `required[]` omits `credentials`, and the Postgres equivalent behaves this way, so this is the same bet #662 made.

## Stacking

Part of a stacked PR chain: based on `fix/664-server-list-pid-consistency`, not `main`.

Fixes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
