### PR TITLE
fix(api): reconcile live OpenAPI drift for 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ With `clickhousectl` you can:
 
 `clickhousectl` helps humans and coding agents develop with ClickHouse and Postgres.
 
+The workspace also publishes the [typed Rust Cloud API client](crates/clickhouse-cloud-api/README.md). Its latest OpenAPI snapshot adds credit balances, service profile discovery, ClickPipes workload identity context, and expanded ClickPipes and ClickStack models; [CLI exposure is tracked separately](https://github.com/ClickHouse/clickhousectl/issues/699).
+
 ## Installation
 
 ### Quick install

--- a/crates/clickhouse-cloud-api/README.md
+++ b/crates/clickhouse-cloud-api/README.md
@@ -2,6 +2,18 @@
 
 Typed Rust client for the [ClickHouse Cloud API](https://clickhouse.com/docs/en/cloud/manage/openapi).
 
+## Updated Cloud API surface
+
+The live snapshot adds `credit_balances_get` (trial and prepaid credit balances), `service_profiles_list` (region and optional BYOC infrastructure), and `click_pipes_service_context_get` (GCP workload identity readiness and principal).
+
+BigQuery and Pub/Sub source models now distinguish service-account and workload-identity authentication with typed unions. Build `ClickPipePostBigQueryServiceAccountSource` or `ClickPipePostPubSubServiceAccountSource` and call `.into()` for existing service-account flows; workload-identity variants omit customer credentials. BigQuery settings and table mappings now permit the optional fields the API accepts. Kafka requests gain optional `protobuf_schema`, which is only supported for Protobuf without a schema registry; MySQL table mappings gain `partition_by_expr`.
+
+`ServiceProfile` now represents the profile discovery response (`profile`, `cpu_cores`, `memory_gi`); the former `Service.profile` value enum is named `ServiceProfileName`. Dynamic profile names remain lossless through its `Unknown(String)` variant.
+
+ClickStack models now include alert channel lists, 30-second alert intervals, query-timeout errors, chart formulas and series limits, dashboard variables and broadcast filters, service-version expressions, and typed SQL/variable saved-filter unions. New formula and saved-filter response/request pairs support explicit fallible write-back through `TryFrom`; absent nested required fields return their wire names. UDF responses include `deterministic`.
+
+The current alert request schemas have no `required` array or optional marker on either `channel` or `channels`, so both fields remain strict in the Rust request models. This mirrors the documented requiredness policy; it does not establish whether the server accepts a channels-only request. Supply the channel list explicitly rather than relying on the empty `Default` value (the API specifies 1–10 channels).
+
 ## Development
 
 ### Structure

--- a/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
+++ b/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
@@ -5,7 +5,7 @@
     "version": "1.0",
     "contact": {
       "name": "ClickHouse Support",
-      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1066254",
+      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1107336",
       "email": "support@clickhouse.com"
     }
   },
@@ -39,7 +39,7 @@
       "name": "Backup"
     },
     {
-      "name": "OpenAPI"
+      "name": "API keys"
     },
     {
       "name": "Prometheus"
@@ -1331,6 +1331,128 @@
             "name": "Beta",
             "position": "after"
           }
+        ]
+      }
+    },
+    "/v1/organizations/{organizationId}/serviceProfiles": {
+      "get": {
+        "summary": "List available service profiles",
+        "description": "Returns the custom instance profiles the organization can use in a region. Pass byoc_id to list the profiles configured for a BYOC infrastructure. The list is empty when the organization tier does not include custom hardware profiles.",
+        "operationId": "serviceProfilesList",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization to list available profiles for.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "region_id",
+            "description": "Region to list profiles for, e.g. us-east-1.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "byoc_id",
+            "description": "ID of the BYOC infrastructure to list profiles for. BYOC profiles are only returned when this is set.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ServiceProfile"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Service"
         ]
       }
     },
@@ -5383,7 +5505,7 @@
           }
         },
         "tags": [
-          "OpenAPI"
+          "API keys"
         ]
       },
       "post": {
@@ -5491,7 +5613,7 @@
           }
         },
         "tags": [
-          "OpenAPI"
+          "API keys"
         ]
       }
     },
@@ -5602,7 +5724,7 @@
           }
         },
         "tags": [
-          "OpenAPI"
+          "API keys"
         ]
       },
       "patch": {
@@ -5720,7 +5842,7 @@
           }
         },
         "tags": [
-          "OpenAPI"
+          "API keys"
         ]
       },
       "delete": {
@@ -5826,7 +5948,7 @@
           }
         },
         "tags": [
-          "OpenAPI"
+          "API keys"
         ]
       }
     },
@@ -7070,7 +7192,7 @@
     "/v1/organizations/{organizationId}/activeBalances": {
       "get": {
         "summary": "Get organization active prepaid balances",
-        "description": "**This endpoint is in beta.** API contract is stable, and no breaking changes are expected in the future. <br /><br /> Returns the active prepaid credit balances for the organization, each with its own balance ID and remaining credits, along with the total remaining credits across all active balances. A balance is active when it has started, has not expired, and has credits remaining. Balances are ordered by expiration date, soonest first, and the returned page is capped at `limit` (default and maximum 100). When `totalCount` exceeds the number of returned balances, page with `limit`/`offset` to retrieve them all. `totalRemainingPrepaidCredits` always covers every active balance, not just the returned page.",
+        "description": "DEPRECATED. Use the `/v1/organizations/{organizationId}/creditBalances` endpoint instead. <br /><br /> Returns the active prepaid credit balances for the organization, each with its own balance ID and remaining credits, along with the total remaining credits across all active balances. A balance is active when it has started, has not expired, and has credits remaining. Balances are ordered by expiration date, soonest first, and the returned page is capped at `limit` (default and maximum 100). When `totalCount` exceeds the number of returned balances, page with `limit`/`offset` to retrieve them all. `totalRemainingPrepaidCredits` always covers every active balance, not just the returned page.",
         "operationId": "activeBalancesGet",
         "parameters": [
           {
@@ -7125,6 +7247,108 @@
                     },
                     "result": {
                       "$ref": "#/components/schemas/ActiveBalances"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "tags": [
+          "Billing"
+        ]
+      }
+    },
+    "/v1/organizations/{organizationId}/creditBalances": {
+      "get": {
+        "summary": "Get organization active credit balances",
+        "description": "**Disclaimer:** This beta endpoint is evolving; the API contract may change. <br /><br /> Returns the active credit balances for the organization, each with its own balance ID, type and remaining credits, along with the total remaining credits across all of them. A balance is active when it has started, has not expired, and has credits remaining. Balances are ordered by expiration date, soonest first. The list is always present and is empty when the organization has no active balances.",
+        "operationId": "creditBalancesGet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the requested organization.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/CreditBalances"
                     }
                   }
                 }
@@ -7424,6 +7648,123 @@
         },
         "tags": [
           "ClickPipes"
+        ]
+      }
+    },
+    "/v1/organizations/{organizationId}/services/{serviceId}/clickpipes/context": {
+      "get": {
+        "summary": "Get ClickPipes service context",
+        "description": "**This endpoint is in beta.** API contract is stable, and no breaking changes are expected in the future. <br /><br /> Returns service-level ClickPipes capabilities and Private Preview workload identity context, including the GCP service account to grant access to customer source resources.",
+        "operationId": "clickPipesServiceContextGet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization that owns the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceId",
+            "description": "ID of the service to get ClickPipes context for.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ClickPipesServiceContext"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "ClickPipes"
+        ],
+        "x-badges": [
+          {
+            "name": "Beta",
+            "position": "after"
+          }
         ]
       }
     },
@@ -19040,11 +19381,11 @@
             ]
           },
           "minReplicaMemoryGb": {
-            "description": "Minimum memory per replica (Gb) when no schedule entry is active.",
+            "description": "Minimum memory per replica (Gb) when no schedule entry is active. Absent for services that do not autoscale memory.",
             "type": "number"
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum memory per replica (Gb) when no schedule entry is active.",
+            "description": "Maximum memory per replica (Gb) when no schedule entry is active. Absent for services that do not autoscale memory.",
             "type": "number"
           },
           "minReplicas": {
@@ -19528,16 +19869,8 @@
             "type": "boolean"
           },
           "profile": {
-            "description": "Custom instance profile. Only available for ENTERPRISE organization tiers.",
-            "type": "string",
-            "enum": [
-              "v1-default",
-              "v1-highmem-xs",
-              "v1-highmem-s",
-              "v1-highmem-m",
-              "v1-highmem-l",
-              "v1-highmem-xl"
-            ]
+            "description": "Custom instance profile. Only available for ENTERPRISE and BYOC organization tiers. Standard values: 'v1-default', 'v1-highmem-xs', 'v1-highmem-s', 'v1-highmem-m', 'v1-highmem-l', 'v1-highmem-xl'. BYOC services may instead use a dynamic BYOC profile configured for their infrastructure (e.g. 'v1-standard-byoc-4'); it requires byocId, and minReplicaMemoryGb and maxReplicaMemoryGb must both equal the profile's memory size. Use the serviceProfiles endpoint to list the profiles available to the organization.",
+            "type": "string"
           },
           "transparentDataEncryptionKeyId": {
             "description": "The ID of the Transparent Data Encryption key used for the service. This is only available if hasTransparentDataEncryption is true.",
@@ -20610,7 +20943,10 @@
             "description": "Google Cloud service account JSON key file content, base64 encoded.",
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "serviceAccountFile"
+        ]
       },
       "ClickPipeKafkaOffset": {
         "properties": {
@@ -20758,7 +21094,7 @@
             "example": "my-clickpipe-consumer-group"
           },
           "authentication": {
-            "description": "Authentication method of the Kafka source. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
+            "description": "Authentication method of the Kafka source. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
             "type": "string",
             "enum": [
               "PLAIN",
@@ -20766,7 +21102,8 @@
               "SCRAM-SHA-512",
               "IAM_ROLE",
               "IAM_USER",
-              "MUTUAL_TLS"
+              "MUTUAL_TLS",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -20863,7 +21200,7 @@
             "example": "my-clickpipe-consumer-group"
           },
           "authentication": {
-            "description": "Authentication method of the Kafka source. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
+            "description": "Authentication method of the Kafka source. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
             "type": "string",
             "enum": [
               "PLAIN",
@@ -20871,7 +21208,8 @@
               "SCRAM-SHA-512",
               "IAM_ROLE",
               "IAM_USER",
-              "MUTUAL_TLS"
+              "MUTUAL_TLS",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -20939,13 +21277,21 @@
                 "$ref": "#/components/schemas/MutualTLS"
               }
             ]
+          },
+          "protobufSchema": {
+            "description": "Base64-encoded .proto source or serialized FileDescriptorSet. Supported only with Protobuf format and cannot be combined with schemaRegistry.",
+            "type": "string",
+            "example": "c3ludGF4ID0gInByb3RvMyI7IG1lc3NhZ2UgRXZlbnQge30=",
+            "maxLength": 1048576,
+            "minLength": 1,
+            "writeOnly": true
           }
         }
       },
       "ClickPipePatchKafkaSource": {
         "properties": {
           "authentication": {
-            "description": "Authentication method of the Kafka source. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
+            "description": "Authentication method of the Kafka source. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. Supported authentication methods: kafka: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, msk: SCRAM-SHA-512, IAM_ROLE, IAM_USER, MUTUAL_TLS, gcmk: PLAIN, MUTUAL_TLS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY, confluent: PLAIN, MUTUAL_TLS, warpstream: PLAIN, azureeventhub: PLAIN, redpanda: SCRAM-SHA-256, SCRAM-SHA-512, MUTUAL_TLS, dokafka: SCRAM-SHA-256, MUTUAL_TLS",
             "type": [
               "string",
               "null"
@@ -20956,7 +21302,8 @@
               "SCRAM-SHA-512",
               "IAM_ROLE",
               "IAM_USER",
-              "MUTUAL_TLS"
+              "MUTUAL_TLS",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -21260,7 +21607,7 @@
             "example": "events/2026-06-01/"
           },
           "authentication": {
-            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
+            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. For GCS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
             "type": [
               "string",
               "null"
@@ -21269,7 +21616,8 @@
               "IAM_ROLE",
               "IAM_USER",
               "CONNECTION_STRING",
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -21397,7 +21745,7 @@
             "example": "events/2026-06-01/"
           },
           "authentication": {
-            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
+            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. For GCS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
             "type": [
               "string",
               "null"
@@ -21406,7 +21754,8 @@
               "IAM_ROLE",
               "IAM_USER",
               "CONNECTION_STRING",
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -21478,7 +21827,7 @@
             "example": "events/2026-06-01/"
           },
           "authentication": {
-            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
+            "description": "Authentication method. IAM_USER is for S3, GCS, and DigitalOcean Spaces. IAM_ROLE is for S3 only. SERVICE_ACCOUNT is for GCS only. For GCS, SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources. CONNECTION_STRING is for Azure Blob Storage. PUBLIC uses no authentication.",
             "type": [
               "string",
               "null"
@@ -21487,7 +21836,8 @@
               "IAM_ROLE",
               "IAM_USER",
               "CONNECTION_STRING",
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ]
           },
           "iamRole": {
@@ -21914,9 +22264,10 @@
             "example": "-----BEGIN CERTIFICATE-----\n..."
           },
           "disableTls": {
-            "description": "Disable TLS for the Postgres connection. Use with caution in production environments.",
+            "description": "Disable TLS for the Postgres connection. Use with caution in production environments. Defaults to false when omitted.",
             "type": "boolean",
-            "example": false
+            "example": false,
+            "default": false
           },
           "skipCertVerification": {
             "description": "Skip TLS certificate verification for the Postgres connection. Use with caution in production environments.",
@@ -22178,6 +22529,11 @@
             "description": "Custom partitioning column used for parallel snapshotting. Must be an indexed column of an integer, date, datetime or timestamp type. Unrelated to ClickHouse partitioning.",
             "type": "string",
             "example": "id"
+          },
+          "partitionByExpr": {
+            "description": "ClickHouse PARTITION BY expression applied to the destination table when ClickPipes creates it.",
+            "type": "string",
+            "example": "toYYYYMM(created_at)"
           }
         },
         "required": [
@@ -22232,6 +22588,14 @@
               "null"
             ],
             "example": "id"
+          },
+          "partitionByExpr": {
+            "description": "ClickHouse PARTITION BY expression applied to the destination table when ClickPipes creates it.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "toYYYYMM(created_at)"
           }
         },
         "required": [
@@ -22388,9 +22752,10 @@
             "example": "-----BEGIN CERTIFICATE-----\n..."
           },
           "disableTls": {
-            "description": "Disable TLS for the MySQL connection. Use with caution in production environments.",
+            "description": "Disable TLS for the MySQL connection. Use with caution in production environments. Defaults to false when omitted.",
             "type": "boolean",
-            "example": false
+            "example": false,
+            "default": false
           },
           "skipCertVerification": {
             "description": "Skip TLS certificate verification for the MySQL connection. Use with caution in production environments.",
@@ -22555,7 +22920,10 @@
             "description": "Number of parallel tables to snapshot.",
             "type": "number"
           }
-        }
+        },
+        "required": [
+          "replicationMode"
+        ]
       },
       "ClickPipeBigQueryPipeTableMapping": {
         "properties": {
@@ -22598,27 +22966,96 @@
               "Null"
             ]
           }
-        }
+        },
+        "required": [
+          "sourceDatasetName",
+          "sourceTable",
+          "targetTable"
+        ]
+      },
+      "ClickPipeBigQueryServiceAccountSource": {
+        "properties": {
+          "snapshotStagingPath": {
+            "description": "GCS bucket path for staging snapshot data (e.g., gs://my-bucket/staging/). Data will be automatically cleaned up after initial load.",
+            "type": "string"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ClickPipeBigQueryPipeSettings"
+          },
+          "tableMappings": {
+            "type": "array",
+            "description": "Table mappings for BigQuery pipe.",
+            "items": {
+              "$ref": "#/components/schemas/ClickPipeBigQueryPipeTableMapping"
+            }
+          },
+          "authentication": {
+            "description": "Authenticated with a Google Cloud service account JSON key.",
+            "type": "string",
+            "enum": [
+              "SERVICE_ACCOUNT"
+            ]
+          },
+          "projectId": {
+            "description": "GCP project ID that owns the BigQuery resources.",
+            "type": "string",
+            "example": "my-gcp-project"
+          }
+        },
+        "required": [
+          "snapshotStagingPath",
+          "settings",
+          "tableMappings",
+          "authentication"
+        ]
+      },
+      "ClickPipeBigQueryWorkloadIdentitySource": {
+        "properties": {
+          "snapshotStagingPath": {
+            "description": "GCS bucket path for staging snapshot data (e.g., gs://my-bucket/staging/). Data will be automatically cleaned up after initial load.",
+            "type": "string"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ClickPipeBigQueryPipeSettings"
+          },
+          "tableMappings": {
+            "type": "array",
+            "description": "Table mappings for BigQuery pipe.",
+            "items": {
+              "$ref": "#/components/schemas/ClickPipeBigQueryPipeTableMapping"
+            }
+          },
+          "authentication": {
+            "description": "Authenticated with the ClickPipes service tenant identity. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources.",
+            "type": "string",
+            "enum": [
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+            ]
+          },
+          "projectId": {
+            "description": "GCP project ID that owns the BigQuery resources. Older pipes created outside OpenAPI may omit this field.",
+            "type": "string",
+            "example": "my-gcp-project"
+          }
+        },
+        "required": [
+          "snapshotStagingPath",
+          "settings",
+          "tableMappings",
+          "authentication"
+        ]
       },
       "ClickPipeBigQuerySource": {
-        "properties": {
-          "snapshotStagingPath": {
-            "description": "GCS bucket path for staging snapshot data (e.g., gs://my-bucket/staging/). Data will be automatically cleaned up after initial load.",
-            "type": "string"
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ClickPipeBigQueryServiceAccountSource"
           },
-          "settings": {
-            "$ref": "#/components/schemas/ClickPipeBigQueryPipeSettings"
-          },
-          "tableMappings": {
-            "type": "array",
-            "description": "Table mappings for BigQuery pipe.",
-            "items": {
-              "$ref": "#/components/schemas/ClickPipeBigQueryPipeTableMapping"
-            }
+          {
+            "$ref": "#/components/schemas/ClickPipeBigQueryWorkloadIdentitySource"
           }
-        }
+        ]
       },
-      "ClickPipeMutateBigQuerySource": {
+      "ClickPipePostBigQueryServiceAccountSource": {
         "properties": {
           "snapshotStagingPath": {
             "description": "GCS bucket path for staging snapshot data (e.g., gs://my-bucket/staging/). Data will be automatically cleaned up after initial load.",
@@ -22633,11 +23070,79 @@
             "items": {
               "$ref": "#/components/schemas/ClickPipeBigQueryPipeTableMapping"
             }
+          },
+          "authentication": {
+            "description": "Authenticate with a Google Cloud service account JSON key. Defaults to SERVICE_ACCOUNT when omitted.",
+            "type": "string",
+            "enum": [
+              "SERVICE_ACCOUNT"
+            ]
+          },
+          "projectId": {
+            "description": "GCP project ID that owns the BigQuery resources.",
+            "type": "string",
+            "example": "my-gcp-project"
           },
           "credentials": {
             "$ref": "#/components/schemas/ServiceAccount"
           }
-        }
+        },
+        "required": [
+          "snapshotStagingPath",
+          "settings",
+          "tableMappings",
+          "credentials"
+        ],
+        "additionalProperties": false
+      },
+      "ClickPipePostBigQueryWorkloadIdentitySource": {
+        "properties": {
+          "snapshotStagingPath": {
+            "description": "GCS bucket path for staging snapshot data (e.g., gs://my-bucket/staging/). Data will be automatically cleaned up after initial load.",
+            "type": "string"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ClickPipeBigQueryPipeSettings"
+          },
+          "tableMappings": {
+            "type": "array",
+            "description": "Table mappings for BigQuery pipe.",
+            "items": {
+              "$ref": "#/components/schemas/ClickPipeBigQueryPipeTableMapping"
+            }
+          },
+          "authentication": {
+            "description": "Authenticate with the ClickPipes service tenant identity. Customer credentials must not be provided. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources.",
+            "type": "string",
+            "enum": [
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+            ],
+            "example": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+          },
+          "projectId": {
+            "description": "GCP project ID that owns the BigQuery resources.",
+            "type": "string",
+            "example": "my-gcp-project"
+          }
+        },
+        "required": [
+          "snapshotStagingPath",
+          "settings",
+          "tableMappings",
+          "authentication",
+          "projectId"
+        ],
+        "additionalProperties": false
+      },
+      "ClickPipeMutateBigQuerySource": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ClickPipePostBigQueryServiceAccountSource"
+          },
+          {
+            "$ref": "#/components/schemas/ClickPipePostBigQueryWorkloadIdentitySource"
+          }
+        ]
       },
       "ClickPipeMongoDBPipeSettings": {
         "properties": {
@@ -22877,7 +23382,8 @@
           "disableTls": {
             "description": "Disable TLS for the MongoDB connection. Defaults to false (TLS enabled).",
             "type": "boolean",
-            "example": false
+            "example": false,
+            "default": false
           },
           "skipCertVerification": {
             "description": "Skip TLS certificate verification for the MongoDB connection. Use with caution in production environments.",
@@ -22913,7 +23419,7 @@
             "$ref": "#/components/schemas/PLAIN"
           },
           "uri": {
-            "description": "MongoDB connection URI. Supports both standard URIs (mongodb://...) and SRV URIs (mongodb+srv://...). Embedded credentials are redacted from API responses, so the returned value can differ from what was submitted.",
+            "description": "MongoDB connection URI (mongodb:// or mongodb+srv://). Credentials are redacted in responses; a masked value is never saved as a credential, so a real credential equal to [REDACTED] cannot be set. To change the connection, send the full URI with real credentials; omit this field or resend the redacted value to leave it unchanged.",
             "type": [
               "string",
               "null"
@@ -23015,10 +23521,11 @@
             "example": "my-topic"
           },
           "authentication": {
-            "description": "Authentication method to use with GCP Pub/Sub. Currently only SERVICE_ACCOUNT is supported.",
+            "description": "Authentication method to use with GCP Pub/Sub. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources.",
             "type": "string",
             "enum": [
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ],
             "example": "SERVICE_ACCOUNT"
           },
@@ -23074,7 +23581,7 @@
           "seekType"
         ]
       },
-      "ClickPipePostPubSubSource": {
+      "ClickPipePostPubSubServiceAccountSource": {
         "properties": {
           "format": {
             "description": "Format of messages in the Pub/Sub topic. GCP Pub/Sub ClickPipes are in limited preview — contact support to enable this feature for your organization.",
@@ -23097,7 +23604,7 @@
             "example": "my-topic"
           },
           "authentication": {
-            "description": "Authentication method to use with GCP Pub/Sub. Currently only SERVICE_ACCOUNT is supported.",
+            "description": "Authenticate with a GCP service account JSON key.",
             "type": "string",
             "enum": [
               "SERVICE_ACCOUNT"
@@ -23158,18 +23665,113 @@
           "authentication",
           "seekType",
           "serviceAccountKey"
+        ],
+        "additionalProperties": false
+      },
+      "ClickPipePostPubSubWorkloadIdentitySource": {
+        "properties": {
+          "format": {
+            "description": "Format of messages in the Pub/Sub topic. GCP Pub/Sub ClickPipes are in limited preview — contact support to enable this feature for your organization.",
+            "type": "string",
+            "enum": [
+              "JSONEachRow",
+              "Avro",
+              "Protobuf"
+            ],
+            "example": "JSONEachRow"
+          },
+          "projectId": {
+            "description": "GCP project ID that owns the Pub/Sub topic.",
+            "type": "string",
+            "example": "my-gcp-project"
+          },
+          "topic": {
+            "description": "Pub/Sub topic name (not the fully-qualified path).",
+            "type": "string",
+            "example": "my-topic"
+          },
+          "authentication": {
+            "description": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources.",
+            "type": "string",
+            "enum": [
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+            ],
+            "example": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+          },
+          "seekType": {
+            "description": "Starting position strategy for consuming the subscription. The seekTimestamp companion is required only when seekType is \"timestamp\"; setting it for a mismatched seek type is rejected.",
+            "type": "string",
+            "enum": [
+              "latest",
+              "earliest",
+              "timestamp"
+            ],
+            "example": "earliest"
+          },
+          "seekTimestamp": {
+            "description": "RFC 3339 / ISO 8601 timestamp to seek to. Required when seekType is \"timestamp\"; must be omitted otherwise.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "example": "2026-04-10T12:00:00Z"
+          },
+          "filter": {
+            "description": "Optional Pub/Sub subscription filter expression (CEL). Maximum 256 characters.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 256
+          },
+          "enableOrdering": {
+            "description": "Whether to enable ordered delivery of messages (requires messages to be published with ordering keys).",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "ackDeadline": {
+            "description": "Acknowledgement deadline for messages, in seconds. Must be between 10 and 600.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 10,
+            "maximum": 600
+          }
+        },
+        "required": [
+          "format",
+          "projectId",
+          "topic",
+          "authentication",
+          "seekType"
+        ],
+        "additionalProperties": false
+      },
+      "ClickPipePostPubSubSource": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ClickPipePostPubSubServiceAccountSource"
+          },
+          {
+            "$ref": "#/components/schemas/ClickPipePostPubSubWorkloadIdentitySource"
+          }
         ]
       },
       "ClickPipePatchPubSubSource": {
         "properties": {
           "authentication": {
-            "description": "Authentication method to use with GCP Pub/Sub. Currently only SERVICE_ACCOUNT is supported.",
+            "description": "Authentication method to use with GCP Pub/Sub. SERVICE_ACCOUNT_WORKLOAD_IDENTITY is in Private Preview. ClickPipes uses the GCP service account returned in gcpWorkloadIdentity.principal by the operation with operationId clickPipesServiceContextGet; grant it access to the source resources.",
             "type": [
               "string",
               "null"
             ],
             "enum": [
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
             ],
             "example": "SERVICE_ACCOUNT"
           },
@@ -23194,9 +23796,38 @@
           }
         },
         "required": [
-          "authentication",
-          "serviceAccountKey"
+          "authentication"
         ]
+      },
+      "ClickPipesGcpWorkloadIdentityContext": {
+        "properties": {
+          "supported": {
+            "description": "Whether the ClickPipes deployment supports GCP workload identity, which is in Private Preview. The principal field identifies the GCP service account used for source access.",
+            "type": "boolean"
+          },
+          "ready": {
+            "description": "Whether the service tenant identity is ready for workload identity authentication.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "principal": {
+            "description": "GCP service account used by ClickPipes for workload identity authentication. Grant this service account access to customer source resources.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "ch-deadbeef@clickpipes-development.iam.gserviceaccount.com"
+          }
+        }
+      },
+      "ClickPipesServiceContext": {
+        "properties": {
+          "gcpWorkloadIdentity": {
+            "$ref": "#/components/schemas/ClickPipesGcpWorkloadIdentityContext"
+          }
+        }
       },
       "ClickPipeScaling": {
         "properties": {
@@ -24669,6 +25300,7 @@
             "type": "string",
             "enum": [
               "QUERY_ERROR",
+              "QUERY_TIMEOUT",
               "WEBHOOK_ERROR",
               "INVALID_ALERT",
               "UNKNOWN"
@@ -24794,6 +25426,15 @@
           }
         ]
       },
+      "ClickStackAlertChannels": {
+        "type": "array",
+        "description": "Notification channels to trigger when the alert fires or resolves. Between 1 and 10 channels; duplicates are rejected.",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/ClickStackAlertChannel"
+        }
+      },
       "ClickStackAlertResponse": {
         "properties": {
           "dashboardId": {
@@ -24842,9 +25483,10 @@
             "example": 500
           },
           "interval": {
-            "description": "Evaluation interval for the alert.",
+            "description": "Evaluation interval for the alert. `30s` requires the 30s alert interval feature to be enabled for your team.",
             "type": "string",
             "enum": [
+              "30s",
               "1m",
               "5m",
               "15m",
@@ -24899,6 +25541,9 @@
           },
           "channel": {
             "$ref": "#/components/schemas/ClickStackAlertChannel"
+          },
+          "channels": {
+            "$ref": "#/components/schemas/ClickStackAlertChannels"
           },
           "name": {
             "description": "Human-friendly alert name.",
@@ -25039,9 +25684,10 @@
             "example": 500
           },
           "interval": {
-            "description": "Evaluation interval for the alert.",
+            "description": "Evaluation interval for the alert. `30s` requires the 30s alert interval feature to be enabled for your team.",
             "type": "string",
             "enum": [
+              "30s",
               "1m",
               "5m",
               "15m",
@@ -25096,6 +25742,9 @@
           },
           "channel": {
             "$ref": "#/components/schemas/ClickStackAlertChannel"
+          },
+          "channels": {
+            "$ref": "#/components/schemas/ClickStackAlertChannels"
           },
           "name": {
             "description": "Human-friendly alert name.",
@@ -25179,9 +25828,10 @@
             "example": 500
           },
           "interval": {
-            "description": "Evaluation interval for the alert.",
+            "description": "Evaluation interval for the alert. `30s` requires the 30s alert interval feature to be enabled for your team.",
             "type": "string",
             "enum": [
+              "30s",
               "1m",
               "5m",
               "15m",
@@ -25237,6 +25887,9 @@
           "channel": {
             "$ref": "#/components/schemas/ClickStackAlertChannel"
           },
+          "channels": {
+            "$ref": "#/components/schemas/ClickStackAlertChannels"
+          },
           "name": {
             "description": "Human-friendly alert name.",
             "type": [
@@ -25271,10 +25924,10 @@
           }
         }
       },
-      "ClickStackSavedFilterValue": {
+      "ClickStackSqlSavedFilterValue": {
         "properties": {
           "type": {
-            "description": "Filter type. Currently only \"sql\" is supported.",
+            "description": "Filter type.",
             "type": "string",
             "enum": [
               "sql"
@@ -25289,6 +25942,48 @@
         },
         "required": [
           "condition"
+        ]
+      },
+      "ClickStackVariableSavedFilterValue": {
+        "properties": {
+          "type": {
+            "description": "Filter type.",
+            "type": "string",
+            "enum": [
+              "variable"
+            ],
+            "example": "variable"
+          },
+          "name": {
+            "description": "The variableName of the dashboard variable this selection belongs to. Only allowed for variable-enabled filters.",
+            "type": "string",
+            "example": "service"
+          },
+          "values": {
+            "type": "array",
+            "description": "Selected values",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "hdx-oss-dev-api"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "values"
+        ]
+      },
+      "ClickStackSavedFilterValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ClickStackSqlSavedFilterValue"
+          },
+          {
+            "$ref": "#/components/schemas/ClickStackVariableSavedFilterValue"
+          }
         ]
       },
       "ClickStackNumberFormat": {
@@ -26087,6 +26782,26 @@
           "aggFn"
         ]
       },
+      "ClickStackFormula": {
+        "properties": {
+          "expression": {
+            "description": "Arithmetic expression over the select items by position, e.g. \"A / (A + B) * 100\" for a success-rate percentage.",
+            "type": "string",
+            "example": "A / (A + B) * 100"
+          },
+          "alias": {
+            "description": "Display label for the formula series in chart legends and column headers. Falls back to the raw expression text when unset.",
+            "type": "string",
+            "example": "Success rate %"
+          },
+          "numberFormat": {
+            "$ref": "#/components/schemas/ClickStackNumberFormat"
+          }
+        },
+        "required": [
+          "expression"
+        ]
+      },
       "ClickStackLineBuilderChartConfig": {
         "properties": {
           "displayType": {
@@ -26135,6 +26850,22 @@
           },
           "compareToPreviousPeriod": {
             "description": "Overlay the equivalent previous time period for comparison.",
+            "type": "boolean"
+          },
+          "seriesLimit": {
+            "description": "Maximum number of series rendered (top-N by value). Omit to use the default render cap, set 0 for unlimited, or a positive N to keep the top N series.",
+            "type": "integer",
+            "example": 5
+          },
+          "formulas": {
+            "type": "array",
+            "description": "Derived series computed from the select items via letter-ref arithmetic (\"A\" = select[0], \"B\" = select[1], ...). Metric, log, and trace sources only. Cannot be combined with asRatio.",
+            "items": {
+              "$ref": "#/components/schemas/ClickStackFormula"
+            }
+          },
+          "showOperandSeries": {
+            "description": "Only meaningful with formulas. When false, only the formula series are returned; the raw operand series are hidden.",
             "type": "boolean"
           }
         },
@@ -26185,6 +26916,22 @@
           },
           "numberFormat": {
             "$ref": "#/components/schemas/ClickStackNumberFormat"
+          },
+          "seriesLimit": {
+            "description": "Maximum number of series rendered (top-N by value). Omit to use the default render cap, set 0 for unlimited, or a positive N to keep the top N series.",
+            "type": "integer",
+            "example": 5
+          },
+          "formulas": {
+            "type": "array",
+            "description": "Derived series computed from the select items via letter-ref arithmetic (\"A\" = select[0], \"B\" = select[1], ...). Metric, log, and trace sources only. Cannot be combined with asRatio.",
+            "items": {
+              "$ref": "#/components/schemas/ClickStackFormula"
+            }
+          },
+          "showOperandSeries": {
+            "description": "Only meaningful with formulas. When false, only the formula series are returned; the raw operand series are hidden.",
+            "type": "boolean"
           }
         },
         "required": [
@@ -26436,6 +27183,17 @@
           },
           "onClick": {
             "$ref": "#/components/schemas/ClickStackOnClick"
+          },
+          "formulas": {
+            "type": "array",
+            "description": "Derived columns computed from the select items via letter-ref arithmetic (\"A\" = select[0], \"B\" = select[1], ...). Metric, log, and trace sources only. Cannot be combined with asRatio.",
+            "items": {
+              "$ref": "#/components/schemas/ClickStackFormula"
+            }
+          },
+          "showOperandSeries": {
+            "description": "Only meaningful with formulas. When false, only the formula columns are returned; the raw operand columns are hidden.",
+            "type": "boolean"
           }
         },
         "required": [
@@ -26461,9 +27219,16 @@
           },
           "select": {
             "type": "array",
-            "description": "Exactly one aggregated value to display as a single number.",
+            "description": "Exactly one aggregated value to display as a single number — unless \"formulas\" is set, in which case the select items are the formula's operands and the (single) formula value is displayed instead.",
             "items": {
               "$ref": "#/components/schemas/ClickStackSelectItem"
+            }
+          },
+          "formulas": {
+            "type": "array",
+            "description": "A single derived value computed from the select items via letter-ref arithmetic (\"A\" = select[0], \"B\" = select[1], ...). Metric, log, and trace sources only. Number tiles display the formula value and always hide the operand series.",
+            "items": {
+              "$ref": "#/components/schemas/ClickStackFormula"
             }
           },
           "numberFormat": {
@@ -26541,7 +27306,7 @@
             "$ref": "#/components/schemas/ClickStackNumberFormat"
           },
           "limit": {
-            "description": "Maximum number of slices (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first slices in that order. Omit to fetch all groups.",
+            "description": "Maximum number of slices (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first slices in that order. Omit or set 0 to fetch all groups.",
             "type": "integer",
             "example": 10
           }
@@ -26588,7 +27353,7 @@
             "$ref": "#/components/schemas/ClickStackNumberFormat"
           },
           "limit": {
-            "description": "Maximum number of bars (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first bars in that order. Omit to fetch all groups.",
+            "description": "Maximum number of bars (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first bars in that order. Omit or set 0 to fetch all groups.",
             "type": "integer",
             "example": 10
           }
@@ -27372,7 +28137,7 @@
             "example": "Environment"
           },
           "expression": {
-            "description": "Key expression used when applying this dashboard filter key",
+            "description": "SQL expression used when querying values for this filter, and when applying this dashboard filter to tiles.",
             "type": "string",
             "example": "environment"
           },
@@ -27409,13 +28174,28 @@
           },
           "appliesToSourceIds": {
             "type": "array",
-            "description": "Optional list of source IDs this filter applies to. Omit or provide an empty array to apply the filter to ALL tiles regardless of source. A non-empty array restricts the filter to only tiles whose source ID is in the list; tiles using other sources are not affected by the selected filter value(s).",
+            "description": "Optional list of source IDs this filter applies to. Omit or provide an empty array to apply the filter to ALL tiles regardless of source. A non-empty array restricts the filter to only tiles whose source ID is in the list; tiles using other sources are not affected by the selected filter value(s). Scopes the broadcast condition only, so a non-empty array is rejected when isBroadcastEnabled is false, and is omitted from responses for such a filter.",
             "items": {
               "type": "string"
             },
             "example": [
               "65f5e4a3b9e77c001a111111"
             ]
+          },
+          "isBroadcastEnabled": {
+            "description": "Whether the selected value is applied as a filter condition on every builder tile this filter applies to (see appliesToSourceIds), and every raw sql tile using the $__filters macro. Omitting the field means enabled.",
+            "type": "boolean",
+            "example": false
+          },
+          "isVariableEnabled": {
+            "description": "Whether the selected value is exposed to tile queries as a dashboard variable named by variableName. Tiles may reference it as `$variableName` or using the (preferred) `$__filter($<variableName>)` and `$__conditionalAll(<condition>, $<variableName>)` macros.",
+            "type": "boolean",
+            "example": true
+          },
+          "variableName": {
+            "description": "Token tiles reference this filter's selected value by, as `$variableName`. Must start with a letter and may contain only letters, numbers, and underscores. Defaults to the display name with whitespace replaced by underscores and remaining illegal characters removed, so a variable-enabled filter whose name derives nothing usable must send this field explicitly. Variable names must be unique across a dashboard's variable-enabled filters. Names the variable only, so the field is rejected when isVariableEnabled is not true, and is omitted from responses for such a filter.",
+            "type": "string",
+            "example": "environment"
           }
         },
         "required": [
@@ -27441,7 +28221,7 @@
             "example": "Environment"
           },
           "expression": {
-            "description": "Key expression used when applying this dashboard filter key",
+            "description": "SQL expression used when querying values for this filter, and when applying this dashboard filter to tiles.",
             "type": "string",
             "example": "environment"
           },
@@ -27478,13 +28258,28 @@
           },
           "appliesToSourceIds": {
             "type": "array",
-            "description": "Optional list of source IDs this filter applies to. Omit or provide an empty array to apply the filter to ALL tiles regardless of source. A non-empty array restricts the filter to only tiles whose source ID is in the list; tiles using other sources are not affected by the selected filter value(s).",
+            "description": "Optional list of source IDs this filter applies to. Omit or provide an empty array to apply the filter to ALL tiles regardless of source. A non-empty array restricts the filter to only tiles whose source ID is in the list; tiles using other sources are not affected by the selected filter value(s). Scopes the broadcast condition only, so a non-empty array is rejected when isBroadcastEnabled is false, and is omitted from responses for such a filter.",
             "items": {
               "type": "string"
             },
             "example": [
               "65f5e4a3b9e77c001a111111"
             ]
+          },
+          "isBroadcastEnabled": {
+            "description": "Whether the selected value is applied as a filter condition on every builder tile this filter applies to (see appliesToSourceIds), and every raw sql tile using the $__filters macro. Omitting the field means enabled.",
+            "type": "boolean",
+            "example": false
+          },
+          "isVariableEnabled": {
+            "description": "Whether the selected value is exposed to tile queries as a dashboard variable named by variableName. Tiles may reference it as `$variableName` or using the (preferred) `$__filter($<variableName>)` and `$__conditionalAll(<condition>, $<variableName>)` macros.",
+            "type": "boolean",
+            "example": true
+          },
+          "variableName": {
+            "description": "Token tiles reference this filter's selected value by, as `$variableName`. Must start with a letter and may contain only letters, numbers, and underscores. Defaults to the display name with whitespace replaced by underscores and remaining illegal characters removed, so a variable-enabled filter whose name derives nothing usable must send this field explicitly. Variable names must be unique across a dashboard's variable-enabled filters. Names the variable only, so the field is rejected when isVariableEnabled is not true, and is omitted from responses for such a filter.",
+            "type": "string",
+            "example": "environment"
           },
           "id": {
             "description": "Unique dashboard filter key ID",
@@ -27525,7 +28320,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys to add to the dashboard and apply across all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts its selected value as a condition, acts as a variable which can be referenced in tile queries, or both.",
             "items": {
               "$ref": "#/components/schemas/ClickStackFilterInput"
             }
@@ -27648,7 +28443,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys on the dashboard, applied across all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts its selected value as a condition, acts as a variable which can be referenced in tile queries, or both.",
             "items": {
               "$ref": "#/components/schemas/ClickStackFilter"
             }
@@ -27725,7 +28520,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys added to the dashboard and applied to all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts its selected value as a condition, acts as a variable which can be referenced in tile queries, or both.",
             "items": {
               "$ref": "#/components/schemas/ClickStackFilter"
             }
@@ -27898,6 +28693,29 @@
         "required": [
           "permissions"
         ]
+      },
+      "ClickStackValidationErrorItemErrors": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "ClickStackValidationErrorItem": {
+        "properties": {
+          "type": {
+            "description": "Request part that failed validation.",
+            "type": "string",
+            "example": "Body"
+          },
+          "errors": {
+            "$ref": "#/components/schemas/ClickStackValidationErrorItemErrors"
+          }
+        }
+      },
+      "ClickStackValidationError": {
+        "type": "array",
+        "description": "zod-express-middleware validation failures.",
+        "items": {
+          "$ref": "#/components/schemas/ClickStackValidationErrorItem"
+        }
       },
       "ClickStackSavedSearchFilter": {
         "properties": {
@@ -28089,7 +28907,7 @@
       "ClickStackFilterSettingsColumn": {
         "properties": {
           "name": {
-            "description": "Column name used to load filters for prepending to every query for the source.",
+            "description": "Column of the source's table that selected filter values are matched against. Also the key the selection is persisted under in links, saved searches, and dashboards.",
             "type": "string",
             "example": "ServiceName"
           },
@@ -28097,6 +28915,19 @@
             "description": "Display label for the column",
             "type": "string",
             "example": "Service Name"
+          },
+          "valueExpression": {
+            "description": "Optional SQL expression, evaluated against the filter-values table, that produces the available filter options. Use it when the options live in a differently-named column, or must be transformed to match the values stored in the source table. Defaults to reading `name` as a plain column when omitted.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "lower(service_name)"
+          },
+          "allowAll": {
+            "description": "Whether to offer an \"All\" option that expands to every available value at query time. Best suited to low-cardinality columns. Defaults to false.",
+            "type": "boolean",
+            "example": false
           }
         },
         "required": [
@@ -28398,6 +29229,14 @@
               "null"
             ],
             "example": "ServiceName"
+          },
+          "serviceVersionExpression": {
+            "description": "Expression identifying the running release of a service. Defaults to the OpenTelemetry service.version resource attribute when unset. Where services carry the release on different attributes, fall back across them with coalesce(nullIf(a, ''), nullIf(b, '')).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "ResourceAttributes['service.version']"
           },
           "severityTextExpression": {
             "description": "Expression to extract the severity/log level text.",
@@ -28709,6 +29548,14 @@
               "null"
             ],
             "example": "ServiceName"
+          },
+          "serviceVersionExpression": {
+            "description": "Expression identifying the running release of a service. Defaults to the OpenTelemetry service.version resource attribute when unset. Where services carry the release on different attributes, fall back across them with coalesce(nullIf(a, ''), nullIf(b, '')).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "ResourceAttributes['service.version']"
           },
           "resourceAttributesExpression": {
             "description": "Expression to extract resource-level attributes.",
@@ -31062,6 +31909,22 @@
           "adjustable"
         ]
       },
+      "ServiceProfile": {
+        "properties": {
+          "profile": {
+            "description": "Profile name to pass as `profile` when creating a service (e.g. 'v1-standard-byoc-4').",
+            "type": "string"
+          },
+          "cpuCores": {
+            "description": "Number of vCPUs per replica.",
+            "type": "number"
+          },
+          "memoryGi": {
+            "description": "Memory per replica in GiB. When creating a BYOC service with this profile, minReplicaMemoryGb and maxReplicaMemoryGb must both equal this value.",
+            "type": "number"
+          }
+        }
+      },
       "ActiveBalance": {
         "properties": {
           "id": {
@@ -31104,6 +31967,60 @@
             "description": "List of active prepaid balances for the organization.",
             "items": {
               "$ref": "#/components/schemas/ActiveBalance"
+            }
+          }
+        }
+      },
+      "CreditBalance": {
+        "properties": {
+          "id": {
+            "description": "Unique ID of the balance.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "description": "Type of the balance.",
+            "type": "string",
+            "enum": [
+              "prepaid",
+              "trial"
+            ]
+          },
+          "remainingCredits": {
+            "description": "Remaining credits available on this balance, in ClickHouse Credits (CHCs).",
+            "type": "number"
+          },
+          "totalAmount": {
+            "description": "Total credits granted on this balance, in ClickHouse Credits (CHCs).",
+            "type": "number"
+          },
+          "amountSpent": {
+            "description": "Credits spent from this balance, in ClickHouse Credits (CHCs).",
+            "type": "number"
+          },
+          "startDate": {
+            "description": "Date the balance became active. ISO-8601, based on the UTC timezone.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "expirationDate": {
+            "description": "Date the balance expires. ISO-8601, based on the UTC timezone.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreditBalances": {
+        "properties": {
+          "totalRemainingCredits": {
+            "description": "Total remaining credits across all active balances, in ClickHouse Credits (CHCs).",
+            "type": "number"
+          },
+          "balances": {
+            "type": "array",
+            "description": "List of active balances for the organization. Empty when the organization has none.",
+            "items": {
+              "$ref": "#/components/schemas/CreditBalance"
             }
           }
         }
@@ -32911,16 +33828,8 @@
             }
           },
           "profile": {
-            "description": "Custom instance profile. Only available for ENTERPRISE organization tiers.",
-            "type": "string",
-            "enum": [
-              "v1-default",
-              "v1-highmem-xs",
-              "v1-highmem-s",
-              "v1-highmem-m",
-              "v1-highmem-l",
-              "v1-highmem-xl"
-            ]
+            "description": "Custom instance profile. Only available for ENTERPRISE and BYOC organization tiers. Standard values: 'v1-default', 'v1-highmem-xs', 'v1-highmem-s', 'v1-highmem-m', 'v1-highmem-l', 'v1-highmem-xl'. BYOC services may instead use a dynamic BYOC profile configured for their infrastructure (e.g. 'v1-standard-byoc-4'); it requires byocId, and minReplicaMemoryGb and maxReplicaMemoryGb must both equal the profile's memory size. Use the serviceProfiles endpoint to list the profiles available to the organization.",
+            "type": "string"
           },
           "complianceType": {
             "description": "Type of regulatory compliance for service.",
@@ -33286,16 +34195,8 @@
             "type": "boolean"
           },
           "profile": {
-            "description": "Custom instance profile. Only available for ENTERPRISE organization tiers.",
-            "type": "string",
-            "enum": [
-              "v1-default",
-              "v1-highmem-xs",
-              "v1-highmem-s",
-              "v1-highmem-m",
-              "v1-highmem-l",
-              "v1-highmem-xl"
-            ]
+            "description": "Custom instance profile. Only available for ENTERPRISE and BYOC organization tiers. Standard values: 'v1-default', 'v1-highmem-xs', 'v1-highmem-s', 'v1-highmem-m', 'v1-highmem-l', 'v1-highmem-xl'. BYOC services may instead use a dynamic BYOC profile configured for their infrastructure (e.g. 'v1-standard-byoc-4'); it requires byocId, and minReplicaMemoryGb and maxReplicaMemoryGb must both equal the profile's memory size. Use the serviceProfiles endpoint to list the profiles available to the organization.",
+            "type": "string"
           },
           "transparentDataEncryptionKeyId": {
             "description": "The ID of the Transparent Data Encryption key used for the service. This is only available if hasTransparentDataEncryption is true.",
@@ -33928,6 +34829,11 @@
                 "default": false,
                 "type": "boolean"
               },
+              "deterministic": {
+                "description": "Marks the UDF as deterministic so ClickHouse can reuse cached query results. Only set this when the UDF always returns the same result for the same arguments.",
+                "default": false,
+                "type": "boolean"
+              },
               "format": {
                 "default": "TabSeparated",
                 "type": "string"
@@ -34059,6 +34965,11 @@
                 ]
               },
               "sendChunkHeader": {
+                "default": false,
+                "type": "boolean"
+              },
+              "deterministic": {
+                "description": "Marks the UDF as deterministic so ClickHouse can reuse cached query results. Only set this when the UDF always returns the same result for the same arguments.",
                 "default": false,
                 "type": "boolean"
               },
@@ -34195,6 +35106,11 @@
                 "default": false,
                 "type": "boolean"
               },
+              "deterministic": {
+                "description": "Marks the UDF as deterministic so ClickHouse can reuse cached query results. Only set this when the UDF always returns the same result for the same arguments.",
+                "default": false,
+                "type": "boolean"
+              },
               "format": {
                 "default": "TabSeparated",
                 "type": "string"
@@ -34324,6 +35240,11 @@
                 "default": false,
                 "type": "boolean"
               },
+              "deterministic": {
+                "description": "Marks the UDF as deterministic so ClickHouse can reuse cached query results. Only set this when the UDF always returns the same result for the same arguments.",
+                "default": false,
+                "type": "boolean"
+              },
               "format": {
                 "default": "TabSeparated",
                 "type": "string"
@@ -34370,6 +35291,48 @@
           }
         ],
         "type": "object"
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "totalRecords": {
+            "description": "Total number of records available.",
+            "type": "integer"
+          },
+          "currentCursor": {
+            "description": "Cursor for the current page. Null for the first page.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nextCursor": {
+            "description": "Cursor for the next page. Null if there are no more results.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "limit": {
+            "description": "Maximum number of records returned per page.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "totalRecords",
+          "currentCursor",
+          "nextCursor",
+          "limit"
+        ],
+        "additionalProperties": false
       },
       "UdfAttachment": {
         "type": "object",
@@ -34426,48 +35389,6 @@
         "required": [
           "items",
           "pagination"
-        ],
-        "additionalProperties": false
-      },
-      "Pagination": {
-        "type": "object",
-        "properties": {
-          "totalRecords": {
-            "description": "Total number of records available.",
-            "type": "integer"
-          },
-          "currentCursor": {
-            "description": "Cursor for the current page. Null for the first page.",
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "nextCursor": {
-            "description": "Cursor for the next page. Null if there are no more results.",
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "limit": {
-            "description": "Maximum number of records returned per page.",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "totalRecords",
-          "currentCursor",
-          "nextCursor",
-          "limit"
         ],
         "additionalProperties": false
       },
@@ -34599,6 +35520,10 @@
             "description": "Whether ClickHouse sends a row-count chunk header.",
             "type": "boolean"
           },
+          "deterministic": {
+            "description": "Whether ClickHouse may reuse cached query results for this UDF.",
+            "type": "boolean"
+          },
           "format": {
             "description": "Input and output format used by the UDF command.",
             "type": "string"
@@ -34657,6 +35582,7 @@
           "maxCommandExecutionTime",
           "memoryLimitMib",
           "sendChunkHeader",
+          "deterministic",
           "format",
           "sandboxType",
           "sandboxVersion",
@@ -34760,9 +35686,9 @@
       ]
     },
     {
-      "name": "OpenAPI",
+      "name": "API keys",
       "tags": [
-        "OpenAPI"
+        "API keys"
       ]
     },
     {

--- a/crates/clickhouse-cloud-api/src/client/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/client/clickpipes.rs
@@ -3,6 +3,31 @@ use crate::error::Error;
 use crate::models::*;
 
 impl Client {
+    /// Get ClickPipes service capabilities and workload identity.
+    pub async fn click_pipes_service_context_get(
+        &self,
+        organization_id: &str,
+        service_id: &str,
+    ) -> Result<ApiResponse<ClickPipesServiceContext>, Error> {
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/context");
+        let req = self.request(reqwest::Method::GET, &path);
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
     /// List ClickPipes
     pub async fn click_pipe_get_list(
         &self,

--- a/crates/clickhouse-cloud-api/src/client/organizations.rs
+++ b/crates/clickhouse-cloud-api/src/client/organizations.rs
@@ -3,6 +3,29 @@ use crate::error::Error;
 use crate::models::*;
 
 impl Client {
+    /// Get active organization credit balances.
+    pub async fn credit_balances_get(
+        &self,
+        organization_id: &str,
+    ) -> Result<ApiResponse<CreditBalances>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/creditBalances");
+        let req = self.request(reqwest::Method::GET, &path);
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
     /// Get organization active prepaid balances
     pub async fn active_balances_get(
         &self,

--- a/crates/clickhouse-cloud-api/src/client/services.rs
+++ b/crates/clickhouse-cloud-api/src/client/services.rs
@@ -3,6 +3,36 @@ use crate::error::Error;
 use crate::models::*;
 
 impl Client {
+    /// List available custom service profiles.
+    pub async fn service_profiles_list(
+        &self,
+        organization_id: &str,
+        region_id: &str,
+        byoc_id: Option<&str>,
+    ) -> Result<ApiResponse<Vec<ServiceProfile>>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/serviceProfiles");
+        let req = self.request(reqwest::Method::GET, &path);
+        let req = req.query(&[("region_id", region_id)]);
+        let req = if let Some(byoc_id) = byoc_id {
+            req.query(&[("byoc_id", byoc_id)])
+        } else {
+            req
+        };
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
     /// List of organization services
     pub async fn instance_get_list(
         &self,

--- a/crates/clickhouse-cloud-api/src/convert/clickstack.rs
+++ b/crates/clickhouse-cloud-api/src/convert/clickstack.rs
@@ -35,7 +35,12 @@ impl TryFrom<ClickStackFilterSettingsColumnResponse> for ClickStackFilterSetting
             missing.push("name");
         }
         match (value.label, value.name) {
-            (Some(label), Some(name)) => Ok(Self { label, name }),
+            (Some(label), Some(name)) => Ok(Self {
+                label,
+                name,
+                allow_all: value.allow_all,
+                value_expression: value.value_expression,
+            }),
             _ => Err(MissingRequiredFields::new(missing)),
         }
     }
@@ -193,6 +198,7 @@ impl TryFrom<ClickStackLogSourceResponse> for ClickStackLogSource {
                 resource_attributes_expression: value.resource_attributes_expression,
                 section: value.section,
                 service_name_expression: value.service_name_expression,
+                service_version_expression: value.service_version_expression,
                 severity_text_expression: value.severity_text_expression,
                 span_id_expression: value.span_id_expression,
                 timestamp_value_expression,
@@ -773,6 +779,7 @@ impl TryFrom<ClickStackTraceSourceResponse> for ClickStackTraceSource {
                 resource_attributes_expression: value.resource_attributes_expression,
                 section: value.section,
                 service_name_expression: value.service_name_expression,
+                service_version_expression: value.service_version_expression,
                 session_source_id: value.session_source_id,
                 span_events_value_expression: value.span_events_value_expression,
                 span_id_expression,
@@ -786,5 +793,147 @@ impl TryFrom<ClickStackTraceSourceResponse> for ClickStackTraceSource {
             }),
             _ => Err(MissingRequiredFields::new(missing)),
         }
+    }
+}
+
+impl TryFrom<ClickStackNumberFormatResponse> for ClickStackNumberFormat {
+    type Error = MissingRequiredFields;
+    fn try_from(value: ClickStackNumberFormatResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.average.is_none() {
+            missing.push("average");
+        }
+        if value.currency_symbol.is_none() {
+            missing.push("currencySymbol");
+        }
+        if value.decimal_bytes.is_none() {
+            missing.push("decimalBytes");
+        }
+        if value.factor.is_none() {
+            missing.push("factor");
+        }
+        if value.mantissa.is_none() {
+            missing.push("mantissa");
+        }
+        if value.numeric_unit.is_none() {
+            missing.push("numericUnit");
+        }
+        if value.output.is_none() {
+            missing.push("output");
+        }
+        if value.thousand_separated.is_none() {
+            missing.push("thousandSeparated");
+        }
+        if value.unit.is_none() {
+            missing.push("unit");
+        }
+        match (
+            value.average,
+            value.currency_symbol,
+            value.decimal_bytes,
+            value.factor,
+            value.mantissa,
+            value.numeric_unit,
+            value.output,
+            value.thousand_separated,
+            value.unit,
+        ) {
+            (
+                Some(average),
+                Some(currency_symbol),
+                Some(decimal_bytes),
+                Some(factor),
+                Some(mantissa),
+                Some(numeric_unit),
+                Some(output),
+                Some(thousand_separated),
+                Some(unit),
+            ) => Ok(Self {
+                average,
+                currency_symbol,
+                decimal_bytes,
+                factor,
+                mantissa,
+                numeric_unit,
+                output,
+                thousand_separated,
+                unit,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackFormulaResponse> for ClickStackFormula {
+    type Error = MissingRequiredFields;
+    fn try_from(value: ClickStackFormulaResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.expression.is_none() {
+            missing.push("expression");
+        }
+        match (value.expression,) {
+            (Some(expression),) => Ok(Self {
+                expression,
+                alias: value.alias,
+                number_format: value.number_format.map(TryInto::try_into).transpose()?,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSqlSavedFilterValueResponse> for ClickStackSqlSavedFilterValue {
+    type Error = MissingRequiredFields;
+    fn try_from(value: ClickStackSqlSavedFilterValueResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.condition.is_none() {
+            missing.push("condition");
+        }
+        match (value.condition,) {
+            (Some(condition),) => Ok(Self {
+                condition,
+                r#type: value.r#type,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackVariableSavedFilterValueResponse> for ClickStackVariableSavedFilterValue {
+    type Error = MissingRequiredFields;
+    fn try_from(value: ClickStackVariableSavedFilterValueResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.r#type.is_none() {
+            missing.push("type");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.values.is_none() {
+            missing.push("values");
+        }
+        match (value.r#type, value.name, value.values) {
+            (Some(r#type), Some(name), Some(values)) => Ok(Self {
+                r#type,
+                name,
+                values,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSavedFilterValueResponse> for ClickStackSavedFilterValue {
+    type Error = MissingRequiredFields;
+    fn try_from(value: ClickStackSavedFilterValueResponse) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ClickStackSavedFilterValueResponse::ClickStackSqlSavedFilterValue(value) => {
+                Self::ClickStackSqlSavedFilterValue(value.try_into()?)
+            }
+            ClickStackSavedFilterValueResponse::ClickStackVariableSavedFilterValue(value) => {
+                Self::ClickStackVariableSavedFilterValue(value.try_into()?)
+            }
+            ClickStackSavedFilterValueResponse::Unknown(value) => Self::Unknown(value),
+        })
     }
 }

--- a/crates/clickhouse-cloud-api/src/meta.rs
+++ b/crates/clickhouse-cloud-api/src/meta.rs
@@ -20,12 +20,12 @@
 /// Snake-case operation IDs (matching [`crate::client::Client`] method names)
 /// that the OpenAPI spec marks Beta via `x-badges`.
 pub const BETA_OPERATIONS: &[&str] = &[
-    "active_balances_get",
     "backup_bucket_create",
     "backup_bucket_delete",
     "backup_bucket_get",
     "backup_bucket_update",
     "click_pipe_schema_discovery",
+    "click_pipes_service_context_get",
     "click_stack_create_alert",
     "click_stack_create_dashboard",
     "click_stack_create_role",
@@ -56,6 +56,7 @@ pub const BETA_OPERATIONS: &[&str] = &[
     "click_stack_update_source",
     "click_stack_update_webhook",
     "click_stack_validate_dashboard",
+    "credit_balances_get",
     "organization_prometheus_discovery_get",
     "organization_quota_get",
     "organization_quotas_get_list",

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -182,8 +182,8 @@ pub use organization_private_endpoints::{
     OrganizationPrivateEndpointRegion, OrganizationPrivateEndpointsPatch,
 };
 pub use organizations::{
-    ActiveBalance, ActiveBalances, Organization, OrganizationPatchRequest,
-    PrometheusDiscoveryLabels, PrometheusDiscoveryTargetGroup,
+    ActiveBalance, ActiveBalances, CreditBalance, CreditBalanceType, CreditBalances, Organization,
+    OrganizationPatchRequest, PrometheusDiscoveryLabels, PrometheusDiscoveryTargetGroup,
 };
 pub use postgres::{
     BasePostgresService, PgBouncerConfig, PgBouncerConfigResponse, PgConfig,
@@ -233,15 +233,15 @@ pub use services::{
     ServicePatchRequestReleasechannel, ServicePostRequest, ServicePostRequestCompliancetype,
     ServicePostRequestProfile, ServicePostRequestProvider, ServicePostRequestRegion,
     ServicePostRequestReleasechannel, ServicePostRequestTier, ServicePostResponse, ServiceProfile,
-    ServiceProvider, ServiceQueryAPIEndpoint, ServiceRegion, ServiceReleasechannel,
-    ServiceReplicaScalingPatchRequest, ServiceScalingPatchRequest, ServiceScalingPatchResponse,
-    ServiceScalingPatchResponseCompliancetype, ServiceScalingPatchResponseProfile,
-    ServiceScalingPatchResponseProvider, ServiceScalingPatchResponseRegion,
-    ServiceScalingPatchResponseReleasechannel, ServiceScalingPatchResponseState,
-    ServiceScalingPatchResponseTier, ServiceState, ServiceStatePatchRequest,
-    ServiceStatePatchRequestCommand, ServiceTier, UpgradeWindow, UpgradeWindowDuration,
-    UpgradeWindowPutRequest, UpgradeWindowStartHourUtc, UsageCost, UsageCostMetrics,
-    UsageCostRecord, UsageCostRecordEntitytype,
+    ServiceProfileName, ServiceProvider, ServiceQueryAPIEndpoint, ServiceRegion,
+    ServiceReleasechannel, ServiceReplicaScalingPatchRequest, ServiceScalingPatchRequest,
+    ServiceScalingPatchResponse, ServiceScalingPatchResponseCompliancetype,
+    ServiceScalingPatchResponseProfile, ServiceScalingPatchResponseProvider,
+    ServiceScalingPatchResponseRegion, ServiceScalingPatchResponseReleasechannel,
+    ServiceScalingPatchResponseState, ServiceScalingPatchResponseTier, ServiceState,
+    ServiceStatePatchRequest, ServiceStatePatchRequestCommand, ServiceTier, UpgradeWindow,
+    UpgradeWindowDuration, UpgradeWindowPutRequest, UpgradeWindowStartHourUtc, UsageCost,
+    UsageCostMetrics, UsageCostRecord, UsageCostRecordEntitytype,
 };
 pub use shared::{
     ApiResponse, AssignedRole, AssignedRoleRoletype, IpAccessListEntry, IpAccessListEntryResponse,

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -172,6 +172,8 @@ pub enum ClickPipeKafkaSourceAuthentication {
     IAM_ROLE,
     IAM_USER,
     MUTUAL_TLS,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -186,6 +188,7 @@ impl std::fmt::Display for ClickPipeKafkaSourceAuthentication {
             Self::IAM_ROLE => write!(f, "IAM_ROLE"),
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::MUTUAL_TLS => write!(f, "MUTUAL_TLS"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -714,6 +717,8 @@ pub enum ClickPipeObjectStorageSourceAuthentication {
     IAM_USER,
     CONNECTION_STRING,
     SERVICE_ACCOUNT,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -726,6 +731,7 @@ impl std::fmt::Display for ClickPipeObjectStorageSourceAuthentication {
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::CONNECTION_STRING => write!(f, "CONNECTION_STRING"),
             Self::SERVICE_ACCOUNT => write!(f, "SERVICE_ACCOUNT"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -854,6 +860,8 @@ pub enum ClickPipePatchKafkaSourceAuthentication {
     IAM_ROLE,
     IAM_USER,
     MUTUAL_TLS,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -868,6 +876,7 @@ impl std::fmt::Display for ClickPipePatchKafkaSourceAuthentication {
             Self::IAM_ROLE => write!(f, "IAM_ROLE"),
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::MUTUAL_TLS => write!(f, "MUTUAL_TLS"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1002,6 +1011,8 @@ pub enum ClickPipePatchObjectStorageSourceAuthentication {
     IAM_USER,
     CONNECTION_STRING,
     SERVICE_ACCOUNT,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1014,6 +1025,7 @@ impl std::fmt::Display for ClickPipePatchObjectStorageSourceAuthentication {
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::CONNECTION_STRING => write!(f, "CONNECTION_STRING"),
             Self::SERVICE_ACCOUNT => write!(f, "SERVICE_ACCOUNT"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1048,6 +1060,8 @@ pub enum ClickPipePatchPubSubSourceAuthentication {
     #[serde(rename = "SERVICE_ACCOUNT")]
     #[default]
     ServiceAccount,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1057,6 +1071,7 @@ impl std::fmt::Display for ClickPipePatchPubSubSourceAuthentication {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ServiceAccount => write!(f, "SERVICE_ACCOUNT"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1074,6 +1089,8 @@ pub enum ClickPipePostKafkaSourceAuthentication {
     IAM_ROLE,
     IAM_USER,
     MUTUAL_TLS,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1088,6 +1105,7 @@ impl std::fmt::Display for ClickPipePostKafkaSourceAuthentication {
             Self::IAM_ROLE => write!(f, "IAM_ROLE"),
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::MUTUAL_TLS => write!(f, "MUTUAL_TLS"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1234,6 +1252,8 @@ pub enum ClickPipePostObjectStorageSourceAuthentication {
     IAM_USER,
     CONNECTION_STRING,
     SERVICE_ACCOUNT,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1246,6 +1266,7 @@ impl std::fmt::Display for ClickPipePostObjectStorageSourceAuthentication {
             Self::IAM_USER => write!(f, "IAM_USER"),
             Self::CONNECTION_STRING => write!(f, "CONNECTION_STRING"),
             Self::SERVICE_ACCOUNT => write!(f, "SERVICE_ACCOUNT"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1563,6 +1584,8 @@ pub enum ClickPipePubSubSourceAuthentication {
     #[serde(rename = "SERVICE_ACCOUNT")]
     #[default]
     ServiceAccount,
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    ServiceAccountWorkloadIdentity,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1572,6 +1595,7 @@ impl std::fmt::Display for ClickPipePubSubSourceAuthentication {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ServiceAccount => write!(f, "SERVICE_ACCOUNT"),
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1829,16 +1853,28 @@ pub struct ClickPipe {
 /// `ClickPipeBigQueryPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeBigQueryPipeSettings {
-    #[serde(rename = "allowNullableColumns")]
-    pub allow_nullable_columns: bool,
-    #[serde(rename = "initialLoadParallelism")]
-    pub initial_load_parallelism: f64,
+    #[serde(
+        rename = "allowNullableColumns",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_nullable_columns: Option<bool>,
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub initial_load_parallelism: Option<f64>,
     #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeBigQueryPipeSettingsReplicationmode,
-    #[serde(rename = "snapshotNumRowsPerPartition")]
-    pub snapshot_num_rows_per_partition: f64,
-    #[serde(rename = "snapshotNumberOfParallelTables")]
-    pub snapshot_number_of_parallel_tables: f64,
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_num_rows_per_partition: Option<f64>,
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_number_of_parallel_tables: Option<f64>,
 }
 
 /// `ClickPipeBigQueryPipeSettings` from the ClickHouse Cloud API, in response
@@ -1876,20 +1912,23 @@ pub struct ClickPipeBigQueryPipeSettingsResponse {
 /// `ClickPipeBigQueryPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeBigQueryPipeTableMapping {
-    #[serde(rename = "excludedColumns")]
-    pub excluded_columns: Vec<String>,
-    #[serde(rename = "sortingKeys")]
-    pub sorting_keys: Vec<String>,
+    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
+    pub excluded_columns: Option<Vec<String>>,
+    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none")]
+    pub sorting_keys: Option<Vec<String>>,
     #[serde(rename = "sourceDatasetName")]
     pub source_dataset_name: String,
     #[serde(rename = "sourceTable")]
     pub source_table: String,
-    #[serde(rename = "tableEngine")]
-    pub table_engine: ClickPipeBigQueryPipeTableMappingTableengine,
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
+    pub table_engine: Option<ClickPipeBigQueryPipeTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: String,
-    #[serde(rename = "useCustomSortingKey")]
-    pub use_custom_sorting_key: bool,
+    #[serde(
+        rename = "useCustomSortingKey",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_custom_sorting_key: Option<bool>,
 }
 
 /// `ClickPipeBigQueryPipeTableMapping` from the ClickHouse Cloud API, in
@@ -1919,18 +1958,38 @@ pub struct ClickPipeBigQueryPipeTableMappingResponse {
     pub use_custom_sorting_key: Option<bool>,
 }
 
-/// `ClickPipeBigQuerySource` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct ClickPipeBigQuerySource {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<ClickPipeBigQueryPipeSettingsResponse>,
-    #[serde(
-        rename = "snapshotStagingPath",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub snapshot_staging_path: Option<String>,
-    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
-    pub table_mappings: Option<Vec<ClickPipeBigQueryPipeTableMappingResponse>>,
+/// `ClickPipeBigQuerySource` from the ClickHouse Cloud API, selected by `authentication`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickPipeBigQuerySource {
+    ClickPipeBigQueryServiceAccountSource(ClickPipeBigQueryServiceAccountSource),
+    ClickPipeBigQueryWorkloadIdentitySource(ClickPipeBigQueryWorkloadIdentitySource),
+    Unknown(serde_json::Value),
+}
+discriminated_union! {
+    ClickPipeBigQuerySource, "authentication" {
+        "SERVICE_ACCOUNT" => ClickPipeBigQueryServiceAccountSource,
+        "SERVICE_ACCOUNT_WORKLOAD_IDENTITY" => ClickPipeBigQueryWorkloadIdentitySource,
+    }
+}
+impl Default for ClickPipeBigQuerySource {
+    fn default() -> Self {
+        // An empty response has no authentication discriminator to select an arm.
+        Self::Unknown(serde_json::json!({}))
+    }
+}
+impl std::fmt::Display for ClickPipeBigQuerySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickPipeBigQueryServiceAccountSource(_) => {
+                write!(f, "ClickPipeBigQueryServiceAccountSource")
+            }
+            Self::ClickPipeBigQueryWorkloadIdentitySource(_) => {
+                write!(f, "ClickPipeBigQueryWorkloadIdentitySource")
+            }
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
 }
 
 /// `ClickPipeDestination` from the ClickHouse Cloud API.
@@ -2268,15 +2327,40 @@ pub struct ClickPipeMongoDBSource {
     pub uri: Option<String>,
 }
 
-/// `ClickPipeMutateBigQuerySource` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct ClickPipeMutateBigQuerySource {
-    pub credentials: ServiceAccount,
-    pub settings: ClickPipeBigQueryPipeSettings,
-    #[serde(rename = "snapshotStagingPath")]
-    pub snapshot_staging_path: String,
-    #[serde(rename = "tableMappings")]
-    pub table_mappings: Vec<ClickPipeBigQueryPipeTableMapping>,
+/// `ClickPipeMutateBigQuerySource` from the ClickHouse Cloud API, selected by `authentication`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickPipeMutateBigQuerySource {
+    ClickPipePostBigQueryServiceAccountSource(ClickPipePostBigQueryServiceAccountSource),
+    ClickPipePostBigQueryWorkloadIdentitySource(ClickPipePostBigQueryWorkloadIdentitySource),
+    Unknown(serde_json::Value),
+}
+discriminated_union! {
+    ClickPipeMutateBigQuerySource, "authentication" {
+        "SERVICE_ACCOUNT" => ClickPipePostBigQueryServiceAccountSource,
+        "SERVICE_ACCOUNT_WORKLOAD_IDENTITY" => ClickPipePostBigQueryWorkloadIdentitySource,
+        none unless "authentication" => ClickPipePostBigQueryServiceAccountSource,
+    }
+}
+impl Default for ClickPipeMutateBigQuerySource {
+    fn default() -> Self {
+        Self::ClickPipePostBigQueryServiceAccountSource(
+            ClickPipePostBigQueryServiceAccountSource::default(),
+        )
+    }
+}
+impl std::fmt::Display for ClickPipeMutateBigQuerySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickPipePostBigQueryServiceAccountSource(_) => {
+                write!(f, "ClickPipePostBigQueryServiceAccountSource")
+            }
+            Self::ClickPipePostBigQueryWorkloadIdentitySource(_) => {
+                write!(f, "ClickPipePostBigQueryWorkloadIdentitySource")
+            }
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
 }
 
 /// `ClickPipeMutateDestination` from the ClickHouse Cloud API.
@@ -2499,6 +2583,8 @@ pub struct ClickPipeMySQLPipeSettingsResponse {
 /// `ClickPipeMySQLPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLPipeTableMapping {
+    #[serde(rename = "partitionByExpr", skip_serializing_if = "Option::is_none")]
+    pub partition_by_expr: Option<String>,
     #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
     pub excluded_columns: Option<Vec<String>>,
     #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
@@ -2528,6 +2614,8 @@ pub struct ClickPipeMySQLPipeTableMapping {
 /// `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLPipeTableMappingResponse {
+    #[serde(rename = "partitionByExpr", skip_serializing_if = "Option::is_none")]
+    pub partition_by_expr: Option<String>,
     #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
     pub excluded_columns: Option<Vec<String>>,
     #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
@@ -2703,6 +2791,8 @@ pub struct ClickPipePatchMongoDBSource {
 /// `ClickPipePatchMySQLPipeRemoveTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLPipeRemoveTableMapping {
+    #[serde(rename = "partitionByExpr", skip_serializing_if = "Option::is_none")]
+    pub partition_by_expr: Option<String>,
     #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
     pub partition_key: Option<String>,
     #[serde(rename = "sourceSchemaName")]
@@ -2894,6 +2984,8 @@ pub struct ClickPipePatchSource {
 /// `ClickPipePostKafkaSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostKafkaSource {
+    #[serde(rename = "protobufSchema", skip_serializing_if = "Option::is_none")]
+    pub protobuf_schema: Option<String>,
     /// Omitted for a broker that requires no authentication: the spec enum has
     /// no "none" value, and the control plane's own field is `omitempty`, so
     /// absence — not a sentinel value — is how "no auth" is expressed.
@@ -3016,26 +3108,39 @@ pub struct ClickPipePostObjectStorageSource {
     pub url: String,
 }
 
-/// `ClickPipePostPubSubSource` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct ClickPipePostPubSubSource {
-    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
-    pub ack_deadline: Option<i64>,
-    pub authentication: ClickPipePostPubSubSourceAuthentication,
-    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none")]
-    pub enable_ordering: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub filter: Option<String>,
-    pub format: ClickPipePostPubSubSourceFormat,
-    #[serde(rename = "projectId")]
-    pub project_id: String,
-    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none")]
-    pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(rename = "seekType")]
-    pub seek_type: ClickPipePostPubSubSourceSeektype,
-    #[serde(rename = "serviceAccountKey")]
-    pub service_account_key: ServiceAccount,
-    pub topic: String,
+/// `ClickPipePostPubSubSource` from the ClickHouse Cloud API, selected by `authentication`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickPipePostPubSubSource {
+    ClickPipePostPubSubServiceAccountSource(ClickPipePostPubSubServiceAccountSource),
+    ClickPipePostPubSubWorkloadIdentitySource(ClickPipePostPubSubWorkloadIdentitySource),
+    Unknown(serde_json::Value),
+}
+discriminated_union! {
+    ClickPipePostPubSubSource, "authentication" {
+        "SERVICE_ACCOUNT" => ClickPipePostPubSubServiceAccountSource,
+        "SERVICE_ACCOUNT_WORKLOAD_IDENTITY" => ClickPipePostPubSubWorkloadIdentitySource,
+    }
+}
+impl Default for ClickPipePostPubSubSource {
+    fn default() -> Self {
+        Self::ClickPipePostPubSubServiceAccountSource(
+            ClickPipePostPubSubServiceAccountSource::default(),
+        )
+    }
+}
+impl std::fmt::Display for ClickPipePostPubSubSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickPipePostPubSubServiceAccountSource(_) => {
+                write!(f, "ClickPipePostPubSubServiceAccountSource")
+            }
+            Self::ClickPipePostPubSubWorkloadIdentitySource(_) => {
+                write!(f, "ClickPipePostPubSubWorkloadIdentitySource")
+            }
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
 }
 
 /// `ClickPipePostRequest` from the ClickHouse Cloud API.
@@ -3638,4 +3743,255 @@ pub struct UpdateReversePrivateEndpoint {
         skip_serializing_if = "Option::is_none"
     )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
+}
+
+/// Values of `ClickPipeBigQueryServiceAccountSourceAuthentication` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickPipeBigQueryServiceAccountSourceAuthentication {
+    #[serde(rename = "SERVICE_ACCOUNT")]
+    #[default]
+    ServiceAccount,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickPipeBigQueryServiceAccountSourceAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccount => write!(f, "SERVICE_ACCOUNT"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `ClickPipeBigQueryServiceAccountSource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeBigQueryServiceAccountSource {
+    #[serde(
+        rename = "snapshotStagingPath",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_staging_path: Option<String>,
+    #[serde(rename = "settings", skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeBigQueryPipeSettingsResponse>,
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipeBigQueryPipeTableMappingResponse>>,
+    #[serde(rename = "authentication", skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipeBigQueryServiceAccountSourceAuthentication>,
+    #[serde(rename = "projectId", skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}
+
+/// Values of `ClickPipeBigQueryWorkloadIdentitySourceAuthentication` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickPipeBigQueryWorkloadIdentitySourceAuthentication {
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    #[default]
+    ServiceAccountWorkloadIdentity,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickPipeBigQueryWorkloadIdentitySourceAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `ClickPipeBigQueryWorkloadIdentitySource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeBigQueryWorkloadIdentitySource {
+    #[serde(
+        rename = "snapshotStagingPath",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_staging_path: Option<String>,
+    #[serde(rename = "settings", skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeBigQueryPipeSettingsResponse>,
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipeBigQueryPipeTableMappingResponse>>,
+    #[serde(rename = "authentication", skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipeBigQueryWorkloadIdentitySourceAuthentication>,
+    #[serde(rename = "projectId", skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}
+
+/// Values of `ClickPipePostBigQueryServiceAccountSourceAuthentication` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickPipePostBigQueryServiceAccountSourceAuthentication {
+    #[serde(rename = "SERVICE_ACCOUNT")]
+    #[default]
+    ServiceAccount,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickPipePostBigQueryServiceAccountSourceAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccount => write!(f, "SERVICE_ACCOUNT"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `ClickPipePostBigQueryServiceAccountSource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostBigQueryServiceAccountSource {
+    #[serde(rename = "snapshotStagingPath")]
+    pub snapshot_staging_path: String,
+    #[serde(rename = "settings")]
+    pub settings: ClickPipeBigQueryPipeSettings,
+    #[serde(rename = "tableMappings")]
+    pub table_mappings: Vec<ClickPipeBigQueryPipeTableMapping>,
+    #[serde(rename = "authentication", skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipePostBigQueryServiceAccountSourceAuthentication>,
+    #[serde(rename = "projectId", skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(rename = "credentials")]
+    pub credentials: ServiceAccount,
+}
+
+/// Values of `ClickPipePostBigQueryWorkloadIdentitySourceAuthentication` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickPipePostBigQueryWorkloadIdentitySourceAuthentication {
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    #[default]
+    ServiceAccountWorkloadIdentity,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickPipePostBigQueryWorkloadIdentitySourceAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `ClickPipePostBigQueryWorkloadIdentitySource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostBigQueryWorkloadIdentitySource {
+    #[serde(rename = "snapshotStagingPath")]
+    pub snapshot_staging_path: String,
+    #[serde(rename = "settings")]
+    pub settings: ClickPipeBigQueryPipeSettings,
+    #[serde(rename = "tableMappings")]
+    pub table_mappings: Vec<ClickPipeBigQueryPipeTableMapping>,
+    #[serde(rename = "authentication")]
+    pub authentication: ClickPipePostBigQueryWorkloadIdentitySourceAuthentication,
+    #[serde(rename = "projectId")]
+    pub project_id: String,
+}
+
+/// `ClickPipePostPubSubServiceAccountSource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostPubSubServiceAccountSource {
+    #[serde(rename = "format")]
+    pub format: ClickPipePostPubSubSourceFormat,
+    #[serde(rename = "projectId")]
+    pub project_id: String,
+    #[serde(rename = "topic")]
+    pub topic: String,
+    #[serde(rename = "authentication")]
+    pub authentication: ClickPipePostPubSubSourceAuthentication,
+    #[serde(rename = "seekType")]
+    pub seek_type: ClickPipePostPubSubSourceSeektype,
+    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none")]
+    pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "filter", skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none")]
+    pub enable_ordering: Option<bool>,
+    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
+    pub ack_deadline: Option<i64>,
+    #[serde(rename = "serviceAccountKey")]
+    pub service_account_key: ServiceAccount,
+}
+
+/// Values of `ClickPipePostPubSubWorkloadIdentitySourceAuthentication` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickPipePostPubSubWorkloadIdentitySourceAuthentication {
+    #[serde(rename = "SERVICE_ACCOUNT_WORKLOAD_IDENTITY")]
+    #[default]
+    ServiceAccountWorkloadIdentity,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickPipePostPubSubWorkloadIdentitySourceAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServiceAccountWorkloadIdentity => write!(f, "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `ClickPipePostPubSubWorkloadIdentitySource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostPubSubWorkloadIdentitySource {
+    #[serde(rename = "format")]
+    pub format: ClickPipePostPubSubSourceFormat,
+    #[serde(rename = "projectId")]
+    pub project_id: String,
+    #[serde(rename = "topic")]
+    pub topic: String,
+    #[serde(rename = "authentication")]
+    pub authentication: ClickPipePostPubSubWorkloadIdentitySourceAuthentication,
+    #[serde(rename = "seekType")]
+    pub seek_type: ClickPipePostPubSubSourceSeektype,
+    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none")]
+    pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "filter", skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none")]
+    pub enable_ordering: Option<bool>,
+    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
+    pub ack_deadline: Option<i64>,
+}
+
+/// `ClickPipesGcpWorkloadIdentityContext` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipesGcpWorkloadIdentityContext {
+    #[serde(rename = "supported", skip_serializing_if = "Option::is_none")]
+    pub supported: Option<bool>,
+    #[serde(rename = "ready", skip_serializing_if = "Option::is_none")]
+    pub ready: Option<bool>,
+    #[serde(rename = "principal", skip_serializing_if = "Option::is_none")]
+    pub principal: Option<String>,
+}
+
+/// `ClickPipesServiceContext` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipesServiceContext {
+    #[serde(
+        rename = "gcpWorkloadIdentity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub gcp_workload_identity: Option<ClickPipesGcpWorkloadIdentityContext>,
+}
+
+impl From<ClickPipePostBigQueryServiceAccountSource> for ClickPipeMutateBigQuerySource {
+    fn from(value: ClickPipePostBigQueryServiceAccountSource) -> Self {
+        Self::ClickPipePostBigQueryServiceAccountSource(value)
+    }
+}
+
+impl From<ClickPipePostBigQueryWorkloadIdentitySource> for ClickPipeMutateBigQuerySource {
+    fn from(value: ClickPipePostBigQueryWorkloadIdentitySource) -> Self {
+        Self::ClickPipePostBigQueryWorkloadIdentitySource(value)
+    }
+}
+
+impl From<ClickPipePostPubSubServiceAccountSource> for ClickPipePostPubSubSource {
+    fn from(value: ClickPipePostPubSubServiceAccountSource) -> Self {
+        Self::ClickPipePostPubSubServiceAccountSource(value)
+    }
+}
+
+impl From<ClickPipePostPubSubWorkloadIdentitySource> for ClickPipePostPubSubSource {
+    fn from(value: ClickPipePostPubSubWorkloadIdentitySource) -> Self {
+        Self::ClickPipePostPubSubWorkloadIdentitySource(value)
+    }
 }

--- a/crates/clickhouse-cloud-api/src/models/clickstack.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickstack.rs
@@ -1317,6 +1317,8 @@ pub struct ClickStackAlertExecutionError {
 /// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertResponse {
+    #[serde(rename = "channels", skip_serializing_if = "Option::is_none")]
+    pub channels: Option<ClickStackAlertChannelsResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<ClickStackAlertChannelResponse>,
     #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
@@ -1409,6 +1411,12 @@ pub struct ClickStackBackgroundChartResponse {
 /// `ClickStackBarBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBarBuilderChartConfig {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "seriesLimit", skip_serializing_if = "Option::is_none")]
+    pub series_limit: Option<i64>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormula>>,
     #[serde(
         rename = "alignDateRangeToGranularity",
         skip_serializing_if = "Option::is_none"
@@ -1436,6 +1444,12 @@ pub struct ClickStackBarBuilderChartConfig {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBarBuilderChartConfigResponse {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "seriesLimit", skip_serializing_if = "Option::is_none")]
+    pub series_limit: Option<i64>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormulaResponse>>,
     #[serde(
         rename = "alignDateRangeToGranularity",
         skip_serializing_if = "Option::is_none"
@@ -1680,6 +1694,8 @@ pub struct ClickStackConnection {
 /// `ClickStackCreateAlertRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCreateAlertRequest {
+    #[serde(rename = "channels")]
+    pub channels: ClickStackAlertChannels,
     pub channel: ClickStackAlertChannel,
     #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none")]
     pub dashboard_id: Option<String>,
@@ -1911,6 +1927,12 @@ pub struct ClickStackEventPatternsChartConfigResponse {
 /// `ClickStackFilter` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilter {
+    #[serde(rename = "variableName", skip_serializing_if = "Option::is_none")]
+    pub variable_name: Option<String>,
+    #[serde(rename = "isVariableEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_variable_enabled: Option<bool>,
+    #[serde(rename = "isBroadcastEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_broadcast_enabled: Option<bool>,
     #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
     pub applies_to_source_ids: Option<Vec<String>>,
     pub expression: String,
@@ -1934,6 +1956,12 @@ pub struct ClickStackFilter {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilterResponse {
+    #[serde(rename = "variableName", skip_serializing_if = "Option::is_none")]
+    pub variable_name: Option<String>,
+    #[serde(rename = "isVariableEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_variable_enabled: Option<bool>,
+    #[serde(rename = "isBroadcastEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_broadcast_enabled: Option<bool>,
     #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
     pub applies_to_source_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1957,6 +1985,12 @@ pub struct ClickStackFilterResponse {
 /// `ClickStackFilterInput` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilterInput {
+    #[serde(rename = "variableName", skip_serializing_if = "Option::is_none")]
+    pub variable_name: Option<String>,
+    #[serde(rename = "isVariableEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_variable_enabled: Option<bool>,
+    #[serde(rename = "isBroadcastEnabled", skip_serializing_if = "Option::is_none")]
+    pub is_broadcast_enabled: Option<bool>,
     #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
     pub applies_to_source_ids: Option<Vec<String>>,
     pub expression: String,
@@ -1975,6 +2009,10 @@ pub struct ClickStackFilterInput {
 /// `ClickStackFilterSettingsColumn` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilterSettingsColumn {
+    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none")]
+    pub value_expression: Option<String>,
+    #[serde(rename = "allowAll", skip_serializing_if = "Option::is_none")]
+    pub allow_all: Option<bool>,
     pub label: String,
     pub name: String,
 }
@@ -1986,6 +2024,10 @@ pub struct ClickStackFilterSettingsColumn {
 /// `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilterSettingsColumnResponse {
+    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none")]
+    pub value_expression: Option<String>,
+    #[serde(rename = "allowAll", skip_serializing_if = "Option::is_none")]
+    pub allow_all: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2130,6 +2172,12 @@ pub struct ClickStackIncidentIOWebhook {
 /// `ClickStackLineBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLineBuilderChartConfig {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "seriesLimit", skip_serializing_if = "Option::is_none")]
+    pub series_limit: Option<i64>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormula>>,
     #[serde(
         rename = "alignDateRangeToGranularity",
         skip_serializing_if = "Option::is_none"
@@ -2164,6 +2212,12 @@ pub struct ClickStackLineBuilderChartConfig {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLineBuilderChartConfigResponse {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "seriesLimit", skip_serializing_if = "Option::is_none")]
+    pub series_limit: Option<i64>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormulaResponse>>,
     #[serde(
         rename = "alignDateRangeToGranularity",
         skip_serializing_if = "Option::is_none"
@@ -2261,6 +2315,11 @@ pub struct ClickStackLineRawSqlChartConfigResponse {
 /// `ClickStackLogSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLogSource {
+    #[serde(
+        rename = "serviceVersionExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_version_expression: Option<String>,
     #[serde(rename = "bodyExpression", skip_serializing_if = "Option::is_none")]
     pub body_expression: Option<String>,
     pub connection: String,
@@ -2358,6 +2417,11 @@ pub struct ClickStackLogSource {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLogSourceResponse {
+    #[serde(
+        rename = "serviceVersionExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_version_expression: Option<String>,
     #[serde(rename = "bodyExpression", skip_serializing_if = "Option::is_none")]
     pub body_expression: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2676,6 +2740,8 @@ pub struct ClickStackMetricTablesResponse {
 /// `ClickStackNumberBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumberBuilderChartConfig {
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormula>>,
     #[serde(rename = "backgroundChart", skip_serializing_if = "Option::is_none")]
     pub background_chart: Option<ClickStackBackgroundChart>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2698,6 +2764,8 @@ pub struct ClickStackNumberBuilderChartConfig {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumberBuilderChartConfigResponse {
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormulaResponse>>,
     #[serde(rename = "backgroundChart", skip_serializing_if = "Option::is_none")]
     pub background_chart: Option<ClickStackBackgroundChartResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3193,25 +3261,68 @@ pub struct ClickStackRole {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-/// `ClickStackSavedFilterValue` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct ClickStackSavedFilterValue {
-    pub condition: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<ClickStackSavedFilterValueType>,
+/// `ClickStackSavedFilterValue` from the ClickHouse Cloud API, selected by `type`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackSavedFilterValue {
+    ClickStackSqlSavedFilterValue(ClickStackSqlSavedFilterValue),
+    ClickStackVariableSavedFilterValue(ClickStackVariableSavedFilterValue),
+    Unknown(serde_json::Value),
+}
+discriminated_union! {
+    ClickStackSavedFilterValue, "type" {
+        "sql" => ClickStackSqlSavedFilterValue,
+        "variable" => ClickStackVariableSavedFilterValue,
+        none unless "name" | "values" => ClickStackSqlSavedFilterValue,
+    }
+}
+impl Default for ClickStackSavedFilterValue {
+    fn default() -> Self {
+        Self::ClickStackSqlSavedFilterValue(ClickStackSqlSavedFilterValue::default())
+    }
+}
+impl std::fmt::Display for ClickStackSavedFilterValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackSqlSavedFilterValue(_) => write!(f, "ClickStackSqlSavedFilterValue"),
+            Self::ClickStackVariableSavedFilterValue(_) => {
+                write!(f, "ClickStackVariableSavedFilterValue")
+            }
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
 }
 
-/// `ClickStackSavedFilterValue` from the ClickHouse Cloud API, in response position.
-///
-/// Response variant of [`ClickStackSavedFilterValue`]: every field is
-/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
-/// `None` instead of failing.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct ClickStackSavedFilterValueResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub condition: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<ClickStackSavedFilterValueType>,
+/// `ClickStackSavedFilterValueResponse` from the ClickHouse Cloud API, selected by `type`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackSavedFilterValueResponse {
+    ClickStackSqlSavedFilterValue(ClickStackSqlSavedFilterValueResponse),
+    ClickStackVariableSavedFilterValue(ClickStackVariableSavedFilterValueResponse),
+    Unknown(serde_json::Value),
+}
+discriminated_union! {
+    ClickStackSavedFilterValueResponse, "type" {
+        "sql" => ClickStackSqlSavedFilterValue,
+        "variable" => ClickStackVariableSavedFilterValue,
+        none unless "name" | "values" => ClickStackSqlSavedFilterValue,
+    }
+}
+impl Default for ClickStackSavedFilterValueResponse {
+    fn default() -> Self {
+        Self::ClickStackSqlSavedFilterValue(ClickStackSqlSavedFilterValueResponse::default())
+    }
+}
+impl std::fmt::Display for ClickStackSavedFilterValueResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackSqlSavedFilterValue(_) => write!(f, "ClickStackSqlSavedFilterValue"),
+            Self::ClickStackVariableSavedFilterValue(_) => {
+                write!(f, "ClickStackVariableSavedFilterValue")
+            }
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
 }
 
 /// `ClickStackSavedSearch` from the ClickHouse Cloud API.
@@ -3536,6 +3647,10 @@ pub struct ClickStackSourceFromResponse {
 /// `ClickStackTableBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTableBuilderChartConfig {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormula>>,
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
     #[serde(rename = "displayType")]
@@ -3567,6 +3682,10 @@ pub struct ClickStackTableBuilderChartConfig {
 /// failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTableBuilderChartConfigResponse {
+    #[serde(rename = "showOperandSeries", skip_serializing_if = "Option::is_none")]
+    pub show_operand_series: Option<bool>,
+    #[serde(rename = "formulas", skip_serializing_if = "Option::is_none")]
+    pub formulas: Option<Vec<ClickStackFormulaResponse>>,
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
     #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
@@ -3745,6 +3864,11 @@ pub struct ClickStackTimeChartSeries {
 /// `ClickStackTraceSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTraceSource {
+    #[serde(
+        rename = "serviceVersionExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_version_expression: Option<String>,
     pub connection: String,
     #[serde(rename = "defaultTableSelectExpression")]
     pub default_table_select_expression: String,
@@ -3857,6 +3981,11 @@ pub struct ClickStackTraceSource {
 /// of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTraceSourceResponse {
+    #[serde(
+        rename = "serviceVersionExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_version_expression: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection: Option<String>,
     #[serde(
@@ -4003,6 +4132,8 @@ pub struct ClickStackTraceSourceMetadataMaterializedViewsResponse {
 /// `ClickStackUpdateAlertRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackUpdateAlertRequest {
+    #[serde(rename = "channels")]
+    pub channels: ClickStackAlertChannels,
     pub channel: ClickStackAlertChannel,
     #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none")]
     pub dashboard_id: Option<String>,
@@ -4196,4 +4327,85 @@ impl Default for ClickStackWebhook {
             ..ClickStackSlackWebhook::default()
         })
     }
+}
+
+/// Notification channels for an alert.
+pub type ClickStackAlertChannels = Vec<ClickStackAlertChannel>;
+/// Tolerant notification channels returned by the API.
+pub type ClickStackAlertChannelsResponse = Vec<ClickStackAlertChannelResponse>;
+
+/// `ClickStackFormula` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackFormula {
+    #[serde(rename = "expression")]
+    pub expression: String,
+    #[serde(rename = "alias", skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormat>,
+}
+
+/// `ClickStackFormulaResponse` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackFormulaResponse {
+    #[serde(rename = "expression", skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(rename = "alias", skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+}
+
+/// `ClickStackSqlSavedFilterValue` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSqlSavedFilterValue {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackSavedFilterValueType>,
+    #[serde(rename = "condition")]
+    pub condition: String,
+}
+
+/// `ClickStackSqlSavedFilterValueResponse` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSqlSavedFilterValueResponse {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackSavedFilterValueType>,
+    #[serde(rename = "condition", skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+}
+
+/// `ClickStackVariableSavedFilterValue` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackVariableSavedFilterValue {
+    #[serde(rename = "type")]
+    pub r#type: ClickStackVariableSavedFilterValueType,
+    #[serde(rename = "name")]
+    pub name: String,
+    #[serde(rename = "values")]
+    pub values: Vec<String>,
+}
+
+/// `ClickStackVariableSavedFilterValueResponse` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackVariableSavedFilterValueResponse {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackVariableSavedFilterValueType>,
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "values", skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<String>>,
+}
+
+/// ClickStack request validation failures.
+pub type ClickStackValidationError = Vec<ClickStackValidationErrorItem>;
+/// Structured validation error details supplied by ClickStack.
+pub type ClickStackValidationErrorItemErrors = std::collections::HashMap<String, serde_json::Value>;
+
+/// `ClickStackValidationErrorItem` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackValidationErrorItem {
+    #[serde(rename = "type")]
+    pub r#type: String,
+    #[serde(rename = "errors")]
+    pub errors: ClickStackValidationErrorItemErrors,
 }

--- a/crates/clickhouse-cloud-api/src/models/clickstack_enums.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickstack_enums.rs
@@ -89,6 +89,8 @@ pub enum ClickStackAlertExecutionErrorType {
     WEBHOOK_ERROR,
     INVALID_ALERT,
     UNKNOWN,
+    #[serde(rename = "QUERY_TIMEOUT")]
+    QueryTimeout,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -101,6 +103,7 @@ impl std::fmt::Display for ClickStackAlertExecutionErrorType {
             Self::WEBHOOK_ERROR => write!(f, "WEBHOOK_ERROR"),
             Self::INVALID_ALERT => write!(f, "INVALID_ALERT"),
             Self::UNKNOWN => write!(f, "UNKNOWN"),
+            Self::QueryTimeout => write!(f, "QUERY_TIMEOUT"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -126,6 +129,8 @@ pub enum ClickStackAlertResponseInterval {
     _12h,
     #[serde(rename = "1d")]
     _1d,
+    #[serde(rename = "30s")]
+    Value30s,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -142,6 +147,7 @@ impl std::fmt::Display for ClickStackAlertResponseInterval {
             Self::_6h => write!(f, "6h"),
             Self::_12h => write!(f, "12h"),
             Self::_1d => write!(f, "1d"),
+            Self::Value30s => write!(f, "30s"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -481,6 +487,8 @@ pub enum ClickStackCreateAlertRequestInterval {
     _12h,
     #[serde(rename = "1d")]
     _1d,
+    #[serde(rename = "30s")]
+    Value30s,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -497,6 +505,7 @@ impl std::fmt::Display for ClickStackCreateAlertRequestInterval {
             Self::_6h => write!(f, "6h"),
             Self::_12h => write!(f, "12h"),
             Self::_1d => write!(f, "1d"),
+            Self::Value30s => write!(f, "30s"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -2641,6 +2650,8 @@ pub enum ClickStackUpdateAlertRequestInterval {
     _12h,
     #[serde(rename = "1d")]
     _1d,
+    #[serde(rename = "30s")]
+    Value30s,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -2657,6 +2668,7 @@ impl std::fmt::Display for ClickStackUpdateAlertRequestInterval {
             Self::_6h => write!(f, "6h"),
             Self::_12h => write!(f, "12h"),
             Self::_1d => write!(f, "1d"),
+            Self::Value30s => write!(f, "30s"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -2771,6 +2783,24 @@ impl std::fmt::Display for ClickStackWebhookInputService {
             Self::Incidentio => write!(f, "incidentio"),
             Self::Generic => write!(f, "generic"),
             Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Values of `ClickStackVariableSavedFilterValueType` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum ClickStackVariableSavedFilterValueType {
+    #[serde(rename = "variable")]
+    #[default]
+    Variable,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for ClickStackVariableSavedFilterValueType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Variable => write!(f, "variable"),
+            Self::Unknown(value) => write!(f, "{value}"),
         }
     }
 }

--- a/crates/clickhouse-cloud-api/src/models/organizations.rs
+++ b/crates/clickhouse-cloud-api/src/models/organizations.rs
@@ -95,3 +95,55 @@ pub struct OrganizationPatchRequest {
     #[serde(rename = "privateEndpoints", skip_serializing_if = "Option::is_none")]
     pub private_endpoints: Option<OrganizationPrivateEndpointsPatch>,
 }
+
+/// Values of `CreditBalanceType` in the Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum CreditBalanceType {
+    #[serde(rename = "prepaid")]
+    #[default]
+    Prepaid,
+    #[serde(rename = "trial")]
+    Trial,
+    #[serde(untagged)]
+    Unknown(String),
+}
+impl std::fmt::Display for CreditBalanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Prepaid => write!(f, "prepaid"),
+            Self::Trial => write!(f, "trial"),
+            Self::Unknown(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// `CreditBalance` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct CreditBalance {
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<CreditBalanceType>,
+    #[serde(rename = "remainingCredits", skip_serializing_if = "Option::is_none")]
+    pub remaining_credits: Option<f64>,
+    #[serde(rename = "totalAmount", skip_serializing_if = "Option::is_none")]
+    pub total_amount: Option<f64>,
+    #[serde(rename = "amountSpent", skip_serializing_if = "Option::is_none")]
+    pub amount_spent: Option<f64>,
+    #[serde(rename = "startDate", skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "expirationDate", skip_serializing_if = "Option::is_none")]
+    pub expiration_date: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// `CreditBalances` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct CreditBalances {
+    #[serde(
+        rename = "totalRemainingCredits",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_remaining_credits: Option<f64>,
+    #[serde(rename = "balances", skip_serializing_if = "Option::is_none")]
+    pub balances: Option<Vec<CreditBalance>>,
+}

--- a/crates/clickhouse-cloud-api/src/models/services.rs
+++ b/crates/clickhouse-cloud-api/src/models/services.rs
@@ -308,7 +308,7 @@ impl std::fmt::Display for ServiceCompliancetype {
 
 /// Inline enum for `Service.profile`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub enum ServiceProfile {
+pub enum ServiceProfileName {
     #[serde(rename = "v1-default")]
     #[default]
     V1_default,
@@ -327,7 +327,7 @@ pub enum ServiceProfile {
     Unknown(String),
 }
 
-impl std::fmt::Display for ServiceProfile {
+impl std::fmt::Display for ServiceProfileName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::V1_default => write!(f, "v1-default"),
@@ -1634,7 +1634,7 @@ pub struct Service {
     #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile: Option<ServiceProfile>,
+    pub profile: Option<ServiceProfileName>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<ServiceProvider>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2121,4 +2121,15 @@ pub struct UsageCostRecord {
     pub service_id: Option<uuid::Uuid>,
     #[serde(rename = "totalCHC", skip_serializing_if = "Option::is_none")]
     pub total_chc: Option<f64>,
+}
+
+/// `ServiceProfile` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ServiceProfile {
+    #[serde(rename = "profile", skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(rename = "cpuCores", skip_serializing_if = "Option::is_none")]
+    pub cpu_cores: Option<f64>,
+    #[serde(rename = "memoryGi", skip_serializing_if = "Option::is_none")]
+    pub memory_gi: Option<f64>,
 }

--- a/crates/clickhouse-cloud-api/src/models/udfs.rs
+++ b/crates/clickhouse-cloud-api/src/models/udfs.rs
@@ -88,6 +88,8 @@ pub struct UdfArgument {
 /// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Udf {
+    #[serde(rename = "deterministic", skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<UdfArgumentResponse>>,
     #[serde(rename = "commandReadTimeout", skip_serializing_if = "Option::is_none")]

--- a/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
@@ -381,22 +381,27 @@ async fn cloud_clickpipe_create_bigquery_snapshot_smoke() -> TestResult<()> {
     let request = ClickPipePostRequest {
         name: ctx.pipe_name("bq"),
         source: ClickPipePostSource {
-            bigquery: Some(ClickPipeMutateBigQuerySource {
-                credentials: ServiceAccount {
-                    service_account_file: sa_b64,
-                },
-                snapshot_staging_path: "gs://smoke-fake-bucket/staging".to_string(),
-                settings: ClickPipeBigQueryPipeSettings {
-                    replication_mode: ClickPipeBigQueryPipeSettingsReplicationmode::Snapshot,
-                    ..Default::default()
-                },
-                table_mappings: vec![ClickPipeBigQueryPipeTableMapping {
-                    source_dataset_name: "smoke_dataset".to_string(),
-                    source_table: "smoke_source".to_string(),
-                    target_table: "smoke_target".to_string(),
-                    ..Default::default()
-                }],
-            }),
+            bigquery: Some(
+                ClickPipePostBigQueryServiceAccountSource {
+                    authentication: None,
+                    project_id: None,
+                    credentials: ServiceAccount {
+                        service_account_file: sa_b64,
+                    },
+                    snapshot_staging_path: "gs://smoke-fake-bucket/staging".to_string(),
+                    settings: ClickPipeBigQueryPipeSettings {
+                        replication_mode: ClickPipeBigQueryPipeSettingsReplicationmode::Snapshot,
+                        ..Default::default()
+                    },
+                    table_mappings: vec![ClickPipeBigQueryPipeTableMapping {
+                        source_dataset_name: "smoke_dataset".to_string(),
+                        source_table: "smoke_source".to_string(),
+                        target_table: "smoke_target".to_string(),
+                        ..Default::default()
+                    }],
+                }
+                .into(),
+            ),
             ..Default::default()
         },
         destination: database_destination(),

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -4289,3 +4289,118 @@ async fn default_base_url_is_production() {
     // but we can verify the client is constructable without panicking.
     let _client = Client::new("key", "secret");
 }
+
+#[tokio::test]
+async fn credit_balances_get_includes_trial_and_prepaid_balances() {
+    let (server, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org/creditBalances"))
+        .and(basic_auth("key", "secret"))
+        .respond_with(ok_json(serde_json::json!({
+            "totalRemainingCredits": 12.5,
+            "balances": [{"type": "trial", "remainingCredits": 2.5}, {"type": "prepaid", "remainingCredits": 10.0}]
+        })))
+        .expect(1).mount(&server).await;
+    let result = client
+        .credit_balances_get("org")
+        .await
+        .unwrap()
+        .result
+        .unwrap();
+    assert_eq!(result.total_remaining_credits, Some(12.5));
+    let balances = result.balances.unwrap();
+    assert_eq!(balances[0].r#type, Some(CreditBalanceType::Trial));
+    assert_eq!(balances[1].r#type, Some(CreditBalanceType::Prepaid));
+}
+
+#[tokio::test]
+async fn service_profiles_list_encodes_region_and_optional_byoc() {
+    let (server, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org/serviceProfiles"))
+        .and(basic_auth("key", "secret"))
+        .and(query_param("region_id", "us-east-1"))
+        .respond_with(ok_json(
+            serde_json::json!([{"profile": "v1-standard-byoc-4", "cpuCores": 4, "memoryGi": 16}]),
+        ))
+        .expect(2)
+        .mount(&server)
+        .await;
+    for byoc in [None, Some("byoc +/id")] {
+        let result = client
+            .service_profiles_list("org", "us-east-1", byoc)
+            .await
+            .unwrap()
+            .result
+            .unwrap();
+        assert_eq!(result[0].profile.as_deref(), Some("v1-standard-byoc-4"));
+        assert_eq!(result[0].cpu_cores, Some(4.0));
+        assert_eq!(result[0].memory_gi, Some(16.0));
+    }
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        !requests[0]
+            .url
+            .query_pairs()
+            .any(|(key, _)| key == "byoc_id")
+    );
+    assert!(
+        requests[1]
+            .url
+            .query_pairs()
+            .any(|(key, value)| key == "byoc_id" && value == "byoc +/id")
+    );
+}
+
+#[tokio::test]
+async fn clickpipes_context_returns_workload_identity_and_tolerates_omissions() {
+    let (server, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org/services/service/clickpipes/context"))
+        .and(basic_auth("key", "secret"))
+        .respond_with(ok_json(serde_json::json!({"gcpWorkloadIdentity": {
+            "supported": true, "ready": null, "principal": "clickpipes@example.iam.gserviceaccount.com"
+        }})))
+        .expect(1).mount(&server).await;
+    let result = client
+        .click_pipes_service_context_get("org", "service")
+        .await
+        .unwrap()
+        .result
+        .unwrap();
+    let identity = result.gcp_workload_identity.unwrap();
+    assert_eq!(identity.supported, Some(true));
+    assert_eq!(identity.ready, None);
+    assert_eq!(
+        identity.principal.as_deref(),
+        Some("clickpipes@example.iam.gserviceaccount.com")
+    );
+}
+
+#[tokio::test]
+async fn new_discovery_operations_preserve_api_errors() {
+    let (server, client) = setup().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(403).set_body_json(serde_json::json!({"error": "forbidden"})),
+        )
+        .expect(3)
+        .mount(&server)
+        .await;
+    let errors = [
+        client.credit_balances_get("org").await.unwrap_err(),
+        client
+            .service_profiles_list("org", "region", None)
+            .await
+            .unwrap_err(),
+        client
+            .click_pipes_service_context_get("org", "service")
+            .await
+            .unwrap_err(),
+    ];
+    for error in errors {
+        assert!(
+            matches!(error, clickhouse_cloud_api::Error::Api { status: 403, message } if message == "forbidden")
+        );
+    }
+}

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -56,6 +56,11 @@ fn discriminated_union_defaults_round_trip_to_the_same_variant() {
         BackupBucketPatchRequest,
         BackupBucketPostRequest,
         BackupBucketProperties,
+        ClickPipeBigQuerySource,
+        ClickPipeMutateBigQuerySource,
+        ClickPipePostPubSubSource,
+        ClickStackSavedFilterValue,
+        ClickStackSavedFilterValueResponse,
         ClickStackAlertChannel,
         ClickStackBarChartConfig,
         ClickStackCategoricalBarChartConfig,
@@ -2386,6 +2391,9 @@ fn deserialize_clickpipe_post_pubsub_source_required_fields() {
         }
     }"#;
     let src: ClickPipePostPubSubSource = serde_json::from_str(json).unwrap();
+    let ClickPipePostPubSubSource::ClickPipePostPubSubServiceAccountSource(src) = src else {
+        panic!("expected service-account source")
+    };
     assert_eq!(src.topic, "projects/p/topics/t");
     assert_eq!(src.seek_type, ClickPipePostPubSubSourceSeektype::Earliest);
     assert_eq!(
@@ -3358,7 +3366,9 @@ fn shared_clickstack_source_types_stay_strict_on_the_request_side() {
         ClickStackMetricTables => ClickStackMetricTablesResponse,
         ClickStackPromqlSource => ClickStackPromqlSourceResponse,
         ClickStackQuerySetting => ClickStackQuerySettingResponse,
-        ClickStackSavedFilterValue => ClickStackSavedFilterValueResponse,
+        ClickStackSqlSavedFilterValue => ClickStackSqlSavedFilterValueResponse,
+        ClickStackVariableSavedFilterValue => ClickStackVariableSavedFilterValueResponse,
+        ClickStackFormula => ClickStackFormulaResponse,
         ClickStackSavedSearchFilter => ClickStackSavedSearchFilterResponse,
         ClickStackSessionSource => ClickStackSessionSourceResponse,
         ClickStackSourceFilterSettings => ClickStackSourceFilterSettingsResponse,
@@ -5936,4 +5946,309 @@ fn reverse_private_endpoint_tolerates_missing_and_null_fields() {
         "{}",
         "absent fields must be omitted, never serialized as null"
     );
+}
+
+#[test]
+fn new_response_models_preserve_missing_and_null_fields() {
+    macro_rules! tolerant {
+        ($model:ty, [$($field:literal),+]) => {{
+            let empty: $model = serde_json::from_value(serde_json::json!({})).unwrap();
+            let nulls: $model = serde_json::from_value(serde_json::json!({$($field: null),+})).unwrap();
+            assert_eq!(empty, nulls);
+            assert_eq!(serde_json::to_value(empty).unwrap(), serde_json::json!({}));
+        }};
+    }
+    tolerant!(
+        CreditBalance,
+        [
+            "id",
+            "type",
+            "remainingCredits",
+            "totalAmount",
+            "amountSpent",
+            "startDate",
+            "expirationDate"
+        ]
+    );
+    tolerant!(CreditBalances, ["totalRemainingCredits", "balances"]);
+    tolerant!(ServiceProfile, ["profile", "cpuCores", "memoryGi"]);
+    tolerant!(
+        ClickPipeBigQueryServiceAccountSource,
+        [
+            "snapshotStagingPath",
+            "settings",
+            "tableMappings",
+            "authentication",
+            "projectId"
+        ]
+    );
+    tolerant!(
+        ClickPipeBigQueryWorkloadIdentitySource,
+        [
+            "snapshotStagingPath",
+            "settings",
+            "tableMappings",
+            "authentication",
+            "projectId"
+        ]
+    );
+    tolerant!(
+        ClickPipesGcpWorkloadIdentityContext,
+        ["supported", "ready", "principal"]
+    );
+    tolerant!(ClickPipesServiceContext, ["gcpWorkloadIdentity"]);
+    tolerant!(
+        ClickStackFormulaResponse,
+        ["expression", "alias", "numberFormat"]
+    );
+    tolerant!(ClickStackSqlSavedFilterValueResponse, ["type", "condition"]);
+    tolerant!(
+        ClickStackVariableSavedFilterValueResponse,
+        ["type", "name", "values"]
+    );
+}
+
+#[test]
+fn clickpipes_workload_identity_sources_round_trip_without_credentials() {
+    let bigquery = serde_json::json!({
+        "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY", "projectId": "project",
+        "snapshotStagingPath": "gs://bucket/staging", "settings": {"replicationMode": "snapshot"},
+        "tableMappings": [{"sourceDatasetName": "dataset", "sourceTable": "source", "targetTable": "target"}]
+    });
+    let parsed: ClickPipeMutateBigQuerySource = serde_json::from_value(bigquery.clone()).unwrap();
+    assert!(matches!(
+        parsed,
+        ClickPipeMutateBigQuerySource::ClickPipePostBigQueryWorkloadIdentitySource(_)
+    ));
+    assert_eq!(serde_json::to_value(parsed).unwrap(), bigquery);
+    let pubsub = serde_json::json!({
+        "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY", "projectId": "project",
+        "topic": "topic", "format": "JSONEachRow", "seekType": "earliest"
+    });
+    let parsed: ClickPipePostPubSubSource = serde_json::from_value(pubsub.clone()).unwrap();
+    assert!(matches!(
+        parsed,
+        ClickPipePostPubSubSource::ClickPipePostPubSubWorkloadIdentitySource(_)
+    ));
+    assert_eq!(serde_json::to_value(parsed).unwrap(), pubsub);
+    assert!(
+        serde_json::from_value::<ClickPipePostBigQueryWorkloadIdentitySource>(
+            serde_json::json!({})
+        )
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<ClickPipePostPubSubWorkloadIdentitySource>(serde_json::json!({}))
+            .is_err()
+    );
+    assert!(
+        serde_json::from_value::<ClickPipePostBigQueryServiceAccountSource>(serde_json::json!({}))
+            .is_err()
+    );
+    assert!(
+        serde_json::from_value::<ClickPipePostPubSubServiceAccountSource>(serde_json::json!({}))
+            .is_err()
+    );
+}
+
+#[test]
+fn bigquery_service_account_allows_omitted_authentication() {
+    let json = serde_json::json!({
+        "snapshotStagingPath": "gs://bucket/staging", "settings": {"replicationMode": "snapshot"},
+        "tableMappings": [], "credentials": {"serviceAccountFile": "encoded-key"}
+    });
+    let parsed: ClickPipeMutateBigQuerySource = serde_json::from_value(json.clone()).unwrap();
+    assert!(matches!(
+        parsed,
+        ClickPipeMutateBigQuerySource::ClickPipePostBigQueryServiceAccountSource(_)
+    ));
+    assert_eq!(serde_json::to_value(parsed).unwrap(), json);
+}
+
+#[test]
+fn new_source_and_saved_filter_unions_preserve_unknown_payloads() {
+    assert_unknown_variant_round_trips::<ClickPipeMutateBigQuerySource>(
+        r#"{"authentication":"FUTURE","newField":1}"#,
+        |v| matches!(v, ClickPipeMutateBigQuerySource::Unknown(_)),
+    );
+    assert_unknown_variant_round_trips::<ClickPipeBigQuerySource>(
+        r#"{"authentication":"FUTURE","newField":1}"#,
+        |v| matches!(v, ClickPipeBigQuerySource::Unknown(_)),
+    );
+    assert_unknown_variant_round_trips::<ClickPipePostPubSubSource>(
+        r#"{"authentication":"FUTURE","newField":1}"#,
+        |v| matches!(v, ClickPipePostPubSubSource::Unknown(_)),
+    );
+    assert_unknown_variant_round_trips::<ClickStackSavedFilterValueResponse>(
+        r#"{"type":"future","values":["keep"]}"#,
+        |v| matches!(v, ClickStackSavedFilterValueResponse::Unknown(_)),
+    );
+    assert_unknown_variant_round_trips::<ClickStackSavedFilterValueResponse>(
+        r#"{"name":"service","values":["keep"]}"#,
+        |v| matches!(v, ClickStackSavedFilterValueResponse::Unknown(_)),
+    );
+    assert_unknown_variant_round_trips::<ClickPipeBigQuerySource>(
+        r#"{"authentication":"SERVICE_ACCOUNT","settings":"new-shape"}"#,
+        |v| matches!(v, ClickPipeBigQuerySource::Unknown(_)),
+    );
+}
+
+#[test]
+fn saved_filter_and_formula_writeback_reports_required_wire_fields() {
+    let sql: ClickStackSavedFilterValueResponse =
+        serde_json::from_value(serde_json::json!({"condition": "x = 1"})).unwrap();
+    let request = ClickStackSavedFilterValue::try_from(sql).unwrap();
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        serde_json::json!({"condition": "x = 1"})
+    );
+    let variable = serde_json::json!({"type": "variable", "name": "service", "values": ["api"]});
+    let response: ClickStackSavedFilterValueResponse =
+        serde_json::from_value(variable.clone()).unwrap();
+    assert_eq!(
+        serde_json::to_value(ClickStackSavedFilterValue::try_from(response).unwrap()).unwrap(),
+        variable
+    );
+    assert_eq!(
+        ClickStackSqlSavedFilterValue::try_from(ClickStackSqlSavedFilterValueResponse::default())
+            .unwrap_err()
+            .fields(),
+        &["condition"]
+    );
+    assert_eq!(
+        ClickStackVariableSavedFilterValue::try_from(
+            ClickStackVariableSavedFilterValueResponse::default()
+        )
+        .unwrap_err()
+        .fields(),
+        &["type", "name", "values"]
+    );
+    assert_eq!(
+        ClickStackFormula::try_from(ClickStackFormulaResponse::default())
+            .unwrap_err()
+            .fields(),
+        &["expression"]
+    );
+    let formula = ClickStackFormula::try_from(ClickStackFormulaResponse {
+        expression: Some("A / B".into()),
+        alias: Some("Rate".into()),
+        number_format: None,
+    })
+    .unwrap();
+    assert_eq!(formula.expression, "A / B");
+    assert_eq!(formula.alias.as_deref(), Some("Rate"));
+    let invalid = ClickStackFormulaResponse {
+        expression: Some("A".into()),
+        number_format: Some(ClickStackNumberFormatResponse::default()),
+        ..Default::default()
+    };
+    assert!(
+        ClickStackFormula::try_from(invalid)
+            .unwrap_err()
+            .fields()
+            .contains(&"currencySymbol")
+    );
+}
+
+#[test]
+fn kafka_inline_protobuf_schema_and_schema_registry_are_independent_options() {
+    let json_source = ClickPipePostKafkaSource {
+        format: ClickPipePostKafkaSourceFormat::JSONEachRow,
+        ..Default::default()
+    };
+    assert!(
+        serde_json::to_value(json_source)
+            .unwrap()
+            .get("protobufSchema")
+            .is_none()
+    );
+    let inline = ClickPipePostKafkaSource {
+        format: ClickPipePostKafkaSourceFormat::Protobuf,
+        protobuf_schema: Some("c3ludGF4".into()),
+        ..Default::default()
+    };
+    let wire = serde_json::to_value(inline).unwrap();
+    assert_eq!(wire["protobufSchema"], "c3ludGF4");
+    assert!(wire.get("schemaRegistry").is_none());
+    let registry = ClickPipePostKafkaSource {
+        format: ClickPipePostKafkaSourceFormat::Protobuf,
+        schema_registry: Some(ClickPipeMutateKafkaSchemaRegistry::default()),
+        ..Default::default()
+    };
+    let wire = serde_json::to_value(registry).unwrap();
+    assert!(wire.get("protobufSchema").is_none());
+    assert!(wire.get("schemaRegistry").is_some());
+}
+
+#[test]
+fn new_clickstack_channels_and_chart_fields_round_trip() {
+    let request = ClickStackCreateAlertRequest {
+        interval: ClickStackCreateAlertRequestInterval::Value30s,
+        channels: vec![ClickStackAlertChannel::default()],
+        ..Default::default()
+    };
+    let wire = serde_json::to_value(&request).unwrap();
+    assert_eq!(wire["channels"].as_array().unwrap().len(), 1);
+    assert_eq!(wire["interval"], "30s");
+    assert!(wire.get("channel").is_some());
+    assert_eq!(
+        serde_json::from_value::<ClickStackCreateAlertRequest>(wire).unwrap(),
+        request
+    );
+    let chart: ClickStackLineBuilderChartConfigResponse =
+        serde_json::from_value(serde_json::json!({
+            "formulas": [{"expression": "A / B", "alias": "Rate"}], "seriesLimit": 15,
+            "showOperandSeries": false
+        }))
+        .unwrap();
+    assert_eq!(chart.series_limit, Some(15));
+    assert_eq!(chart.show_operand_series, Some(false));
+    assert_eq!(
+        chart.formulas.unwrap()[0].expression.as_deref(),
+        Some("A / B")
+    );
+}
+
+#[test]
+fn clickstack_nested_writeback_preserves_number_format_and_source_expressions() {
+    let formula = serde_json::json!({
+        "expression": "A / B", "alias": "Success rate", "numberFormat": {
+            "average": false, "currencySymbol": "$", "decimalBytes": true,
+            "factor": 100.0, "mantissa": 2, "numericUnit": "bytes_si",
+            "output": "percent", "thousandSeparated": true, "unit": "%"
+        }
+    });
+    let response: ClickStackFormulaResponse = serde_json::from_value(formula.clone()).unwrap();
+    let request = ClickStackFormula::try_from(response).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), formula);
+
+    let log = serde_json::json!({
+        "kind": "log", "connection": "connection-1", "name": "Application logs",
+        "defaultTableSelectExpression": "*", "timestampValueExpression": "Timestamp",
+        "from": {"databaseName": "default", "tableName": "otel_logs"},
+        "serviceVersionExpression": "ResourceAttributes['service.version']",
+        "filterSettings": {
+            "databaseName": "default", "tableName": "service_names",
+            "columns": [{"name": "ServiceName", "label": "Service", "allowAll": true,
+                "valueExpression": "lower(service_name)"}]
+        }
+    });
+    let response: ClickStackSourceResponse = serde_json::from_value(log.clone()).unwrap();
+    let request = ClickStackSource::try_from(response).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), log);
+
+    let mut trace = log;
+    trace["kind"] = "trace".into();
+    trace["name"] = "Application traces".into();
+    trace["from"]["tableName"] = "otel_traces".into();
+    trace["durationExpression"] = "Duration".into();
+    trace["durationPrecision"] = 9.into();
+    trace["parentSpanIdExpression"] = "ParentSpanId".into();
+    trace["spanIdExpression"] = "SpanId".into();
+    trace["spanKindExpression"] = "SpanKind".into();
+    trace["spanNameExpression"] = "SpanName".into();
+    trace["traceIdExpression"] = "TraceId".into();
+    let response: ClickStackSourceResponse = serde_json::from_value(trace.clone()).unwrap();
+    let request = ClickStackSource::try_from(response).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), trace);
 }

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -50,6 +50,9 @@ pub fn clickhouse_cloud_config() -> AnalyzerConfig {
 }
 
 const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
+    // The spec allows protobufSchema only for Protobuf without schemaRegistry;
+    // requiring it would reject JSON/Avro and schema-registry Kafka requests.
+    ("ClickPipePostKafkaSource", "protobufSchema"),
     // The legacy service-create schema marks almost every property required,
     // but the API requires only name/provider/region and rejects many defaults.
     ("ServicePostRequest", "autoscalingMode"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1621,7 +1621,7 @@ fn build_kafka_credentials(
                 "MUTUAL_TLS requires --client-certificate and --client-key",
             )),
         },
-        Auth::Unknown(_) => Ok(serde_json::Value::Null),
+        Auth::ServiceAccountWorkloadIdentity | Auth::Unknown(_) => Ok(serde_json::Value::Null),
     }
 }
 
@@ -1712,6 +1712,7 @@ fn build_kafka_source(
             timestamp: args.offset_timestamp.clone(),
         }),
         schema_registry,
+        protobuf_schema: None,
         ca_certificate,
         reverse_private_endpoint_ids: args.reverse_private_endpoint_ids.clone(),
     })
@@ -1859,9 +1860,9 @@ fn parse_pubsub_seek_timestamp(value: &str) -> CloudResult<chrono::DateTime<chro
 /// creation send an identical `pubsub` source.
 fn build_pubsub_source(
     args: &PubSubSourceFields,
-) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostPubSubSource> {
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostPubSubServiceAccountSource> {
     use clickhouse_cloud_api::models::{
-        ClickPipePostPubSubSource, ClickPipePostPubSubSourceSeektype, ServiceAccount,
+        ClickPipePostPubSubServiceAccountSource, ClickPipePostPubSubSourceSeektype, ServiceAccount,
     };
 
     let seek_type: ClickPipePostPubSubSourceSeektype = parse_enum(&args.seek_type)?;
@@ -1875,7 +1876,7 @@ fn build_pubsub_source(
         )));
     }
 
-    Ok(ClickPipePostPubSubSource {
+    Ok(ClickPipePostPubSubServiceAccountSource {
         topic: args.topic.clone(),
         project_id: args.project_id.clone(),
         format: parse_enum(&args.format)?,
@@ -1913,7 +1914,7 @@ fn build_pubsub_schema_discovery_request(
             kafka: None,
             kinesis: None,
             object_storage: None,
-            pubsub: Some(build_pubsub_source(args)?),
+            pubsub: Some(build_pubsub_source(args)?.into()),
         },
     })
 }
@@ -1933,7 +1934,7 @@ async fn clickpipe_create_pubsub(
     let request = ClickPipePostRequest {
         name: args.name.clone(),
         source: ClickPipePostSource {
-            pubsub: Some(source),
+            pubsub: Some(source.into()),
             ..Default::default()
         },
         destination: build_destination(
@@ -3220,7 +3221,8 @@ async fn clickpipe_create_bigquery(
 ) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeBigQueryPipeSettings, ClickPipeBigQueryPipeTableMapping,
-        ClickPipeMutateBigQuerySource, ClickPipePostRequest, ClickPipePostSource, ServiceAccount,
+        ClickPipePostBigQueryServiceAccountSource, ClickPipePostRequest, ClickPipePostSource,
+        ServiceAccount,
     };
 
     let org_id = resolve_org_id(client, args.org_id.as_deref()).await?;
@@ -3252,7 +3254,9 @@ async fn clickpipe_create_bigquery(
         })
         .collect::<CloudResult<Vec<_>>>()?;
 
-    let source = ClickPipeMutateBigQuerySource {
+    let source = ClickPipePostBigQueryServiceAccountSource {
+        authentication: None,
+        project_id: None,
         credentials: ServiceAccount {
             service_account_file,
         },
@@ -3267,7 +3271,7 @@ async fn clickpipe_create_bigquery(
     let request = ClickPipePostRequest {
         name: args.name.clone(),
         source: ClickPipePostSource {
-            bigquery: Some(source),
+            bigquery: Some(source.into()),
             ..Default::default()
         },
         destination: build_destination(
@@ -7135,7 +7139,7 @@ mod tests {
         assert!(request.source.kafka.is_none());
         assert!(request.source.kinesis.is_none());
         assert!(request.source.object_storage.is_none());
-        let source = request.source.pubsub.expect("pubsub source is set");
+        let clickhouse_cloud_api::models::ClickPipePostPubSubSource::ClickPipePostPubSubServiceAccountSource(source) = request.source.pubsub.expect("pubsub source is set") else { panic!("expected service-account source") };
         assert_eq!(source.topic, "events");
         assert_eq!(source.project_id, "my-gcp-project");
         assert_eq!(source.format, ClickPipePostPubSubSourceFormat::JSONEachRow);
@@ -7180,7 +7184,7 @@ mod tests {
         assert!(request.source.kafka.is_none());
         assert!(request.source.kinesis.is_none());
         assert!(request.source.object_storage.is_none());
-        let source = request.source.pubsub.expect("pubsub source is set");
+        let clickhouse_cloud_api::models::ClickPipePostPubSubSource::ClickPipePostPubSubServiceAccountSource(source) = request.source.pubsub.expect("pubsub source is set") else { panic!("expected service-account source") };
         assert_eq!(
             source.seek_type,
             ClickPipePostPubSubSourceSeektype::Timestamp


### PR DESCRIPTION
The live Cloud API specification had 107 actionable drift findings against the published Rust client. Refresh the snapshot from the unchanged live document and reconcile those findings: the final live dry run and captured-document analyzer both report zero actionable findings, with the same five pre-existing unsupported-enum acknowledgements.

Add typed client methods for credit balances, region/BYOC service profiles, and ClickPipes workload identity context. Update ClickPipes authentication unions, Kafka inline Protobuf schema, MySQL partition expressions, and BigQuery optional settings; add ClickStack channels, formulas, variable filters, series limits, service-version expressions and alert enum values; expose UDF response determinism; regenerate beta metadata. New response fields remain tolerant, and new ClickStack response/request pairs have explicit fallible write-back conversions. CLI edits only adapt existing builders and tests to the changed library types.

Compatibility details for 0.5.0:
- `ServiceProfile` is now the discovery-response object; the former service-profile value enum is `ServiceProfileName`.
- BigQuery/PubSub source models and ClickStack saved filter values become typed unions. Existing service-account source structs convert to their union through `.into()`.
- Both `channel` and `channels` remain strict on ClickStack alert requests under the documented legacy requiredness convention. Server acceptance of a channels-only payload is not established by this change; the README calls this out.
- Kafka `protobufSchema` has a narrowly documented optionality exemption because the live spec permits it only for Protobuf without a schema registry. No missing API surface was exempted.

Validation completed by remediation:
- `cargo fmt --all` and `git diff --check`.
- API/analyzer all-target Clippy with warnings denied.
- Full API/analyzer tests: 560 passed, 26 ignored (live cloud tests and documentation examples); the additional complete nested write-back regression fixture passed separately.
- Python tooling tests: 90 passed.
- `cargo check -p clickhousectl`.
- Live `python3 scripts/check-openapi-drift.py --dry-run`: 0 actionable findings, 5 unchanged acknowledgements.
- Snapshot byte-identical to the captured live document (SHA-256 `c9f12e2e734947fc31a04ca225a9a21c2ff975dc499df04562ef4c372d9ae79c`).

Root CLI gates all passed: default Clippy with warnings denied; `cargo check -p clickhousectl --no-default-features`; all-target no-default-features Clippy with warnings denied; `cargo test -p clickhousectl -- --test-threads=1` (1,020 unit tests, 240 Cloud subprocess tests, all local suites, 50 telemetry tests; 2 existing ignored).

Closes #522. CLI exposure is planned separately in #699. Known analyzer/model gaps discovered by the broader audit are tracked separately in #697 (map-valued PgBouncer config), #698 (explicit-null API-key expiry), and #571 (inline UDF request fields); zero typed findings does not establish complete wire-semantic coverage.
