### PR TITLE
fix(cli): preserve PgBouncer parameters in file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,20 @@ clickhousectl cloud postgres switchover <primary-id>
 clickhousectl cloud postgres switchover <primary-id> --wait --wait-timeout 600
 ```
 
+PgBouncer files passed to `--pg-bouncer-config-file` on create, read-replica create, and restore are JSON objects with string values, for example:
+
+```json
+{"default_pool_size":"16","pool_mode":"transaction"}
+```
+
+For `postgres config patch --file`, put that map under `pgBouncerConfig` alongside `pgConfig`:
+
+```json
+{"pgConfig":{},"pgBouncerConfig":{"default_pool_size":"16"}}
+```
+
+PgBouncer parameter names are open-ended; values must be quoted strings, including numbers. Invalid value types fail locally before any API request. `config replace` replaces the complete Postgres and PgBouncer configuration: obtain the current document with `config get`, edit it, and retain both sections and every setting you want to keep.
+
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
 
 `postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -71,7 +71,7 @@ CONTEXT FOR AGENTS:
         /// Path to a JSON file with a PgConfig object
         #[arg(long)]
         pg_config_file: Option<PathBuf>,
-        /// Path to a JSON file with a PgBouncerConfig object
+        /// JSON file of PgBouncer parameters with string values
         #[arg(long)]
         pg_bouncer_config_file: Option<PathBuf>,
         /// Organization ID (auto-detected only if you have one org)
@@ -177,7 +177,7 @@ CONTEXT FOR AGENTS:
         /// Path to a JSON file with a PgConfig object
         #[arg(long)]
         pg_config_file: Option<PathBuf>,
-        /// Path to a JSON file with a PgBouncerConfig object
+        /// JSON file of PgBouncer parameters with string values
         #[arg(long)]
         pg_bouncer_config_file: Option<PathBuf>,
         /// Organization ID (auto-detected only if you have one org)
@@ -319,7 +319,7 @@ CONTEXT FOR AGENTS:
         /// Path to a JSON file with a PgConfig object
         #[arg(long)]
         pg_config_file: Option<PathBuf>,
-        /// Path to a JSON file with a PgBouncerConfig object
+        /// JSON file of PgBouncer parameters with string values
         #[arg(long)]
         pg_bouncer_config_file: Option<PathBuf>,
         /// Organization ID (auto-detected only if you have one org)
@@ -1051,8 +1051,6 @@ pub async fn postgres_create(
     opts: PostgresCreateOptions<'_>,
     json: bool,
 ) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, opts.org_id).await?;
-
     let provider: PgProvider = parse_serde_enum(opts.provider, "provider", PgProvider::VALUES)?;
     let size = parse_pg_size(opts.size)?;
     let pg_version: Option<PgVersion> = opts
@@ -1085,6 +1083,7 @@ pub async fn postgres_create(
         pg_bouncer_config,
     };
 
+    let org_id = resolve_org_id(client, opts.org_id).await?;
     let resp = client
         .api()
         .postgres_service_create(&org_id, &req)
@@ -1285,8 +1284,8 @@ pub async fn postgres_config_replace(
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, org_id).await?;
     let cfg = instance_config_from_json(&load_json_file::<serde_json::Value>(file)?)?;
+    let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
         .postgres_instance_config_post(&org_id, postgres_id, &cfg)
@@ -1313,8 +1312,6 @@ pub async fn postgres_config_patch(
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
     debug_assert!(
         !sets.is_empty() || file.is_some(),
         "clap ArgGroup(\"patch_source\") requires --set or --file"
@@ -1332,6 +1329,7 @@ pub async fn postgres_config_patch(
         .map_err(|e| CloudError::new(format!("failed to build config from --set entries: {}", e)))?
     };
 
+    let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
         .postgres_instance_config_patch(&org_id, postgres_id, &cfg)
@@ -1409,7 +1407,6 @@ pub async fn postgres_read_replica_create(
     opts: PostgresReadReplicaOptions<'_>,
     json: bool,
 ) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, opts.org_id).await?;
     let tags = parse_tags(opts.tags)?;
     let pg_config = opts
         .pg_config_file
@@ -1427,6 +1424,7 @@ pub async fn postgres_read_replica_create(
         pg_bouncer_config,
     };
 
+    let org_id = resolve_org_id(client, opts.org_id).await?;
     let resp = client
         .api()
         .postgres_instance_create_read_replica(&org_id, postgres_id, &req)
@@ -1450,7 +1448,6 @@ pub async fn postgres_restore(
     opts: PostgresRestoreOptions<'_>,
     json: bool,
 ) -> CloudResult<()> {
-    let org_id = resolve_org_id(client, opts.org_id).await?;
     let tags = parse_tags(opts.tags)?;
     let pg_config = opts
         .pg_config_file
@@ -1472,6 +1469,7 @@ pub async fn postgres_restore(
         pg_bouncer_config,
     };
 
+    let org_id = resolve_org_id(client, opts.org_id).await?;
     let resp = client
         .api()
         .postgres_instance_restore(&org_id, postgres_id, &req)
@@ -3008,12 +3006,13 @@ mod tests {
     fn instance_config_from_json_accepts_both_sections() {
         let cfg = instance_config_from_json(&serde_json::json!({
             "pgConfig": { "max_connections": 500, "work_mem": "64MB" },
-            "pgBouncerConfig": {},
+            "pgBouncerConfig": { "default_pool_size": "16", "future_parameter": "on" },
         }))
         .unwrap();
         assert_eq!(cfg.pg_config.max_connections, Some(serde_json::json!(500)));
         assert_eq!(cfg.pg_config.work_mem, Some(serde_json::json!("64MB")));
-        assert_eq!(cfg.pg_bouncer_config, PgBouncerConfig::default());
+        assert_eq!(cfg.pg_bouncer_config["default_pool_size"], "16");
+        assert_eq!(cfg.pg_bouncer_config["future_parameter"], "on");
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -12360,3 +12360,202 @@ async fn service_delete_reports_a_well_formed_unknown_id_as_not_found() {
         vec![("DELETE".to_string(), service_path)]
     );
 }
+
+// PgBouncer parameters must survive all advertised file-input paths (#697).
+fn pgbouncer_write_commands<'a>(
+    map_file: &'a str,
+    config_file: &'a str,
+) -> Vec<(Vec<&'a str>, &'static str, &'static str)> {
+    vec![
+        (
+            vec![
+                "postgres",
+                "create",
+                "--name",
+                "pg-test",
+                "--region",
+                "us-east-1",
+                "--size",
+                "c6gd.large",
+                "--pg-bouncer-config-file",
+                map_file,
+            ],
+            "POST",
+            "/v1/organizations/org-1/postgres",
+        ),
+        (
+            vec![
+                "postgres",
+                "read-replica",
+                "create",
+                "pg-1",
+                "--name",
+                "replica-test",
+                "--pg-bouncer-config-file",
+                map_file,
+            ],
+            "POST",
+            "/v1/organizations/org-1/postgres/pg-1/readReplica",
+        ),
+        (
+            vec![
+                "postgres",
+                "restore",
+                "pg-1",
+                "--name",
+                "restored-test",
+                "--restore-target",
+                "2026-08-01T00:00:00Z",
+                "--pg-bouncer-config-file",
+                map_file,
+            ],
+            "POST",
+            "/v1/organizations/org-1/postgres/pg-1/restoredService",
+        ),
+        (
+            vec!["postgres", "config", "patch", "pg-1", "--file", config_file],
+            "PATCH",
+            "/v1/organizations/org-1/postgres/pg-1/config",
+        ),
+        (
+            vec![
+                "postgres",
+                "config",
+                "replace",
+                "pg-1",
+                "--file",
+                config_file,
+            ],
+            "POST",
+            "/v1/organizations/org-1/postgres/pg-1/config",
+        ),
+    ]
+}
+
+fn invoke_pgbouncer_cli(mock: &MockServer, args: &[&str]) -> std::process::Output {
+    let directory = tempfile::tempdir().unwrap();
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    command
+        .env("HOME", directory.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(directory.path())
+        .args(["cloud", "--url", &mock.uri(), "--json"])
+        .args(args)
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn pgbouncer_file_inputs_preserve_string_maps_in_every_write_path() {
+    let directory = tempfile::tempdir().unwrap();
+    let map_file = directory.path().join("pgbouncer.json");
+    let config_file = directory.path().join("config.json");
+    let parameters =
+        serde_json::json!({"default_pool_size": "16", "future_parameter": "on", "empty": ""});
+    let configuration =
+        serde_json::json!({"pgConfig": {"work_mem": "64MB"}, "pgBouncerConfig": parameters});
+    std::fs::write(&map_file, parameters.to_string()).unwrap();
+    std::fs::write(&config_file, configuration.to_string()).unwrap();
+
+    for (mut args, verb, endpoint) in
+        pgbouncer_write_commands(map_file.to_str().unwrap(), config_file.to_str().unwrap())
+    {
+        let mock = MockServer::start().await;
+        Mock::given(method(verb))
+            .and(path(endpoint))
+            .and(wiremock::matchers::basic_auth(
+                "fake-key-for-tests",
+                "fake-secret-for-tests",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": configuration, "status": 200,
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        args.extend(["--org-id", "org-1"]);
+        let output = invoke_pgbouncer_cli(&mock, &args);
+        assert_success(&output);
+        let requests = mock.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body["pgBouncerConfig"], parameters, "{args:?}");
+        if endpoint.ends_with("/config") {
+            assert_eq!(body, configuration);
+            let output: Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(output["pgBouncerConfig"], parameters);
+        }
+    }
+}
+
+#[tokio::test]
+async fn pgbouncer_invalid_file_values_fail_before_any_api_request() {
+    let directory = tempfile::tempdir().unwrap();
+    let map_file = directory.path().join("pgbouncer.json");
+    let config_file = directory.path().join("config.json");
+    for value in [
+        serde_json::json!(16),
+        serde_json::json!(false),
+        serde_json::json!(null),
+    ] {
+        let parameters = serde_json::json!({"default_pool_size": value});
+        std::fs::write(&map_file, parameters.to_string()).unwrap();
+        std::fs::write(
+            &config_file,
+            serde_json::json!({"pgConfig": {}, "pgBouncerConfig": parameters}).to_string(),
+        )
+        .unwrap();
+        for (args, _, _) in
+            pgbouncer_write_commands(map_file.to_str().unwrap(), config_file.to_str().unwrap())
+        {
+            let mock = MockServer::start().await;
+            // No --org-id: validation must precede even organization discovery.
+            let output = invoke_pgbouncer_cli(&mock, &args);
+            assert_eq!(output.status.code(), Some(1), "{args:?}");
+            let error = String::from_utf8_lossy(&output.stderr);
+            assert!(error.contains("string"), "{args:?}: {error}");
+            assert!(
+                error.contains("pgBouncerConfig") || error.contains("pgbouncer.json"),
+                "{error}"
+            );
+            assert!(
+                mock.received_requests().await.unwrap().is_empty(),
+                "{args:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn pgbouncer_config_get_json_preserves_values_and_tolerates_absent_sections() {
+    for result in [
+        serde_json::json!({"pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),
+        serde_json::json!({"pgBouncerConfig": {}}),
+        serde_json::json!({"pgBouncerConfig": null}),
+        serde_json::json!({}),
+    ] {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/organizations/org-1/postgres/pg-1/config"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": result})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_pgbouncer_cli(
+            &mock,
+            &["postgres", "config", "get", "pg-1", "--org-id", "org-1"],
+        );
+        assert_success(&output);
+        let actual: Value = serde_json::from_slice(&output.stdout).unwrap();
+        if result.get("pgBouncerConfig").is_none_or(Value::is_null) {
+            assert!(actual.get("pgBouncerConfig").is_none());
+        } else {
+            assert_eq!(actual["pgBouncerConfig"], result["pgBouncerConfig"]);
+        }
+    }
+}


### PR DESCRIPTION
Existing Postgres file inputs now preserve every PgBouncer string parameter through create, replica creation, restore, config PATCH/POST, and JSON output, using the preceding API map correction. Validate files before organization discovery so malformed map values fail locally without issuing an API request.

Document the PgBouncer JSON string-map format for standalone files and config envelopes, and explain that config replacement requires the complete configuration. Keep PgBouncer keys open-ended; pgConfig key/enum validation remains tracked by #591.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- Real-binary/wiremock assertions cover all five write paths, exact config request/response maps, fifteen invalid-value cases with zero HTTP calls, and GET output with populated, empty, missing, and null sections.

No source/test files were added or renamed. Existing command/auth classifications are retained.

Closes #697.
