### PR TITLE
fix(api): distinguish omitted and cleared API key expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With `clickhousectl` you can:
 
 `clickhousectl` helps humans and coding agents develop with ClickHouse and Postgres.
 
-The workspace also publishes the [typed Rust Cloud API client](crates/clickhouse-cloud-api/README.md). PgBouncer configuration uses an open string map, preserving arbitrary parameters when reading and writing configurations. Its latest OpenAPI snapshot adds credit balances, service profile discovery, ClickPipes workload identity context, and expanded ClickPipes and ClickStack models; [CLI exposure is tracked separately](https://github.com/ClickHouse/clickhousectl/issues/699).
+The workspace also publishes the [typed Rust Cloud API client](crates/clickhouse-cloud-api/README.md). PgBouncer configuration uses an open string map, preserving arbitrary parameters when reading and writing configurations. API key PATCH requests distinguish an omitted expiry (preserve), a timestamp (set), and explicit null (clear). Its latest OpenAPI snapshot adds credit balances, service profile discovery, ClickPipes workload identity context, and expanded ClickPipes and ClickStack models; [CLI exposure is tracked separately](https://github.com/ClickHouse/clickhousectl/issues/699).
 
 ## Installation
 

--- a/crates/clickhouse-cloud-api/README.md
+++ b/crates/clickhouse-cloud-api/README.md
@@ -43,6 +43,8 @@ Additional rules:
 
 In `src/models/<domain>.rs`, request fields follow those rules: required non-nullable fields use `T`, while optional or nullable fields use `Option<T>`. Every response field uses `Option<T>` plus `skip_serializing_if`, so missing keys and explicit `null` deserialize natively to `None` and absent fields are omitted when serialized. `#[serde(default)]` is banned because it can fabricate required request values and is redundant for `Option` response fields.
 
+API key PATCH expiry uses `Option<Option<DateTime<Utc>>>`: `None` leaves the current expiry unchanged, `Some(Some(time))` sets it, and `Some(None)` removes it. These three states survive serialization and deserialization. API key creation still uses `Option<DateTime<Utc>>`, where omission creates a key without an expiry.
+
 ### Deprecated fields
 
 The OpenAPI spec marks some response fields as deprecated (e.g. `Service.tier`, `ApiKey.roles`, `Member.role`). In almost all cases, these are not needed. The Cloud API library disables them by default, gated by a Cargo feature flag `deprecated-fields`. Enable this feature if you need to consume deprecated fields.

--- a/crates/clickhouse-cloud-api/src/models/api_keys.rs
+++ b/crates/clickhouse-cloud-api/src/models/api_keys.rs
@@ -107,12 +107,13 @@ pub struct ApiKeyHashData {
 }
 
 /// `ApiKeyPatchRequest` from the ClickHouse Cloud API.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub struct ApiKeyPatchRequest {
     #[serde(rename = "assignedRoleIds", skip_serializing_if = "Option::is_none")]
     pub assigned_role_ids: Option<Vec<uuid::Uuid>>,
+    /// `None` preserves the expiry, `Some(Some(time))` sets it, and `Some(None)` clears it.
     #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none")]
-    pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expire_at: Option<Option<chrono::DateTime<chrono::Utc>>>,
     #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
     pub ip_access_list: Option<Vec<IpAccessListEntry>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -122,6 +123,38 @@ pub struct ApiKeyPatchRequest {
     pub roles: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<ApiKeyPatchRequestState>,
+}
+
+// Derived nested-Option deserialization loses the distinction between an omitted
+// field and explicit null. Preserve key presence without inventing field defaults.
+impl<'de> Deserialize<'de> for ApiKeyPatchRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut fields = serde_json::Map::<String, serde_json::Value>::deserialize(deserializer)?;
+        fn take<T: serde::de::DeserializeOwned, E: serde::de::Error>(
+            fields: &mut serde_json::Map<String, serde_json::Value>,
+            name: &str,
+        ) -> Result<Option<T>, E> {
+            fields
+                .remove(name)
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(E::custom)
+        }
+
+        Ok(Self {
+            assigned_role_ids: take::<Option<_>, D::Error>(&mut fields, "assignedRoleIds")?
+                .flatten(),
+            expire_at: take::<Option<_>, D::Error>(&mut fields, "expireAt")?,
+            ip_access_list: take::<Option<_>, D::Error>(&mut fields, "ipAccessList")?.flatten(),
+            name: take::<Option<_>, D::Error>(&mut fields, "name")?.flatten(),
+            #[cfg(feature = "deprecated-fields")]
+            roles: take::<Option<_>, D::Error>(&mut fields, "roles")?.flatten(),
+            state: take::<Option<_>, D::Error>(&mut fields, "state")?.flatten(),
+        })
+    }
 }
 
 /// `ApiKeyPostRequest` from the ClickHouse Cloud API.

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -4446,3 +4446,40 @@ async fn new_discovery_operations_preserve_api_errors() {
         );
     }
 }
+
+#[tokio::test]
+async fn update_api_key_sends_omitted_timestamp_and_null_expiry() {
+    let timestamp = chrono::DateTime::parse_from_rfc3339("2030-01-02T03:04:05Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    for (expire_at, wire) in [
+        (None, serde_json::json!({"name": "retained"})),
+        (
+            Some(Some(timestamp)),
+            serde_json::json!({"name": "retained", "expireAt": "2030-01-02T03:04:05Z"}),
+        ),
+        (
+            Some(None),
+            serde_json::json!({"name": "retained", "expireAt": null}),
+        ),
+    ] {
+        let (server, client) = setup().await;
+        Mock::given(method("PATCH"))
+            .and(path("/v1/organizations/org-1/keys/key-1"))
+            .and(body_json(wire))
+            .respond_with(ok_json(serde_json::json!({"name": "retained"})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let request = ApiKeyPatchRequest {
+            name: Some("retained".into()),
+            expire_at,
+            ..Default::default()
+        };
+        let response = client
+            .openapi_key_update("org-1", "key-1", &request)
+            .await
+            .unwrap();
+        assert_eq!(response.result.unwrap().name.as_deref(), Some("retained"));
+    }
+}

--- a/crates/clickhouse-cloud-api/tests/integration_org_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_org_test.rs
@@ -1231,6 +1231,42 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                 )
                 .await?;
 
+            // Expiry PATCH must distinguish a timestamp from explicit null.
+            let api_key_uuid_for_expiry = api_key_uuid.clone();
+            failures
+                .run(&ctx, StepKind::NonBlocking, "openapi_key_update expiry round-trip", || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let api_key_uuid = api_key_uuid_for_expiry.clone();
+                    async move {
+                        let before = client.openapi_key_get(&org_id, &api_key_uuid).await?
+                            .result.ok_or("key missing before expiry update")?;
+                        let expires = chrono::Utc::now() + chrono::Duration::days(7);
+                        // Use whole seconds because the API may normalize timestamp precision.
+                        let expires = chrono::DateTime::from_timestamp(expires.timestamp(), 0)
+                            .ok_or("invalid expiry timestamp")?;
+                        for expire_at in [Some(expires), None] {
+                            let request = ApiKeyPatchRequest {
+                                expire_at: Some(expire_at),
+                                ..Default::default()
+                            };
+                            client.openapi_key_update(&org_id, &api_key_uuid, &request).await?;
+                            let after = client.openapi_key_get(&org_id, &api_key_uuid).await?
+                                .result.ok_or("key missing after expiry update")?;
+                            if after.expire_at != expire_at {
+                                return Err(format!("key expiry {:?}, expected {:?}", after.expire_at, expire_at).into());
+                            }
+                            if after.name != before.name || after.state != before.state
+                                || after.assigned_roles != before.assigned_roles
+                                || after.ip_access_list != before.ip_access_list {
+                                return Err("expiry update changed other key settings".into());
+                            }
+                        }
+                        Ok(())
+                    }
+                })
+                .await?;
+
             // openapi_key_delete — end of phase. On success, drop it from
             // the cleanup registry; if delete fails (or never runs because
             // an earlier blocking step bailed) the registry teardown will

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6311,3 +6311,75 @@ fn pgbouncer_parent_responses_preserve_missing_null_and_empty_sections() {
         serde_json::json!({"pgBouncerConfig": {}})
     );
 }
+
+#[test]
+fn api_key_patch_expiry_preserves_omit_set_and_clear() {
+    let timestamp = chrono::DateTime::parse_from_rfc3339("2030-01-02T03:04:05Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    for (expire_at, wire) in [
+        (None, serde_json::json!({})),
+        (
+            Some(Some(timestamp)),
+            serde_json::json!({"expireAt": "2030-01-02T03:04:05Z"}),
+        ),
+        (Some(None), serde_json::json!({"expireAt": null})),
+    ] {
+        let request = ApiKeyPatchRequest {
+            expire_at,
+            ..Default::default()
+        };
+        assert_eq!(serde_json::to_value(&request).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_value::<ApiKeyPatchRequest>(wire).unwrap(),
+            request
+        );
+    }
+}
+
+#[test]
+fn api_key_patch_deserialization_preserves_other_fields_and_ignores_unknowns() {
+    let wire = serde_json::json!({
+        "expireAt": null,
+        "assignedRoleIds": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+        "ipAccessList": [{"source": "10.0.0.0/8", "description": "private"}],
+        "name": "renamed",
+        "state": "disabled"
+    });
+    let mut extended = wire.clone();
+    extended["newServerField"] = serde_json::json!({"nested": true});
+    let request: ApiKeyPatchRequest = serde_json::from_value(extended).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), wire);
+    let nulls: ApiKeyPatchRequest = serde_json::from_value(serde_json::json!({
+        "assignedRoleIds": null, "ipAccessList": null, "name": null, "state": null
+    }))
+    .unwrap();
+    assert_eq!(nulls, ApiKeyPatchRequest::default());
+}
+
+#[test]
+fn api_key_patch_deserialization_rejects_invalid_recognized_fields() {
+    for wire in [
+        serde_json::json!({"expireAt": "tomorrow"}),
+        serde_json::json!({"expireAt": 42}),
+        serde_json::json!({"assignedRoleIds": ["invalid"]}),
+        serde_json::json!({"ipAccessList": [{}]}),
+        serde_json::json!({"name": false}),
+        serde_json::json!({"state": {}}),
+        serde_json::json!(null),
+        serde_json::json!([]),
+    ] {
+        assert!(
+            serde_json::from_value::<ApiKeyPatchRequest>(wire.clone()).is_err(),
+            "accepted {wire}"
+        );
+    }
+}
+
+#[cfg(feature = "deprecated-fields")]
+#[test]
+fn api_key_patch_deserialization_preserves_deprecated_roles() {
+    let wire = serde_json::json!({"expireAt": null, "roles": ["admin"]});
+    let request: ApiKeyPatchRequest = serde_json::from_value(wire.clone()).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), wire);
+}

--- a/crates/clickhouse-cloud-api/tests/service_query_key_cli_test.rs
+++ b/crates/clickhouse-cloud-api/tests/service_query_key_cli_test.rs
@@ -1306,7 +1306,7 @@ fn key_patch(
 ) -> ApiKeyPatchRequest {
     ApiKeyPatchRequest {
         assigned_role_ids: None,
-        expire_at,
+        expire_at: expire_at.map(Some),
         ip_access_list: None,
         name: None,
         #[cfg(feature = "deprecated-fields")]

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -312,7 +312,8 @@ fn build_api_key_update_request(options: &KeyUpdateOptions) -> CloudResult<ApiKe
             .expires_at
             .as_deref()
             .map(parse_expire_at)
-            .transpose()?,
+            .transpose()?
+            .map(Some),
         state: options
             .state
             .as_deref()
@@ -980,7 +981,7 @@ mod tests {
                 .with_timezone(&chrono::Utc);
         assert_eq!(update.name.as_deref(), Some("renamed"));
         assert_eq!(update.assigned_role_ids, Some(vec![expected_role_id]));
-        assert_eq!(update.expire_at, Some(expected_update_expiration));
+        assert_eq!(update.expire_at, Some(Some(expected_update_expiration)));
         assert_eq!(update.state, Some(ApiKeyPatchRequestState::Disabled));
         let ip_access_list = update.ip_access_list.as_ref().unwrap();
         assert_eq!(ip_access_list.len(), 1);


### PR DESCRIPTION
API key PATCH requests currently cannot remove an expiry: `None` omits `expireAt`. Represent expiry as `Option<Option<DateTime<Utc>>>`, allowing omission, a timestamp, or explicit null. A focused deserializer preserves all three states through write-back while retaining strict recognized-field types and ignoring unknown fields. API key response and create models keep their existing behavior.

Adapt existing timestamp construction sites and document the Rust migration. Add exact request/model round trips and a live organization lifecycle step that sets and clears expiry on the test-owned key while checking other settings remain unchanged. CLI `--clear-expiry` exposure follows in a separate stacked PR.

Refs #698.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer` — 575 passed; live tests remain ignored locally
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 91 passed
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo test -p clickhousectl --bin clickhousectl cloud::api_keys::tests` — 14 passed
- `cargo test -p clickhouse-cloud-api --test models_test --all-features api_key_patch` — 4 passed

The new live expiry lifecycle step is compiled but has not been run locally.
