### PR TITLE
feat(api): expose checked Postgres config enum values

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/models/postgres.rs
@@ -732,6 +732,12 @@ impl std::fmt::Display for PgConfigDefaultTransactionIsolation {
     }
 }
 
+impl PgConfigDefaultTransactionIsolation {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] =
+        &["read committed", "repeatable read", "serializable"];
+}
+
 /// Inline enum for `pgConfig.ssl_min_protocol_version`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum PgConfigSslMinProtocolVersion {
@@ -761,6 +767,11 @@ impl std::fmt::Display for PgConfigSslMinProtocolVersion {
     }
 }
 
+impl PgConfigSslMinProtocolVersion {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"];
+}
+
 /// Inline enum for `pgConfig.wal_compression`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum PgConfigWalCompression {
@@ -788,6 +799,11 @@ impl std::fmt::Display for PgConfigWalCompression {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl PgConfigWalCompression {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["off", "on", "lz4", "zstd"];
 }
 
 /// Type alias for `pgCreatedAtProperty`.

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -682,6 +682,37 @@ fn postgres_gcp_provider_roundtrips() {
 }
 
 #[test]
+fn postgres_config_enum_values_roundtrip_and_match_values() {
+    for value in PgConfigDefaultTransactionIsolation::VALUES {
+        let parsed: PgConfigDefaultTransactionIsolation =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, PgConfigDefaultTransactionIsolation::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+    }
+    for value in PgConfigSslMinProtocolVersion::VALUES {
+        let parsed: PgConfigSslMinProtocolVersion =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, PgConfigSslMinProtocolVersion::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+    }
+    for value in PgConfigWalCompression::VALUES {
+        let parsed: PgConfigWalCompression =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, PgConfigWalCompression::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+    }
+}
+
+#[test]
 fn postgres_gcp_sizes_roundtrip_as_known_variants() {
     let sizes = [
         "c4a-highmem-4",


### PR DESCRIPTION
Expose `VALUES` on the three closed Postgres configuration enums so CLI validation can use the API library's accepted values. The existing analyzer checks these constants against each enum and the OpenAPI schema, preventing a copied CLI allowlist from falling behind.

This prerequisite adds round-trip coverage for all values. The following CLI layer validates config keys, enum values and file sections before networking.

Validation: formatting, library/analyzer Clippy with warnings denied, full library/analyzer tests including vendored drift coverage, and all 91 Python tests passed. Integrated CLI Clippy also passed.

Refs #591.
