### PR TITLE
fix(cli): preserve query endpoint keys when adding access

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,11 @@ clickhousectl cloud service delete <service-id>
 clickhousectl cloud service delete <service-id> --force
 ```
 
+`query-endpoint create` adds and deduplicates API keys while preserving existing browser origins. `--role` is required and replaces the endpoint-wide roles for **all** authorized keys; roles are not assigned per key.
+Pass `--allowed-origins` on first creation or to change browser access (`'*'` explicitly allows every origin). Use `--replace-open-api-keys` with `--open-api-key` to deliberately replace the entire authorized-key list.
+The command reads the existing configuration before updating; a failed or incomplete read prevents changes to unknown fields. Avoid concurrent changes to the same query endpoint.
+
+
 `--backup-start-time` requires the backup period to be 24 or 48 hours. Nothing is defaulted when the period is omitted: the API validates the new start time against the period already stored on the service, so either pass `--backup-period-hours 24` or `--backup-period-hours 48` in the same call, or leave the stored period at one of those. When a start time is given without a period, the CLI reads the current configuration first and fails before sending the update if the stored period is something else.
 
 `--clear-backup-start-time` removes a stored start time and lifts that restriction, so a service that has one can go back to any backup period. It sends an explicit `"backupStartTime": null`, which the API accepts even though the OpenAPI spec does not mark the field nullable, and it can be combined with `--backup-period-hours` to clear the start time and set an otherwise incompatible period in a single call. The two start-time flags conflict: pass one or the other.

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -1279,7 +1279,9 @@ pub(crate) async fn rejected_stored_query_key_error(
 /// `openApiKeys` cannot be read as "no keys bound": merging into an empty list
 /// would revoke every binding the response failed to report. An explicitly
 /// empty list is a real answer and merges normally.
-fn existing_open_api_keys(endpoint: ServiceQueryAPIEndpoint) -> CloudResult<Vec<String>> {
+pub(crate) fn existing_open_api_keys(
+    endpoint: ServiceQueryAPIEndpoint,
+) -> CloudResult<Vec<String>> {
     endpoint.open_api_keys.ok_or_else(|| {
         CloudError::new(
             "the query endpoint response is missing field 'openApiKeys', so the keys currently \
@@ -1400,7 +1402,7 @@ impl CloudClient {
         }
     }
 
-    async fn get_query_endpoint_for_binding(
+    pub(crate) async fn get_query_endpoint_for_binding(
         &self,
         org_id: &str,
         service_id: &str,

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -7,7 +7,7 @@ use crate::cloud::credentials;
 use crate::cloud::output::{
     ABSENT, CloudErrorCode, CloudErrorDetail, eprint_line, or_absent, print_human, print_line,
 };
-use crate::cloud::service_query::RepairVerification;
+use crate::cloud::service_query::{RepairVerification, existing_open_api_keys};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::{self, ApiFailure, FailureKind, FailureStage, ProvisioningState};
@@ -20,8 +20,9 @@ use clickhouse_cloud_api::models::{
     ServiceEndpointChangeProtocol, ServiceEndpointProtocol, ServicePasswordPatchRequest,
     ServicePatchRequest, ServicePatchRequestReleasechannel, ServicePostRequest,
     ServicePostRequestCompliancetype, ServicePostRequestProfile, ServicePostRequestProvider,
-    ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest,
-    ServiceState, ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
+    ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceQueryAPIEndpoint,
+    ServiceReplicaScalingPatchRequest, ServiceState, ServiceStatePatchRequest,
+    ServiceStatePatchRequestCommand,
 };
 #[cfg(test)]
 use clickhouse_cloud_api::models::{IpAccessListEntryResponse, ResourceTagsV1Response};
@@ -535,21 +536,30 @@ pub enum QueryEndpointCommands {
         org_id: Option<String>,
     },
 
-    /// Create the Query API endpoint
+    /// Create or update the Query API endpoint
+    #[command(after_help = "CONTEXT FOR AGENTS:\n\
+        Existing API keys are preserved unless --replace-open-api-keys is set.\n\
+        Roles replace the endpoint-wide role list for every authorized key.\n\
+        First creation requires --allowed-origins; use '*' explicitly for all.\n\
+        Avoid concurrent changes to the same endpoint.")]
     Create {
         /// Service ID
         service_id: String,
 
-        /// Role to grant access (repeatable)
-        #[arg(long, value_parser = PossibleValuesParser::new(QueryEndpointRole::VALUES))]
+        /// Endpoint-wide role to grant (required, repeatable)
+        #[arg(long, required = true, value_parser = PossibleValuesParser::new(QueryEndpointRole::VALUES))]
         role: Vec<String>,
 
         /// API key ID to authorize (repeatable)
-        #[arg(long = "open-api-key")]
+        #[arg(long = "open-api-key", value_parser = clap::builder::NonEmptyStringValueParser::new())]
         open_api_key: Vec<String>,
 
-        /// Allowed origins for browser access; "*" when omitted
-        #[arg(long)]
+        /// Replace existing API keys (requires --open-api-key)
+        #[arg(long, requires = "open_api_key")]
+        replace_open_api_keys: bool,
+
+        /// Browser origins; preserve when omitted on an existing endpoint
+        #[arg(long, value_parser = clap::builder::NonEmptyStringValueParser::new())]
         allowed_origins: Option<String>,
 
         /// Organization ID (auto-detected only if you have one org)
@@ -792,12 +802,14 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
                 service_id,
                 role,
                 open_api_key,
+                replace_open_api_keys,
                 allowed_origins,
                 org_id,
             } => {
                 let options = QueryEndpointCreateOptions {
                     roles: role,
                     open_api_keys: open_api_key,
+                    replace_open_api_keys,
                     allowed_origins,
                     org_id,
                 };
@@ -1198,6 +1210,7 @@ struct ServiceResetPasswordOptions {
 struct QueryEndpointCreateOptions {
     roles: Vec<String>,
     open_api_keys: Vec<String>,
+    replace_open_api_keys: bool,
     allowed_origins: Option<String>,
     org_id: Option<String>,
 }
@@ -1450,18 +1463,46 @@ fn build_service_password_patch_request(
 
 fn build_query_endpoint_create_request(
     options: &QueryEndpointCreateOptions,
+    existing: Option<&ServiceQueryAPIEndpoint>,
 ) -> CloudResult<InstanceServiceQueryApiEndpointsPostRequest> {
+    if options.roles.is_empty() {
+        return Err(CloudError::new("at least one --role is required"));
+    }
+    let mut open_api_keys = match existing {
+        Some(endpoint) if !options.replace_open_api_keys => {
+            existing_open_api_keys(endpoint.clone())
+                .map_err(|error| error.at_stage(FailureStage::EndpointGet))?
+        }
+        _ => Vec::new(),
+    };
+    open_api_keys.extend(options.open_api_keys.iter().cloned());
+    let mut seen = HashSet::new();
+    open_api_keys.retain(|key| seen.insert(key.clone()));
+
+    let allowed_origins = match (&options.allowed_origins, existing) {
+        (Some(origins), _) => origins.clone(),
+        (None, Some(endpoint)) => endpoint.allowed_origins.clone().ok_or_else(|| {
+            CloudError::new(
+                "the query endpoint response is missing field 'allowedOrigins'; \
+                 pass --allowed-origins to explicitly replace it",
+            )
+            .at_stage(FailureStage::EndpointGet)
+        })?,
+        (None, None) => {
+            return Err(CloudError::new(
+                "--allowed-origins is required when creating a new query endpoint; \
+                 pass browser origins or '*' explicitly to allow all origins",
+            ));
+        }
+    };
     Ok(InstanceServiceQueryApiEndpointsPostRequest {
         roles: options
             .roles
             .iter()
             .map(|role| parse_serde_enum(role, "role", QueryEndpointRole::VALUES))
             .collect::<Result<_, _>>()?,
-        open_api_keys: options.open_api_keys.clone(),
-        allowed_origins: options
-            .allowed_origins
-            .clone()
-            .unwrap_or_else(|| "*".to_string()),
+        open_api_keys,
+        allowed_origins,
     })
 }
 
@@ -1896,26 +1937,20 @@ async fn query_endpoint_create(
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
-    let request = build_query_endpoint_create_request(&options)?;
+    let existing = client
+        .get_query_endpoint_for_binding(&org_id, service_id)
+        .await
+        .map_err(|error| error.at_stage(FailureStage::EndpointGet))?;
+    let request = build_query_endpoint_create_request(&options, existing.as_ref())?;
     let endpoint = client
         .create_query_endpoint(&org_id, service_id, &request)
-        .await?;
+        .await
+        .map_err(|error| error.at_stage(FailureStage::EndpointUpsert))?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&endpoint)?);
     } else {
-        println!("Query endpoint created for service {}", service_id);
-        println!("  ID: {}", or_absent(endpoint.id.as_deref()));
-        println!(
-            "  Roles: {}",
-            or_absent(endpoint.roles.as_ref().map(|roles| {
-                roles
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            }))
-        );
+        print_human(&endpoint)?;
     }
     Ok(())
 }
@@ -3657,6 +3692,8 @@ mod tests {
             "query-endpoint",
             "create",
             "svc-1",
+            "--role",
+            "sql_console_read_only",
         ]);
         let crate::cloud::cli::ServiceCommands::QueryEndpoint { command } = query_endpoint else {
             panic!("expected query-endpoint command");
@@ -3665,13 +3702,15 @@ mod tests {
             role,
             open_api_key,
             allowed_origins,
+            replace_open_api_keys,
             org_id,
             ..
         } = command
         else {
             panic!("expected query-endpoint create");
         };
-        assert!(role.is_empty());
+        assert_eq!(role, ["sql_console_read_only"]);
+        assert!(!replace_open_api_keys);
         assert!(open_api_key.is_empty());
         assert!(allowed_origins.is_none());
         assert!(org_id.is_none());
@@ -4392,6 +4431,7 @@ mod tests {
             "key-1",
             "--open-api-key",
             "key-2",
+            "--replace-open-api-keys",
             "--allowed-origins",
             "https://example.com",
             "--org-id",
@@ -4405,12 +4445,14 @@ mod tests {
             role,
             open_api_key,
             allowed_origins,
+            replace_open_api_keys,
             org_id,
         } = command
         else {
             panic!("expected query-endpoint create");
         };
         assert_eq!(service_id, "svc-1");
+        assert!(replace_open_api_keys);
         assert_eq!(role, vec!["sql_console_read_only", "sql_console_admin"]);
         assert_eq!(open_api_key, vec!["key-1", "key-2"]);
         assert_eq!(allowed_origins.as_deref(), Some("https://example.com"));
@@ -4440,6 +4482,42 @@ mod tests {
                     panic!("expected query-endpoint {action}")
                 }
             }
+        }
+    }
+
+    #[test]
+    fn query_endpoint_create_requires_roles_and_nonempty_explicit_values() {
+        let prefix = [
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query-endpoint",
+            "create",
+            "svc-1",
+        ];
+        let missing_role = Cli::try_parse_from(prefix).err().unwrap();
+        assert_eq!(
+            missing_role.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        for (flags, expected) in [
+            (
+                vec!["--role", "sql_console_read_only", "--replace-open-api-keys"],
+                clap::error::ErrorKind::MissingRequiredArgument,
+            ),
+            (
+                vec!["--role", "sql_console_read_only", "--open-api-key", ""],
+                clap::error::ErrorKind::InvalidValue,
+            ),
+            (
+                vec!["--role", "sql_console_read_only", "--allowed-origins", ""],
+                clap::error::ErrorKind::InvalidValue,
+            ),
+        ] {
+            let error = Cli::try_parse_from(prefix.into_iter().chain(flags))
+                .err()
+                .unwrap();
+            assert_eq!(error.kind(), expected);
         }
     }
 
@@ -4785,17 +4863,18 @@ mod tests {
             false,
         );
         for action in ["create", "delete"] {
-            assert_write(
-                &[
-                    "clickhousectl",
-                    "cloud",
-                    "service",
-                    "query-endpoint",
-                    action,
-                    "svc-1",
-                ],
-                true,
-            );
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "service",
+                "query-endpoint",
+                action,
+                "svc-1",
+            ];
+            if action == "create" {
+                args.extend(["--role", "sql_console_read_only"]);
+            }
+            assert_write(&args, true);
         }
         assert_write(
             &[
@@ -6275,35 +6354,122 @@ mod tests {
 
     #[test]
     fn build_query_endpoint_create_request_supports_minimal_fields() {
-        let request =
-            build_query_endpoint_create_request(&QueryEndpointCreateOptions::default()).unwrap();
+        let request = build_query_endpoint_create_request(
+            &QueryEndpointCreateOptions {
+                roles: vec!["sql_console_read_only".into()],
+                allowed_origins: Some("https://example.com".into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
 
-        assert!(request.roles.is_empty());
+        assert_eq!(request.roles, [QueryEndpointRole::SqlConsoleReadOnly]);
         assert!(request.open_api_keys.is_empty());
-        assert_eq!(request.allowed_origins, "*");
+        assert_eq!(request.allowed_origins, "https://example.com");
     }
 
     #[test]
     fn build_query_endpoint_create_request_supports_maximal_fields() {
-        let request = build_query_endpoint_create_request(&QueryEndpointCreateOptions {
-            roles: vec![
-                "sql_console_read_only".to_string(),
-                "sql_console_admin".to_string(),
-            ],
-            open_api_keys: vec!["key-1".to_string(), "key-2".to_string()],
-            allowed_origins: Some("https://example.com".to_string()),
-            org_id: None,
-        })
+        let request = build_query_endpoint_create_request(
+            &QueryEndpointCreateOptions {
+                roles: vec!["sql_console_read_only".into(), "sql_console_admin".into()],
+                open_api_keys: vec!["key-1".into(), "key-2".into(), "key-1".into()],
+                replace_open_api_keys: true,
+                allowed_origins: Some("*".into()),
+                org_id: Some("org-1".into()),
+            },
+            Some(&ServiceQueryAPIEndpoint {
+                open_api_keys: Some(vec!["old-key".into()]),
+                allowed_origins: Some("https://before.example.com".into()),
+                ..Default::default()
+            }),
+        )
         .unwrap();
 
         assert_eq!(
             request.roles,
-            vec![
+            [
                 QueryEndpointRole::SqlConsoleReadOnly,
-                QueryEndpointRole::SqlConsoleAdmin,
+                QueryEndpointRole::SqlConsoleAdmin
             ]
         );
-        assert_eq!(request.open_api_keys, vec!["key-1", "key-2"]);
+        assert_eq!(request.open_api_keys, ["key-1", "key-2"]);
+        assert_eq!(request.allowed_origins, "*");
+    }
+
+    #[test]
+    fn build_query_endpoint_create_request_merges_keys_and_preserves_origins() {
+        let request = build_query_endpoint_create_request(
+            &QueryEndpointCreateOptions {
+                roles: vec!["sql_console_read_only".into()],
+                open_api_keys: vec!["key-2".into(), "key-3".into(), "key-3".into()],
+                ..Default::default()
+            },
+            Some(&ServiceQueryAPIEndpoint {
+                roles: Some(vec![QueryEndpointRole::SqlConsoleAdmin]),
+                open_api_keys: Some(vec!["key-1".into(), "key-2".into(), "key-1".into()]),
+                allowed_origins: Some("https://before.example.com".into()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(request.roles, [QueryEndpointRole::SqlConsoleReadOnly]);
+        assert_eq!(request.open_api_keys, ["key-1", "key-2", "key-3"]);
+        assert_eq!(request.allowed_origins, "https://before.example.com");
+    }
+
+    #[test]
+    fn build_query_endpoint_create_request_requires_roles_and_first_origins() {
+        assert!(
+            build_query_endpoint_create_request(&QueryEndpointCreateOptions::default(), None)
+                .is_err()
+        );
+        assert!(
+            build_query_endpoint_create_request(
+                &QueryEndpointCreateOptions {
+                    roles: vec!["sql_console_read_only".into()],
+                    ..Default::default()
+                },
+                None
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn build_query_endpoint_create_request_preserves_explicitly_empty_state() {
+        let request = build_query_endpoint_create_request(
+            &QueryEndpointCreateOptions {
+                roles: vec!["sql_console_read_only".into()],
+                ..Default::default()
+            },
+            Some(&ServiceQueryAPIEndpoint {
+                open_api_keys: Some(vec![]),
+                allowed_origins: Some(String::new()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        assert!(request.open_api_keys.is_empty());
+        assert!(request.allowed_origins.is_empty());
+    }
+
+    #[test]
+    fn build_query_endpoint_create_request_rejects_unknown_fields_unless_replaced() {
+        let existing = ServiceQueryAPIEndpoint::default();
+        let mut options = QueryEndpointCreateOptions {
+            roles: vec!["sql_console_read_only".into()],
+            open_api_keys: vec!["key-1".into()],
+            ..Default::default()
+        };
+        assert!(build_query_endpoint_create_request(&options, Some(&existing)).is_err());
+        options.replace_open_api_keys = true;
+        assert!(build_query_endpoint_create_request(&options, Some(&existing)).is_err());
+        options.allowed_origins = Some("https://example.com".into());
+        let request = build_query_endpoint_create_request(&options, Some(&existing)).unwrap();
+        assert_eq!(request.open_api_keys, ["key-1"]);
         assert_eq!(request.allowed_origins, "https://example.com");
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -612,51 +612,251 @@ async fn dispatched_cloud_500_remains_a_generic_error() {
 
 // ── Organization-scoped error context (issue #334) ─────────────────────────
 
-#[tokio::test]
-async fn query_endpoint_create_sends_typed_roles() {
+const MANUAL_QUERY_ENDPOINT_PATH: &str =
+    "/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint";
+
+async fn manual_query_endpoint_mock(get_response: ResponseTemplate) -> MockServer {
     let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(MANUAL_QUERY_ENDPOINT_PATH))
+        .respond_with(get_response)
+        .expect(1)
+        .mount(&mock)
+        .await;
     Mock::given(method("POST"))
-        .and(path(
-            "/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint",
-        ))
+        .and(path(MANUAL_QUERY_ENDPOINT_PATH))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "result": {
-                "id": "endpoint-1",
-                "roles": ["sql_console_read_only", "sql_console_admin"]
-            },
+            "result": { "id": "endpoint-1" },
             "status": 200,
             "requestId": "stub-query-endpoint-create"
         })))
         .mount(&mock)
         .await;
+    mock
+}
 
+fn manual_query_endpoint_args<'a>(extra: &[&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "service",
+        "query-endpoint",
+        "create",
+        "svc-1",
+        "--org-id",
+        "org-1",
+        "--role",
+        "sql_console_read_only",
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+fn manual_query_endpoint_response(result: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "result": result, "status": 200, "requestId": "stub-query-endpoint-get"
+    }))
+}
+
+#[tokio::test]
+async fn query_endpoint_create_sends_typed_roles_and_explicit_first_origins() {
+    for origins in ["https://app.example.com", "*"] {
+        let mock = manual_query_endpoint_mock(ResponseTemplate::new(404)).await;
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &manual_query_endpoint_args(&[
+                "--role",
+                "sql_console_admin",
+                "--open-api-key",
+                "key-1",
+                "--allowed-origins",
+                origins,
+            ]),
+        );
+        assert_success(&output);
+        let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(result, serde_json::json!({"id": "endpoint-1"}));
+        let requests = mock.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, wiremock::http::Method::GET);
+        assert_eq!(requests[1].method, wiremock::http::Method::POST);
+        assert_eq!(
+            requests[1].body_json::<Value>().unwrap(),
+            serde_json::json!({
+                "roles": ["sql_console_read_only", "sql_console_admin"],
+                "openApiKeys": ["key-1"], "allowedOrigins": origins,
+            })
+        );
+        for request in &requests {
+            assert!(
+                request
+                    .headers
+                    .get("authorization")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .starts_with("Basic ")
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn query_endpoint_create_preserves_existing_keys_and_default_origins() {
+    let mock = manual_query_endpoint_mock(manual_query_endpoint_response(serde_json::json!({
+        "id": "endpoint-1", "roles": ["sql_console_admin"],
+        "openApiKeys": ["existing-1", "existing-2", "existing-1"],
+        "allowedOrigins": "https://before.example.com",
+    })))
+    .await;
     let body = invoke_cli_capture_body(
+        &mock,
+        &manual_query_endpoint_args(&[
+            "--open-api-key",
+            "existing-2",
+            "--open-api-key",
+            "new-key",
+            "--open-api-key",
+            "new-key",
+        ]),
+    )
+    .await;
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "roles": ["sql_console_read_only"],
+            "openApiKeys": ["existing-1", "existing-2", "new-key"],
+            "allowedOrigins": "https://before.example.com",
+        })
+    );
+}
+
+#[tokio::test]
+async fn query_endpoint_create_explicit_origins_replace_without_dropping_keys() {
+    for origins in ["https://after.example.com", "*"] {
+        let mock = manual_query_endpoint_mock(manual_query_endpoint_response(serde_json::json!({
+            "openApiKeys": ["existing-1", "existing-2"],
+            "allowedOrigins": "https://before.example.com",
+        })))
+        .await;
+        let body = invoke_cli_capture_body(
+            &mock,
+            &manual_query_endpoint_args(&["--allowed-origins", origins]),
+        )
+        .await;
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "roles": ["sql_console_read_only"],
+                "openApiKeys": ["existing-1", "existing-2"], "allowedOrigins": origins,
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn query_endpoint_create_key_replacement_is_explicit() {
+    let mock = manual_query_endpoint_mock(manual_query_endpoint_response(serde_json::json!({
+        "openApiKeys": ["existing-1", "existing-2"],
+        "allowedOrigins": "https://before.example.com",
+    })))
+    .await;
+    let body = invoke_cli_capture_body(
+        &mock,
+        &manual_query_endpoint_args(&[
+            "--open-api-key",
+            "new-key",
+            "--open-api-key",
+            "new-key",
+            "--replace-open-api-keys",
+        ]),
+    )
+    .await;
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "roles": ["sql_console_read_only"], "openApiKeys": ["new-key"],
+            "allowedOrigins": "https://before.example.com",
+        })
+    );
+}
+
+#[tokio::test]
+async fn query_endpoint_create_refuses_failed_or_incomplete_get_without_writing() {
+    let cases = [
+        (
+            ResponseTemplate::new(403),
+            vec!["--allowed-origins", "*"],
+            4,
+        ),
+        (
+            ResponseTemplate::new(503),
+            vec![
+                "--allowed-origins",
+                "*",
+                "--replace-open-api-keys",
+                "--open-api-key",
+                "new-key",
+            ],
+            1,
+        ),
+        (
+            ResponseTemplate::new(200).set_body_string("invalid JSON"),
+            vec![],
+            1,
+        ),
+        (ResponseTemplate::new(404), vec![], 1),
+        (
+            manual_query_endpoint_response(
+                serde_json::json!({"allowedOrigins": "https://before.example.com"}),
+            ),
+            vec!["--open-api-key", "new-key"],
+            1,
+        ),
+        (
+            manual_query_endpoint_response(serde_json::json!({"openApiKeys": ["existing-1"]})),
+            vec![],
+            1,
+        ),
+        (
+            manual_query_endpoint_response(serde_json::json!(null)),
+            vec!["--allowed-origins", "*"],
+            1,
+        ),
+    ];
+    for (response, flags, exit_code) in cases {
+        let mock = manual_query_endpoint_mock(response).await;
+        let output = invoke_cli_with_cloud_credentials(&mock, &manual_query_endpoint_args(&flags));
+        assert_eq!(
+            output.status.code(),
+            Some(exit_code),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let requests = mock.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method, wiremock::http::Method::GET);
+    }
+}
+
+#[tokio::test]
+async fn query_endpoint_create_omitted_role_fails_before_contacting_api() {
+    let mock = MockServer::start().await;
+    let output = invoke_cli_with_cloud_credentials(
         &mock,
         &[
             "service",
             "query-endpoint",
             "create",
             "svc-1",
-            "--role",
-            "sql_console_read_only",
-            "--role",
-            "sql_console_admin",
-            "--open-api-key",
-            "key-1",
             "--org-id",
             "org-1",
+            "--open-api-key",
+            "new-key",
+            "--allowed-origins",
+            "*",
         ],
-    )
-    .await;
-
-    assert_eq!(
-        body,
-        serde_json::json!({
-            "roles": ["sql_console_read_only", "sql_console_admin"],
-            "openApiKeys": ["key-1"],
-            "allowedOrigins": "*"
-        })
     );
+    assert_eq!(output.status.code(), Some(2));
+    assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
`cloud service query-endpoint create` could silently revoke every existing API key because the endpoint API replaces its configuration. The command now reads the endpoint, adds and deduplicates requested keys, and preserves browser origins unless `--allowed-origins` explicitly changes them. Failed or incomplete reads stop the update before any write.

`--role` is required and explicitly replaces the endpoint-wide role list. First creation requires `--allowed-origins` (including an explicit `'*'` for unrestricted browser origins). `--replace-open-api-keys` deliberately replaces the authorized-key list and requires at least one `--open-api-key`. README and command help document these semantics and the need to avoid concurrent endpoint updates.

Validation: request-builder and clap tests cover required roles, additive/replacement keys, deduplication, explicit and omitted origins, and sparse responses. Subprocess wiremock tests verify read-before-write order, Basic auth, JSON output, first creation, updates, replacement, and no writes on failed/incomplete reads or invalid arguments. Checks:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl -- --test-threads=1`

Closes #596
