### PR TITLE
fix(api): preserve PgBouncer configuration maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With `clickhousectl` you can:
 
 `clickhousectl` helps humans and coding agents develop with ClickHouse and Postgres.
 
-The workspace also publishes the [typed Rust Cloud API client](crates/clickhouse-cloud-api/README.md). Its latest OpenAPI snapshot adds credit balances, service profile discovery, ClickPipes workload identity context, and expanded ClickPipes and ClickStack models; [CLI exposure is tracked separately](https://github.com/ClickHouse/clickhousectl/issues/699).
+The workspace also publishes the [typed Rust Cloud API client](crates/clickhouse-cloud-api/README.md). PgBouncer configuration uses an open string map, preserving arbitrary parameters when reading and writing configurations. Its latest OpenAPI snapshot adds credit balances, service profile discovery, ClickPipes workload identity context, and expanded ClickPipes and ClickStack models; [CLI exposure is tracked separately](https://github.com/ClickHouse/clickhousectl/issues/699).
 
 ## Installation
 

--- a/crates/clickhouse-cloud-api/AGENTS.md
+++ b/crates/clickhouse-cloud-api/AGENTS.md
@@ -35,6 +35,8 @@ outage. Tolerance lives in the **type system**, not in serde attributes:
   `false` that a get → edit → write-back caller silently persists; on an `Option` field it is dead weight.
   Sweeping it across every field was the superseded policy of #312/#313 — do not reintroduce it.
 - **Unknown fields are ignored.** Never `deny_unknown_fields`.
+- **Typed `additionalProperties` maps preserve dynamic keys.** Use typed string-keyed map aliases instead of
+  empty structs; keep parent response fields optional. The analyzer checks named map schemas in both directions.
 
 ### Naming and the split
 

--- a/crates/clickhouse-cloud-api/src/convert/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/convert/postgres.rs
@@ -1,13 +1,6 @@
 use super::MissingRequiredFields;
 use crate::models::*;
 
-impl From<PgBouncerConfigResponse> for PgBouncerConfig {
-    fn from(_value: PgBouncerConfigResponse) -> Self {
-        // The schema declares no properties, so the conversion is total.
-        Self {}
-    }
-}
-
 impl From<PgConfigResponse> for PgConfig {
     fn from(value: PgConfigResponse) -> Self {
         // Every `pgConfig` GUC is optional in both directions (omitting one
@@ -66,7 +59,7 @@ impl TryFrom<PostgresInstanceConfigResponse> for PostgresInstanceConfig {
         }
         match (value.pg_bouncer_config, value.pg_config) {
             (Some(pg_bouncer_config), Some(pg_config)) => Ok(Self {
-                pg_bouncer_config: pg_bouncer_config.into(),
+                pg_bouncer_config,
                 pg_config: pg_config.into(),
             }),
             _ => Err(MissingRequiredFields::new(missing)),

--- a/crates/clickhouse-cloud-api/src/models/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/models/postgres.rs
@@ -1191,17 +1191,16 @@ pub struct PostgresSlowQueryPatternDetail {
     pub recent_executions: Option<Vec<PostgresQueryExecution>>,
 }
 
-/// `pgBouncerConfig` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct PgBouncerConfig {}
-
-/// `pgBouncerConfig` from the ClickHouse Cloud API, in response position.
+/// PgBouncer configuration parameters, with string values as required by the API.
 ///
-/// Response variant of [`PgBouncerConfig`]: every field is `Option<T>`, so a
-/// field the API drops or sends as `null` deserializes to `None` instead of
-/// failing. The schema currently declares no properties.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct PgBouncerConfigResponse {}
+/// Keys are open-ended: newly supported PgBouncer parameters are preserved.
+pub type PgBouncerConfig = std::collections::BTreeMap<String, String>;
+
+/// PgBouncer configuration returned by the API.
+///
+/// Parent response fields are optional, preserving missing and null sections.
+/// Present map entries retain their wire string values for lossless write-back.
+pub type PgBouncerConfigResponse = PgBouncerConfig;
 
 /// `pgConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -3274,7 +3274,7 @@ async fn create_postgres_service() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/postgres"))
-        .and(body_partial_json(serde_json::json!({"name": "pg-svc", "provider": "aws", "region": "us-east-1", "size": "c6gd.large"})))
+        .and(body_partial_json(serde_json::json!({"name": "pg-svc", "provider": "aws", "region": "us-east-1", "size": "c6gd.large", "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}})))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "name": "pg-svc",
@@ -3291,6 +3291,10 @@ async fn create_postgres_service() {
         provider: PgProvider::Aws,
         region: "us-east-1".to_string(),
         size: PgSize::C6gd_large,
+        pg_bouncer_config: Some(PgBouncerConfig::from([
+            ("default_pool_size".into(), "16".into()),
+            ("future_parameter".into(), "on".into()),
+        ])),
         ..Default::default()
     };
     let resp = c.postgres_service_create("org-1", &body).await.unwrap();
@@ -3465,7 +3469,7 @@ async fn get_postgres_config() {
             "pgConfig": {
                 "max_connections": 100
             },
-            "pgBouncerConfig": {}
+            "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}
         })))
         .mount(&s)
         .await;
@@ -3475,6 +3479,14 @@ async fn get_postgres_config() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
+    assert_eq!(
+        config.pg_bouncer_config.as_ref().unwrap()["default_pool_size"],
+        "16"
+    );
+    assert_eq!(
+        config.pg_bouncer_config.as_ref().unwrap()["future_parameter"],
+        "on"
+    );
     assert_eq!(
         config
             .pg_config
@@ -3491,12 +3503,12 @@ async fn replace_postgres_config() {
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/config"))
         .and(body_partial_json(
-            serde_json::json!({"pgConfig": {"max_connections": 200}, "pgBouncerConfig": {}}),
+            serde_json::json!({"pgConfig": {"max_connections": 200}, "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),
         ))
         .respond_with(ok_json(serde_json::json!({
             "message": "Configuration updated",
             "pgConfig": { "max_connections": 200 },
-            "pgBouncerConfig": {}
+            "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}
         })))
         .mount(&s)
         .await;
@@ -3506,13 +3518,24 @@ async fn replace_postgres_config() {
             max_connections: Some(serde_json::json!(200)),
             ..Default::default()
         },
-        pg_bouncer_config: PgBouncerConfig::default(),
+        pg_bouncer_config: PgBouncerConfig::from([
+            ("default_pool_size".into(), "16".into()),
+            ("future_parameter".into(), "on".into()),
+        ]),
     };
     let resp = c
         .postgres_instance_config_post("org-1", "pg-1", &body)
         .await
         .unwrap();
     let result = resp.result.unwrap();
+    assert_eq!(
+        result.pg_bouncer_config.as_ref().unwrap()["default_pool_size"],
+        "16"
+    );
+    assert_eq!(
+        result.pg_bouncer_config.as_ref().unwrap()["future_parameter"],
+        "on"
+    );
     assert_eq!(result.message, Some("Configuration updated".to_string()));
     assert_eq!(
         result
@@ -3530,12 +3553,12 @@ async fn patch_postgres_config() {
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/config"))
         .and(body_partial_json(
-            serde_json::json!({"pgConfig": {"max_connections": 150}, "pgBouncerConfig": {}}),
+            serde_json::json!({"pgConfig": {"max_connections": 150}, "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),
         ))
         .respond_with(ok_json(serde_json::json!({
             "message": "OK",
             "pgConfig": { "max_connections": 150 },
-            "pgBouncerConfig": {}
+            "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}
         })))
         .mount(&s)
         .await;
@@ -3545,13 +3568,24 @@ async fn patch_postgres_config() {
             max_connections: Some(serde_json::json!(150)),
             ..Default::default()
         },
-        pg_bouncer_config: PgBouncerConfig::default(),
+        pg_bouncer_config: PgBouncerConfig::from([
+            ("default_pool_size".into(), "16".into()),
+            ("future_parameter".into(), "on".into()),
+        ]),
     };
     let resp = c
         .postgres_instance_config_patch("org-1", "pg-1", &body)
         .await
         .unwrap();
     let result = resp.result.unwrap();
+    assert_eq!(
+        result.pg_bouncer_config.as_ref().unwrap()["default_pool_size"],
+        "16"
+    );
+    assert_eq!(
+        result.pg_bouncer_config.as_ref().unwrap()["future_parameter"],
+        "on"
+    );
     assert_eq!(
         result
             .pg_config
@@ -3568,7 +3602,7 @@ async fn create_postgres_read_replica() {
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/readReplica"))
         .and(body_partial_json(
-            serde_json::json!({"name": "pg-1-replica"}),
+            serde_json::json!({"name": "pg-1-replica", "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),
         ))
         .respond_with(ok_json(serde_json::json!({
             "id": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
@@ -3580,6 +3614,10 @@ async fn create_postgres_read_replica() {
 
     let body = PostgresServiceReadReplicaRequest {
         name: "pg-1-replica".to_string(),
+        pg_bouncer_config: Some(PgBouncerConfig::from([
+            ("default_pool_size".into(), "16".into()),
+            ("future_parameter".into(), "on".into()),
+        ])),
         ..Default::default()
     };
     let resp = c
@@ -3599,7 +3637,7 @@ async fn restore_postgres_service() {
             "/v1/organizations/org-1/postgres/pg-1/restoredService",
         ))
         .and(body_partial_json(
-            serde_json::json!({"name": "pg-1-restored"}),
+            serde_json::json!({"name": "pg-1-restored", "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),
         ))
         .respond_with(ok_json(serde_json::json!({
             "id": "cccccccc-dddd-eeee-ffff-000000000000",
@@ -3611,6 +3649,10 @@ async fn restore_postgres_service() {
 
     let body = PostgresServiceRestoreRequest {
         name: "pg-1-restored".to_string(),
+        pg_bouncer_config: Some(PgBouncerConfig::from([
+            ("default_pool_size".into(), "16".into()),
+            ("future_parameter".into(), "on".into()),
+        ])),
         restore_target: Utc::now(),
         ..Default::default()
     };

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -1713,7 +1713,10 @@ fn postgres_instance_config_response_converts_back_into_a_request_body() {
             max_connections: Some(serde_json::json!(200)),
             ..Default::default()
         }),
-        pg_bouncer_config: Some(PgBouncerConfigResponse {}),
+        pg_bouncer_config: Some(PgBouncerConfigResponse::from([
+            ("default_pool_size".to_string(), "16".to_string()),
+            ("future_parameter".to_string(), "on".to_string()),
+        ])),
     };
     let request = PostgresInstanceConfig::try_from(response).unwrap();
     assert_eq!(
@@ -1722,7 +1725,7 @@ fn postgres_instance_config_response_converts_back_into_a_request_body() {
     );
     assert_eq!(
         serde_json::to_value(&request).unwrap(),
-        serde_json::json!({ "pgConfig": { "max_connections": 200 }, "pgBouncerConfig": {} })
+        serde_json::json!({ "pgConfig": { "max_connections": 200 }, "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"} })
     );
 }
 
@@ -6251,4 +6254,60 @@ fn clickstack_nested_writeback_preserves_number_format_and_source_expressions() 
     let response: ClickStackSourceResponse = serde_json::from_value(trace.clone()).unwrap();
     let request = ClickStackSource::try_from(response).unwrap();
     assert_eq!(serde_json::to_value(request).unwrap(), trace);
+}
+
+#[test]
+fn pgbouncer_map_round_trips_arbitrary_string_parameters() {
+    let document = serde_json::json!({
+        "default_pool_size": "16", "future_parameter": "on", "empty": ""
+    });
+    let request: PgBouncerConfig = serde_json::from_value(document.clone()).unwrap();
+    let response: PgBouncerConfigResponse = serde_json::from_value(document.clone()).unwrap();
+    assert_eq!(request, response);
+    assert_eq!(serde_json::to_value(request).unwrap(), document);
+    assert_eq!(serde_json::to_value(response).unwrap(), document);
+}
+
+#[test]
+fn pgbouncer_requests_reject_non_string_values() {
+    for value in [
+        serde_json::json!(16),
+        serde_json::json!(true),
+        serde_json::json!(null),
+        serde_json::json!([]),
+        serde_json::json!({}),
+    ] {
+        assert!(
+            serde_json::from_value::<PgBouncerConfig>(
+                serde_json::json!({"default_pool_size": value})
+            )
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn pgbouncer_parent_responses_preserve_missing_null_and_empty_sections() {
+    for document in [
+        serde_json::json!({}),
+        serde_json::json!({"pgBouncerConfig": null}),
+    ] {
+        let config: PostgresInstanceConfigResponse =
+            serde_json::from_value(document.clone()).unwrap();
+        assert!(config.pg_bouncer_config.is_none());
+        assert_eq!(serde_json::to_value(config).unwrap(), serde_json::json!({}));
+        let update: PostgresInstanceUpdateConfigResponse =
+            serde_json::from_value(document).unwrap();
+        assert!(update.pg_bouncer_config.is_none());
+        assert_eq!(serde_json::to_value(update).unwrap(), serde_json::json!({}));
+    }
+    let config: PostgresInstanceConfigResponse = serde_json::from_value(
+        serde_json::json!({"pgBouncerConfig": {}, "futureField": "ignored"}),
+    )
+    .unwrap();
+    assert_eq!(config.pg_bouncer_config, Some(PgBouncerConfig::new()));
+    assert_eq!(
+        serde_json::to_value(config).unwrap(),
+        serde_json::json!({"pgBouncerConfig": {}})
+    );
 }

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -5,7 +5,7 @@ use crate::openapi::{
     EnumConstraint, EnumContext, EnumValues, OpenApiInventory, PropertyStep, pascalize,
 };
 use crate::report::{DriftReport, Finding, FindingKind, UnsupportedEnumConstraint};
-use crate::rust_inventory::RustInventory;
+use crate::rust_inventory::{RustInventory, TypeNode};
 
 pub(crate) fn compare(
     rust: &RustInventory,
@@ -17,6 +17,7 @@ pub(crate) fn compare(
     compare_operations(rust, spec, config, &mut report);
     compare_models_and_refs(rust, spec, &mut report);
     compare_fields(rust, spec, config, &mut report);
+    compare_additional_properties(rust, spec, &mut report);
     compare_beta_and_deprecation(rust, spec, config, &mut report);
     compare_enums(rust, spec, config, &mut report);
     compare_snapshot(spec, snapshot, &mut report);
@@ -237,7 +238,7 @@ fn compare_fields(
                 continue;
             };
             for (spec_name, field) in &struct_info.fields {
-                if property_names.contains(spec_name.as_str()) {
+                if field.flatten || property_names.contains(spec_name.as_str()) {
                     continue;
                 }
                 let key = (rust_name.clone(), spec_name.clone());
@@ -264,6 +265,120 @@ fn compare_fields(
         &extra_hits,
         report,
     );
+}
+
+/// Dynamic keys are invisible to ordinary named-property comparison. Require a
+/// typed string-keyed map (directly, through aliases, or in a flattened field)
+/// so deserialization cannot silently discard those keys.
+fn compare_additional_properties(
+    rust: &RustInventory,
+    spec: &OpenApiInventory,
+    report: &mut DriftReport,
+) {
+    for (schema_name, additional) in &spec.additional_properties {
+        for (name, direction) in field_check_targets(rust, spec, schema_name) {
+            if !rust.model_types.contains(&name) {
+                continue;
+            }
+            let named = TypeNode::Path(name.clone());
+            let resolved = rust.resolve_alias(&named);
+            let candidate = match resolved {
+                TypeNode::Map(_, _) => Some(resolved),
+                TypeNode::Path(struct_name) => rust.structs.get(struct_name).and_then(|info| {
+                    info.fields
+                        .values()
+                        .find(|field| field.flatten)
+                        .map(|field| &field.rust_type)
+                }),
+                _ => None,
+            };
+            let candidate = candidate.map(|ty| {
+                let ty = rust.resolve_alias(ty);
+                // A flattened response map can itself be absent.
+                if let TypeNode::Option(inner) = ty {
+                    rust.resolve_alias(inner)
+                } else {
+                    ty
+                }
+            });
+            let matches = candidate.is_some_and(|ty| {
+                let TypeNode::Map(key, value) = ty else {
+                    return false;
+                };
+                matches!(rust.resolve_alias(key), TypeNode::Path(name) if name == "String")
+                    && map_value_matches(rust, spec, value, &additional.value_schema, direction)
+            });
+            if !matches {
+                let actual = candidate.unwrap_or(resolved).display();
+                report.findings.push(Finding::new(
+                    FindingKind::AdditionalPropertiesMismatch,
+                    format!("{name} must preserve additionalProperties in a typed string-keyed map, found {actual}"),
+                )
+                .at_spec(&additional.pointer)
+                .at_rust(format!("models.rs::{name}"))
+                .detail("schema", schema_name)
+                .detail("expected_value_schema", additional.value_schema.to_string())
+                .detail("actual", actual));
+            }
+        }
+    }
+}
+
+fn map_value_matches(
+    rust: &RustInventory,
+    spec: &OpenApiInventory,
+    ty: &TypeNode,
+    schema: &serde_json::Value,
+    direction: Direction,
+) -> bool {
+    let ty = rust.resolve_alias(ty);
+    if schema.get("nullable").and_then(serde_json::Value::as_bool) == Some(true) {
+        let TypeNode::Option(inner) = ty else {
+            return false;
+        };
+        let mut non_nullable = schema.clone();
+        non_nullable.as_object_mut().unwrap().remove("nullable");
+        return map_value_matches(rust, spec, inner, &non_nullable, direction);
+    }
+    if let Some(reference) = schema.get("$ref").and_then(serde_json::Value::as_str) {
+        let Some(schema_name) = reference.strip_prefix("#/components/schemas/") else {
+            return false;
+        };
+        let schema_name = schema_name.replace("~1", "/").replace("~0", "~");
+        let expected = match direction {
+            Direction::Request => pascalize(&schema_name),
+            Direction::Response => response_position_type(rust, spec, &pascalize(&schema_name)),
+        };
+        return ty == rust.resolve_alias(&TypeNode::Path(expected));
+    }
+    match schema.get("type").and_then(serde_json::Value::as_str) {
+        Some("string") => matches!(ty, TypeNode::Path(name) if name == "String"),
+        Some("boolean") => matches!(ty, TypeNode::Path(name) if name == "bool"),
+        Some("integer") => {
+            matches!(ty, TypeNode::Path(name) if matches!(name.as_str(), "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "isize" | "usize"))
+        }
+        Some("number") => {
+            matches!(ty, TypeNode::Path(name) if matches!(name.as_str(), "f32" | "f64"))
+        }
+        Some("array") => match ty {
+            TypeNode::Vec(inner) => schema
+                .get("items")
+                .is_some_and(|items| map_value_matches(rust, spec, inner, items, direction)),
+            _ => false,
+        },
+        Some("object") => match ty {
+            TypeNode::Map(key, value) => {
+                matches!(rust.resolve_alias(key), TypeNode::Path(name) if name == "String")
+                    && schema
+                        .get("additionalProperties")
+                        .is_some_and(|additional| {
+                            map_value_matches(rust, spec, value, additional, direction)
+                        })
+            }
+            _ => false,
+        },
+        _ => false,
+    }
 }
 
 fn compare_beta_and_deprecation(
@@ -961,6 +1076,174 @@ mod tests {
         .unwrap();
         let openapi = OpenApiInventory::build(&spec, &config).unwrap();
         compare(&rust, &openapi, &openapi, &config)
+    }
+
+    #[test]
+    fn additional_properties_detects_empty_structs_in_both_directions() {
+        let report = analyze_directional(
+            "pub struct Widget {} pub struct WidgetResponse {}",
+            directional_spec(
+                serde_json::json!({
+                    "type": "object", "additionalProperties": {"type": "string"}
+                }),
+                true,
+                true,
+            ),
+            AnalyzerConfig::default(),
+        );
+        assert_eq!(report.findings.len(), 2, "{}", report.render_text());
+        for finding in &report.findings {
+            assert_eq!(finding.kind, FindingKind::AdditionalPropertiesMismatch);
+            assert_eq!(
+                finding.spec_pointer.as_deref(),
+                Some("/components/schemas/Widget/additionalProperties")
+            );
+        }
+        assert_eq!(
+            report.findings[0].rust_item.as_deref(),
+            Some("models.rs::Widget")
+        );
+        assert_eq!(
+            report.findings[1].rust_item.as_deref(),
+            Some("models.rs::WidgetResponse")
+        );
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["schema_version"], 4);
+        assert_eq!(
+            json["findings"][0]["kind"],
+            "additional_properties_mismatch"
+        );
+        assert!(
+            report
+                .render_text()
+                .contains("AdditionalPropertiesMismatch")
+        );
+    }
+
+    #[test]
+    fn additional_properties_accepts_map_aliases_and_flattened_maps() {
+        for models in [
+            "pub type Widget = std::collections::BTreeMap<String, String>; pub type WidgetResponse = Widget;",
+            "pub type Text = String; pub type Widget = HashMap<Text, Text>; pub type WidgetResponse = Widget;",
+            "pub struct Widget { #[serde(flatten)] pub values: BTreeMap<String, String> } pub type WidgetResponse = Widget;",
+        ] {
+            let report = analyze_directional(
+                models,
+                directional_spec(
+                    serde_json::json!({
+                        "type": "object", "additionalProperties": {"type": "string"}
+                    }),
+                    true,
+                    true,
+                ),
+                AnalyzerConfig::default(),
+            );
+            assert!(!report.has_drift(), "{}", report.render_text());
+        }
+    }
+
+    #[test]
+    fn additional_properties_rejects_losing_or_untyped_representations() {
+        for models in [
+            "pub type Widget = serde_json::Value;",
+            "pub type Widget = BTreeMap<String, serde_json::Value>;",
+            "pub type Widget = BTreeMap<i64, String>;",
+            "pub type Widget = BTreeMap<String, i64>;",
+            "pub type Widget = BTreeMap<String, Option<String>>;",
+            "pub struct Widget { pub values: BTreeMap<String, String> }",
+            "pub type Widget = Cycle; pub type Cycle = Widget;",
+        ] {
+            let report = analyze_fixture(
+                models,
+                serde_json::json!({
+                    "type": "object", "additionalProperties": {"type": "string"}
+                }),
+                AnalyzerConfig::default(),
+            );
+            assert_eq!(
+                report.findings.len(),
+                1,
+                "{models}: {}",
+                report.render_text()
+            );
+            assert_eq!(
+                report.findings[0].kind,
+                FindingKind::AdditionalPropertiesMismatch
+            );
+        }
+    }
+
+    #[test]
+    fn additional_properties_leaves_untyped_and_closed_objects_alone() {
+        for additional in [
+            serde_json::json!(true),
+            serde_json::json!(false),
+            serde_json::json!({}),
+        ] {
+            let report = analyze_fixture(
+                "pub struct Widget {}",
+                serde_json::json!({
+                    "type": "object", "additionalProperties": additional
+                }),
+                AnalyzerConfig::default(),
+            );
+            assert!(!report.has_drift(), "{}", report.render_text());
+        }
+    }
+
+    #[test]
+    fn additional_properties_maps_coexist_with_named_properties() {
+        let report = analyze_fixture(
+            "pub struct Widget { pub name: String, #[serde(flatten)] pub values: BTreeMap<String, String> }",
+            serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}, "additionalProperties": {"type": "string"}}),
+            AnalyzerConfig::default(),
+        );
+        assert!(!report.has_drift(), "{}", report.render_text());
+    }
+
+    #[test]
+    fn additional_properties_checks_nested_and_nullable_values() {
+        for (value_type, value_schema) in [
+            ("bool", serde_json::json!({"type": "boolean"})),
+            ("i64", serde_json::json!({"type": "integer"})),
+            ("f64", serde_json::json!({"type": "number"})),
+            (
+                "Vec<String>",
+                serde_json::json!({"type": "array", "items": {"type": "string"}}),
+            ),
+            (
+                "BTreeMap<String, String>",
+                serde_json::json!({"type": "object", "additionalProperties": {"type": "string"}}),
+            ),
+            (
+                "Option<String>",
+                serde_json::json!({"type": "string", "nullable": true}),
+            ),
+        ] {
+            let report = analyze_fixture(
+                &format!("pub type Widget = BTreeMap<String, {value_type}>;"),
+                serde_json::json!({"type": "object", "additionalProperties": value_schema}),
+                AnalyzerConfig::default(),
+            );
+            assert!(!report.has_drift(), "{}", report.render_text());
+        }
+    }
+
+    #[test]
+    fn additional_properties_resolves_referenced_value_models_by_direction() {
+        let mut spec = directional_spec(
+            serde_json::json!({"type": "object", "additionalProperties": {"$ref": "#/components/schemas/Entry"}}),
+            true,
+            true,
+        );
+        spec["components"]["schemas"]["Entry"] =
+            serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        let report = analyze_directional(
+            "pub type Widget = BTreeMap<String, Entry>; pub type WidgetResponse = BTreeMap<String, EntryResponse>; pub struct Entry {pub name: String} pub struct EntryResponse {pub name: Option<String>}",
+            spec,
+            AnalyzerConfig::default(),
+        );
+        assert!(!report.has_drift(), "{}", report.render_text());
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -24,6 +24,13 @@ pub(crate) struct PropertyInfo {
     pub(crate) schema_type: Option<String>,
 }
 
+/// A named schema whose dynamic keys have a declared value schema.
+#[derive(Debug, Clone)]
+pub(crate) struct AdditionalPropertiesInfo {
+    pub(crate) pointer: String,
+    pub(crate) value_schema: Value,
+}
+
 /// One hop in a property chain from a named schema down to an enum position.
 ///
 /// `property` is the spec property name entered at this step. `array_item` is
@@ -76,6 +83,7 @@ pub(crate) struct OpenApiInventory {
     /// models a spec schema literally named `{Name}Response`.
     pub(crate) rust_schema_names: BTreeSet<String>,
     pub(crate) properties: BTreeMap<(String, String), PropertyInfo>,
+    pub(crate) additional_properties: BTreeMap<String, AdditionalPropertiesInfo>,
     pub(crate) referenced_schemas: BTreeMap<String, String>,
     /// Schemas transitively reachable from a request body or an operation
     /// parameter. Requiredness/optionality drift is checked only here.
@@ -181,6 +189,18 @@ impl OpenApiInventory {
             ]);
             self.schemas
                 .insert(schema_name.clone(), schema_pointer.clone());
+            if let Some(additional) = schema
+                .get("additionalProperties")
+                .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
+            {
+                self.additional_properties.insert(
+                    schema_name.clone(),
+                    AdditionalPropertiesInfo {
+                        pointer: format!("{schema_pointer}/additionalProperties"),
+                        value_schema: additional.clone(),
+                    },
+                );
+            }
             let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
                 continue;
             };

--- a/crates/clickhouse-openapi-analyzer/src/report.rs
+++ b/crates/clickhouse-openapi-analyzer/src/report.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-pub const REPORT_SCHEMA_VERSION: u32 = 3;
+pub const REPORT_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -14,6 +14,7 @@ pub enum FindingKind {
     MissingStructField,
     ExtraStructField,
     FieldOptionalityMismatch,
+    AdditionalPropertiesMismatch,
     NewlyBetaOperation,
     GraduatedBetaOperation,
     NewlyDeprecatedField,

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -358,6 +358,7 @@ fn evaluate_name_value_cfg(value: &syn::MetaNameValue) -> syn::Result<CfgValue> 
 pub(crate) enum TypeNode {
     Option(Box<TypeNode>),
     Vec(Box<TypeNode>),
+    Map(Box<TypeNode>, Box<TypeNode>),
     Boxed(Box<TypeNode>),
     Reference(Box<TypeNode>),
     Path(String),
@@ -375,18 +376,24 @@ impl TypeNode {
                     return Self::Other(ty.to_token_stream().to_string());
                 };
                 let name = segment.ident.unraw().to_string();
-                let first_type = match &segment.arguments {
-                    PathArguments::AngleBracketed(arguments) => {
-                        arguments.args.iter().find_map(|arg| {
+                let types: Vec<_> = match &segment.arguments {
+                    PathArguments::AngleBracketed(arguments) => arguments
+                        .args
+                        .iter()
+                        .filter_map(|arg| {
                             if let GenericArgument::Type(inner) = arg {
                                 Some(Self::from_syn(inner))
                             } else {
                                 None
                             }
                         })
-                    }
-                    _ => None,
+                        .collect(),
+                    _ => Vec::new(),
                 };
+                if matches!(name.as_str(), "BTreeMap" | "HashMap" | "Map") && types.len() >= 2 {
+                    return Self::Map(Box::new(types[0].clone()), Box::new(types[1].clone()));
+                }
+                let first_type = types.into_iter().next();
                 match (name.as_str(), first_type) {
                     ("Option", Some(inner)) => Self::Option(Box::new(inner)),
                     ("Vec", Some(inner)) => Self::Vec(Box::new(inner)),
@@ -415,15 +422,15 @@ impl TypeNode {
             | Self::Boxed(inner)
             | Self::Reference(inner) => inner.terminal(),
             Self::Path(name) => Some(name),
-            Self::Other(_) => None,
+            Self::Map(_, _) | Self::Other(_) => None,
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn display(&self) -> String {
         match self {
             Self::Option(inner) => format!("Option<{}>", inner.display()),
             Self::Vec(inner) => format!("Vec<{}>", inner.display()),
+            Self::Map(key, value) => format!("Map<{}, {}>", key.display(), value.display()),
             Self::Boxed(inner) => format!("Box<{}>", inner.display()),
             Self::Reference(inner) => format!("&{}", inner.display()),
             Self::Path(name) | Self::Other(name) => name.clone(),
@@ -450,6 +457,7 @@ pub(crate) struct FieldInfo {
     /// Response-tree `Option` fields must all carry it so an absent field is
     /// omitted from serialized output rather than emitted as `null`.
     pub(crate) skip_serializing_if: bool,
+    pub(crate) flatten: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -618,6 +626,7 @@ impl RustInventory {
                                     // the attribute up to the struct.
                                     serde_default: options.default || container.default,
                                     skip_serializing_if: options.skip_serializing_if,
+                                    flatten: options.flatten,
                                 },
                             );
                         }
@@ -781,6 +790,20 @@ impl RustInventory {
         seen
     }
 
+    pub(crate) fn resolve_alias<'a>(&'a self, mut ty: &'a TypeNode) -> &'a TypeNode {
+        let mut seen = BTreeSet::new();
+        while let TypeNode::Path(name) = ty {
+            if !seen.insert(name) {
+                break;
+            }
+            let Some(alias) = self.aliases.get(name) else {
+                break;
+            };
+            ty = alias;
+        }
+        ty
+    }
+
     pub(crate) fn terminal_type(&self, ty: &TypeNode) -> Option<String> {
         self.resolve_terminal(ty, &mut BTreeSet::new())
     }
@@ -819,7 +842,7 @@ impl RustInventory {
                     .get(name)
                     .and_then(|alias| self.resolve_array_item(alias, seen))
             }
-            TypeNode::Other(_) => None,
+            TypeNode::Map(_, _) | TypeNode::Other(_) => None,
         }
     }
 }
@@ -889,6 +912,7 @@ struct SerdeOptions {
     other: bool,
     default: bool,
     skip_serializing_if: bool,
+    flatten: bool,
 }
 
 fn serde_options(attributes: &[Attribute]) -> syn::Result<SerdeOptions> {
@@ -934,6 +958,8 @@ fn serde_options(attributes: &[Attribute]) -> syn::Result<SerdeOptions> {
                 if meta.input.peek(syn::Token![=]) {
                     let _: Expr = meta.value()?.parse()?;
                 }
+            } else if meta.path.is_ident("flatten") {
+                options.flatten = true;
             } else if meta.path.is_ident("skip_serializing_if") {
                 options.skip_serializing_if = true;
                 let _: Expr = meta.value()?.parse()?;

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -101,7 +101,7 @@ def run_analyzer(spec: dict) -> dict:
         report = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         raise RuntimeError("OpenAPI analyzer emitted invalid JSON") from error
-    if report.get("schema_version") != 3:
+    if report.get("schema_version") != 4:
         raise RuntimeError(
             f"Unsupported DriftReport schema version: {report.get('schema_version')!r}"
         )
@@ -513,6 +513,7 @@ def build_issue_body(report: dict, live_spec: dict) -> str:
         f"| Missing enum values | {counts['missing_enum_value']} |",
         f"| Extra enum values | {counts['extra_enum_value']} |",
         f"| Enum VALUES const mismatches | {counts['enum_values_mismatch']} |",
+        f"| Additional properties mismatches | {counts['additional_properties_mismatch']} |",
         f"| Field optionality mismatches | {counts['field_optionality_mismatch']} |",
         f"| Beta status changes | {total('newly_beta_operation', 'graduated_beta_operation')} |",
         f"| Deprecated-field changes | {total('newly_deprecated_field', 'undeprecated_field', 'missing_deprecated_marker', 'stray_deprecated_marker')} |",
@@ -560,6 +561,7 @@ def build_issue_body(report: dict, live_spec: dict) -> str:
         ("extra_enum_value", "Extra Enum Values"),
         ("enum_values_mismatch", "Enum VALUES Const Mismatches"),
         ("field_optionality_mismatch", "Field Optionality Mismatches"),
+        ("additional_properties_mismatch", "Additional Properties Mismatches"),
         ("newly_beta_operation", "Newly Beta Operations"),
         ("graduated_beta_operation", "Graduated Beta Operations"),
         ("newly_deprecated_field", "Newly Deprecated Fields"),

--- a/scripts/tests/test_check_openapi_drift.py
+++ b/scripts/tests/test_check_openapi_drift.py
@@ -20,7 +20,7 @@ def generated_issue_body(body):
 class DriftScriptTests(unittest.TestCase):
     def test_groups_findings_and_renders_spec_snippets(self):
         report = {
-            "schema_version": 3,
+            "schema_version": 4,
             "findings": [
                 {
                     "kind": "missing_client_method",
@@ -71,6 +71,19 @@ class DriftScriptTests(unittest.TestCase):
         self.assertIn('"operationId": "listWidgets"', body)
         self.assertIn("## Acknowledged Unsupported Enum Constraints", body)
         self.assertIn("## Enum VALUES Const Mismatches", body)
+
+    def test_renders_additional_properties_mismatches(self):
+        report = {"schema_version": 4, "findings": [{
+            "kind": "additional_properties_mismatch",
+            "message": "PgBouncerConfig must preserve additionalProperties in a typed string-keyed map",
+            "spec_pointer": "/components/schemas/pgBouncerConfig/additionalProperties",
+            "rust_item": "models.rs::PgBouncerConfig",
+        }]}
+        body = drift.build_issue_body(report, {})
+        self.assertIn("| Additional properties mismatches | 1 |", body)
+        self.assertIn("## Additional Properties Mismatches", body)
+        self.assertIn("PgBouncerConfig must preserve additionalProperties", body)
+        self.assertIn("/components/schemas/pgBouncerConfig/additionalProperties", body)
 
     def test_sync_creates_issue_when_none_is_open(self):
         with (
@@ -381,8 +394,8 @@ class DriftScriptTests(unittest.TestCase):
 
     def test_dry_run_never_queries_or_mutates_github(self):
         reports = [
-            {"schema_version": 3, "findings": []},
-            {"schema_version": 3, "findings": [{"kind": "missing_struct_field"}]},
+            {"schema_version": 4, "findings": []},
+            {"schema_version": 4, "findings": [{"kind": "missing_struct_field"}]},
         ]
         for report in reports:
             with self.subTest(findings=len(report["findings"])):
@@ -399,7 +412,7 @@ class DriftScriptTests(unittest.TestCase):
                 sync_issue.assert_not_called()
 
     def test_main_exits_nonzero_when_synchronization_fails(self):
-        report = {"schema_version": 3, "findings": []}
+        report = {"schema_version": 4, "findings": []}
         with (
             mock.patch.object(sys, "argv", [str(SCRIPT)]),
             mock.patch.object(drift, "fetch_live_spec", return_value={}),
@@ -603,7 +616,7 @@ class DriftScriptTests(unittest.TestCase):
     def test_analyzer_receives_the_rust_source_tree(self, run):
         run.return_value = SimpleNamespace(
             returncode=0,
-            stdout=json.dumps({"schema_version": 3, "findings": []}),
+            stdout=json.dumps({"schema_version": 4, "findings": []}),
             stderr="",
         )
 


### PR DESCRIPTION
PgBouncer configuration previously used empty Rust structs, silently turning every supplied or returned parameter into `{}`. Replace them with typed string maps and preserve response-to-request conversion, while optional response sections continue distinguishing absent/null from an explicit empty map.

The canonical analyzer now checks named schemas with typed `additionalProperties` in both request and response positions, including map aliases and flattened maps. It rejects the old representation and incorrect key/value types. Reports and the Python renderer move together to schema version 4; no exemptions or unsupported acknowledgements were added.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer` (all non-ignored tests passed; live resource-provisioning tests retain their existing ignored status)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (91 passed)
- `python3 scripts/check-openapi-drift.py --dry-run` against the live public spec: 0 actionable findings; unchanged 5 acknowledged enum constraints
- Focused coverage includes create, replica, restore, config GET/POST/PATCH wire bodies and responses, strict string values, missing/null response sections, lossless write-back and analyzer regression fixtures.

No CLI files or new source/test paths change in this prerequisite. The following stack layer covers existing CLI file inputs and their local validation contract.

Refs #697.
