### PR TITLE
fix(api): cover inline UDF request fields in OpenAPI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,8 @@ To see exactly what would be sent without sending it, set `CHCTL_TELEMETRY_DEBUG
 
 Distribution packagers can compile telemetry out entirely (including the `telemetry` subcommand) with `cargo build --no-default-features`.
 
+UDF API request models preserve `deterministic` and nullable `memoryLimitMib` in both executable variants, including version creation. The OpenAPI analyzer checks inline union payload fields and their request requiredness; its report format is version 5.
+
 ## Cloud integration testing
 
 Maintainer operation, exact-SHA overrides, stacked-PR policy, and the required

--- a/crates/clickhouse-cloud-api/src/models/udfs.rs
+++ b/crates/clickhouse-cloud-api/src/models/udfs.rs
@@ -304,6 +304,10 @@ impl std::fmt::Display for UdfCreateRequest {
 /// The `executable` variant of [`UdfCreateRequest`].
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UdfCreateRequestV1 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
+    #[serde(rename = "memoryLimitMib", skip_serializing_if = "Option::is_none")]
+    pub memory_limit_mib: Option<i64>,
     pub arguments: Vec<UdfArgument>,
     #[serde(rename = "commandReadTimeout", skip_serializing_if = "Option::is_none")]
     pub command_read_timeout: Option<i64>,
@@ -363,6 +367,10 @@ impl std::fmt::Display for UdfCreateRequestV1Type {
 /// The `executable_pool` variant of [`UdfCreateRequest`].
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UdfCreateRequestV2 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
+    #[serde(rename = "memoryLimitMib", skip_serializing_if = "Option::is_none")]
+    pub memory_limit_mib: Option<i64>,
     pub arguments: Vec<UdfArgument>,
     #[serde(rename = "commandReadTimeout", skip_serializing_if = "Option::is_none")]
     pub command_read_timeout: Option<i64>,
@@ -478,6 +486,10 @@ impl std::fmt::Display for UdfVersionCreateRequest {
 /// The `executable` variant of [`UdfVersionCreateRequest`].
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UdfVersionCreateRequestV1 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
+    #[serde(rename = "memoryLimitMib", skip_serializing_if = "Option::is_none")]
+    pub memory_limit_mib: Option<i64>,
     pub arguments: Vec<UdfArgument>,
     #[serde(rename = "commandReadTimeout", skip_serializing_if = "Option::is_none")]
     pub command_read_timeout: Option<i64>,
@@ -535,6 +547,10 @@ impl std::fmt::Display for UdfVersionCreateRequestV1Type {
 /// The `executable_pool` variant of [`UdfVersionCreateRequest`].
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UdfVersionCreateRequestV2 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deterministic: Option<bool>,
+    #[serde(rename = "memoryLimitMib", skip_serializing_if = "Option::is_none")]
+    pub memory_limit_mib: Option<i64>,
     pub arguments: Vec<UdfArgument>,
     #[serde(rename = "commandReadTimeout", skip_serializing_if = "Option::is_none")]
     pub command_read_timeout: Option<i64>,

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -2635,13 +2635,15 @@ async fn create_udf_encodes_request_body() {
             "returnType": "String",
             "runtime": "python3.11",
             "type": "executable",
-            "uploadId": "upload-1"
+            "uploadId": "upload-1", "deterministic": false, "memoryLimitMib": 256
         })))
         .respond_with(created_json(serde_json::json!({"functionName": "my_udf"})))
         .mount(&s)
         .await;
 
     let body = UdfCreateRequest::UdfCreateRequestV1(UdfCreateRequestV1 {
+        deterministic: Some(false),
+        memory_limit_mib: Some(256),
         arguments: vec![],
         function_name: "my_udf".to_string(),
         return_type: "String".to_string(),
@@ -2672,13 +2674,15 @@ async fn create_udf_version_encodes_request_body() {
             "returnType": "String",
             "runtime": "python3.11",
             "type": "executable",
-            "uploadId": "upload-1"
+            "uploadId": "upload-1", "deterministic": false, "memoryLimitMib": 256
         })))
         .respond_with(created_json(serde_json::json!({"functionName": "my_udf"})))
         .mount(&s)
         .await;
 
     let body = UdfVersionCreateRequest::UdfVersionCreateRequestV1(UdfVersionCreateRequestV1 {
+        deterministic: Some(false),
+        memory_limit_mib: Some(256),
         arguments: vec![],
         return_type: "String".to_string(),
         runtime: UdfRuntime::Python3_11,

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6414,3 +6414,30 @@ fn api_key_patch_deserialization_preserves_deprecated_roles() {
     let request: ApiKeyPatchRequest = serde_json::from_value(wire.clone()).unwrap();
     assert_eq!(serde_json::to_value(request).unwrap(), wire);
 }
+
+#[test]
+fn udf_request_inline_variants_preserve_determinism_and_memory() {
+    fn check<T: serde::de::DeserializeOwned + serde::Serialize>(kind: &str, create: bool) {
+        let mut input = serde_json::json!({"uploadId": "upload-1", "runtime": "native",
+            "arguments": [], "returnType": "UInt64", "type": kind});
+        if create {
+            input["functionName"] = serde_json::json!("my_udf");
+        }
+        let minimal: T = serde_json::from_value(input.clone()).unwrap();
+        assert_eq!(serde_json::to_value(minimal).unwrap(), input);
+        input["deterministic"] = serde_json::json!(false);
+        input["memoryLimitMib"] = serde_json::json!(128);
+        let full: T = serde_json::from_value(input.clone()).unwrap();
+        assert_eq!(serde_json::to_value(full).unwrap(), input);
+        input["memoryLimitMib"] = serde_json::Value::Null;
+        let nullable: T = serde_json::from_value(input.clone()).unwrap();
+        input.as_object_mut().unwrap().remove("memoryLimitMib");
+        assert_eq!(serde_json::to_value(nullable).unwrap(), input);
+        input.as_object_mut().unwrap().remove("runtime");
+        assert!(serde_json::from_value::<T>(input).is_err());
+    }
+    check::<UdfCreateRequestV1>("executable", true);
+    check::<UdfCreateRequestV2>("executable_pool", true);
+    check::<UdfVersionCreateRequestV1>("executable", false);
+    check::<UdfVersionCreateRequestV2>("executable_pool", false);
+}

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -16,7 +16,7 @@ pub(crate) fn compare(
     let mut report = DriftReport::default();
     compare_operations(rust, spec, config, &mut report);
     compare_models_and_refs(rust, spec, &mut report);
-    compare_fields(rust, spec, config, &mut report);
+    compare_inline_union_fields(rust, spec, config, &mut report);
     compare_additional_properties(rust, spec, &mut report);
     compare_beta_and_deprecation(rust, spec, config, &mut report);
     compare_enums(rust, spec, config, &mut report);
@@ -265,6 +265,96 @@ fn compare_fields(
         &extra_hits,
         report,
     );
+}
+
+/// Resolve inline object branches using their constant discriminator and the
+/// value enums on the union's actual payload structs, never source ordering or
+/// guessed variant names. Reuse the ordinary field checks in each direction.
+fn compare_inline_union_fields(
+    rust: &RustInventory,
+    spec: &OpenApiInventory,
+    config: &AnalyzerConfig,
+    report: &mut DriftReport,
+) {
+    let mut inline = spec.clone();
+    for (parent, pointer, branch) in &spec.inline_union_objects {
+        let properties = branch["properties"].as_object().unwrap();
+        let discriminators: Vec<_> = properties
+            .iter()
+            .filter_map(|(key, value)| {
+                value
+                    .get("const")
+                    .and_then(serde_json::Value::as_str)
+                    .map(|value| (key, value))
+            })
+            .collect();
+        for (union_name, direction) in field_check_targets(rust, spec, parent) {
+            let candidates: Vec<_> = rust
+                .enums
+                .get(&union_name)
+                .into_iter()
+                .flat_map(|info| &info.variant_type_names)
+                .filter(|name| {
+                    rust.structs.get(*name).is_some_and(|info| {
+                        !discriminators.is_empty()
+                            && discriminators.iter().all(|(key, value)| {
+                                info.fields
+                                    .get(*key)
+                                    .and_then(|field| rust.terminal_type(&field.rust_type))
+                                    .and_then(|name| rust.enums.get(&name))
+                                    .is_some_and(|info| {
+                                        info.is_value_enum
+                                            && info.values.len() == 1
+                                            && info.values.contains(*value)
+                                    })
+                            })
+                    })
+                })
+                .collect();
+            let [name] = candidates.as_slice() else {
+                report.findings.push(
+                    Finding::new(
+                        FindingKind::MissingModelType,
+                        format!(
+                            "{union_name} has no unique typed payload for inline object branch"
+                        ),
+                    )
+                    .at_spec(pointer)
+                    .at_rust(format!("models.rs::{union_name}")),
+                );
+                continue;
+            };
+            let name = (*name).clone();
+            inline.schemas.insert(name.clone(), pointer.clone());
+            inline.rust_schema_names.insert(name.clone());
+            match direction {
+                Direction::Request => {
+                    inline.request_position_schemas.insert(name.clone());
+                }
+                Direction::Response => {
+                    inline.response_position_schemas.insert(name.clone());
+                }
+            }
+            let required = crate::openapi::required_fields(parent, branch, config);
+            for (key, value) in properties {
+                inline.properties.insert(
+                    (name.clone(), key.clone()),
+                    crate::openapi::PropertyInfo {
+                        pointer: format!(
+                            "{pointer}/properties/{}",
+                            key.replace('~', "~0").replace('/', "~1")
+                        ),
+                        required_non_nullable: required.contains(key),
+                        schema_type: value
+                            .get("type")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_owned),
+                    },
+                );
+            }
+        }
+    }
+    compare_fields(rust, &inline, config, report);
 }
 
 /// Dynamic keys are invisible to ordinary named-property comparison. Require a
@@ -1027,6 +1117,91 @@ mod tests {
         compare(&rust, &openapi, &openapi, &config)
     }
 
+    #[test]
+    fn inline_union_fields_follow_discriminators_and_keep_exact_pointers() {
+        let models = r#"
+            pub enum Widget { Second(B), First(A), Unknown(serde_json::Value) }
+            pub struct A { pub kind: KindA, pub required: Option<String>, pub extra: bool }
+            pub struct B { pub kind: KindB, pub required: String, pub memory: Option<i64> }
+            pub enum KindA { #[serde(rename = "a")] A }
+            pub enum KindB { #[serde(rename = "b")] B }
+        "#;
+        let schema = serde_json::json!({"oneOf": [
+            {"properties": {"kind": {"const": "a"}, "required": {"type": "string"},
+                "memory": {"type": "integer", "nullable": true}}, "required": ["kind", "required"]},
+            {"properties": {"kind": {"const": "b"}, "required": {"type": "string"},
+                "memory": {"type": "integer", "nullable": true}}, "required": ["kind", "required"]}
+        ]});
+        let report = analyze_fixture(models, schema, AnalyzerConfig::default());
+        assert_eq!(report.findings.len(), 3);
+        let missing = report
+            .findings
+            .iter()
+            .find(|f| f.kind == FindingKind::MissingStructField)
+            .unwrap();
+        assert_eq!(
+            missing.spec_pointer.as_deref(),
+            Some("/components/schemas/Widget/oneOf/0/properties/memory")
+        );
+        assert_eq!(missing.rust_item.as_deref(), Some("models.rs::A::memory"));
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.kind == FindingKind::ExtraStructField)
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.kind == FindingKind::FieldOptionalityMismatch)
+        );
+        assert_eq!(
+            serde_json::from_str::<DriftReport>(&serde_json::to_string(&report).unwrap()).unwrap(),
+            report
+        );
+        assert!(report.render_text().contains("A.memory"));
+    }
+
+    #[test]
+    fn inline_union_response_fields_remain_optional_and_presence_checked() {
+        let schema = serde_json::json!({"oneOf": [{"properties": {
+            "kind": {"const": "a"}, "required": {"type": "string"},
+            "memory": {"type": "integer"}}, "required": ["kind", "required", "memory"]}]});
+        let report = analyze_directional(
+            r#"
+            pub enum Widget { A(A) }
+            pub enum WidgetResponse { A(AResponse) }
+            pub struct A { pub kind: Kind, pub required: String, pub memory: i64 }
+            pub struct AResponse { pub kind: Option<Kind>, pub required: Option<String> }
+            pub enum Kind { #[serde(rename = "a")] A }
+        "#,
+            directional_spec(schema, true, true),
+            AnalyzerConfig::default(),
+        );
+        assert_eq!(report.findings.len(), 1, "{}", report.render_text());
+        assert_eq!(report.findings[0].kind, FindingKind::MissingStructField);
+        assert_eq!(
+            report.findings[0].rust_item.as_deref(),
+            Some("models.rs::AResponse::memory")
+        );
+    }
+
+    #[test]
+    fn inline_union_unmapped_branch_is_actionable() {
+        let report = analyze_fixture(
+            "pub enum Widget { Unknown(serde_json::Value) }",
+            serde_json::json!({"anyOf": [{"properties": {"kind": {"const": "future"}}}]}),
+            AnalyzerConfig::default(),
+        );
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, FindingKind::MissingModelType);
+        assert_eq!(
+            report.findings[0].spec_pointer.as_deref(),
+            Some("/components/schemas/Widget/anyOf/0")
+        );
+    }
+
     /// A minimal spec with one operation that sends `Widget` as the request
     /// body when `request` is set, and returns `Widget` when `response` is set,
     /// so fixtures can place the schema in either or both positions.
@@ -1108,7 +1283,7 @@ mod tests {
             Some("models.rs::WidgetResponse")
         );
         let json = serde_json::to_value(&report).unwrap();
-        assert_eq!(json["schema_version"], 4);
+        assert_eq!(json["schema_version"], 5);
         assert_eq!(
             json["findings"][0]["kind"],
             "additional_properties_mismatch"

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -77,6 +77,8 @@ pub(crate) struct EnumConstraint {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct OpenApiInventory {
     pub(crate) operations: BTreeMap<String, OperationInfo>,
+    /// Inline object branches retain their parent direction and exact spec pointer.
+    pub(crate) inline_union_objects: Vec<(String, String, Value)>,
     pub(crate) schemas: BTreeMap<String, String>,
     /// Pascalized Rust type names of every named spec schema. Used to
     /// distinguish a split `{Name}Response` Rust variant from a Rust type that
@@ -189,6 +191,23 @@ impl OpenApiInventory {
             ]);
             self.schemas
                 .insert(schema_name.clone(), schema_pointer.clone());
+            for composition in ["oneOf", "anyOf"] {
+                if let Some(branches) = schema.get(composition).and_then(Value::as_array) {
+                    for (index, branch) in branches.iter().enumerate() {
+                        if branch
+                            .get("properties")
+                            .and_then(Value::as_object)
+                            .is_some()
+                        {
+                            self.inline_union_objects.push((
+                                schema_name.clone(),
+                                format!("{schema_pointer}/{composition}/{index}"),
+                                branch.clone(),
+                            ));
+                        }
+                    }
+                }
+            }
             if let Some(additional) = schema
                 .get("additionalProperties")
                 .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
@@ -358,7 +377,11 @@ fn transitive_schema_closure(
     seen
 }
 
-fn required_fields(schema_name: &str, schema: &Value, config: &AnalyzerConfig) -> BTreeSet<String> {
+pub(crate) fn required_fields(
+    schema_name: &str,
+    schema: &Value,
+    config: &AnalyzerConfig,
+) -> BTreeSet<String> {
     let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
         return BTreeSet::new();
     };

--- a/crates/clickhouse-openapi-analyzer/src/report.rs
+++ b/crates/clickhouse-openapi-analyzer/src/report.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-pub const REPORT_SCHEMA_VERSION: u32 = 4;
+pub const REPORT_SCHEMA_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -101,7 +101,7 @@ def run_analyzer(spec: dict) -> dict:
         report = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         raise RuntimeError("OpenAPI analyzer emitted invalid JSON") from error
-    if report.get("schema_version") != 4:
+    if report.get("schema_version") != 5:
         raise RuntimeError(
             f"Unsupported DriftReport schema version: {report.get('schema_version')!r}"
         )

--- a/scripts/tests/test_check_openapi_drift.py
+++ b/scripts/tests/test_check_openapi_drift.py
@@ -20,7 +20,7 @@ def generated_issue_body(body):
 class DriftScriptTests(unittest.TestCase):
     def test_groups_findings_and_renders_spec_snippets(self):
         report = {
-            "schema_version": 4,
+            "schema_version": 5,
             "findings": [
                 {
                     "kind": "missing_client_method",
@@ -73,7 +73,7 @@ class DriftScriptTests(unittest.TestCase):
         self.assertIn("## Enum VALUES Const Mismatches", body)
 
     def test_renders_additional_properties_mismatches(self):
-        report = {"schema_version": 4, "findings": [{
+        report = {"schema_version": 5, "findings": [{
             "kind": "additional_properties_mismatch",
             "message": "PgBouncerConfig must preserve additionalProperties in a typed string-keyed map",
             "spec_pointer": "/components/schemas/pgBouncerConfig/additionalProperties",
@@ -394,8 +394,8 @@ class DriftScriptTests(unittest.TestCase):
 
     def test_dry_run_never_queries_or_mutates_github(self):
         reports = [
-            {"schema_version": 4, "findings": []},
-            {"schema_version": 4, "findings": [{"kind": "missing_struct_field"}]},
+            {"schema_version": 5, "findings": []},
+            {"schema_version": 5, "findings": [{"kind": "missing_struct_field"}]},
         ]
         for report in reports:
             with self.subTest(findings=len(report["findings"])):
@@ -412,7 +412,7 @@ class DriftScriptTests(unittest.TestCase):
                 sync_issue.assert_not_called()
 
     def test_main_exits_nonzero_when_synchronization_fails(self):
-        report = {"schema_version": 4, "findings": []}
+        report = {"schema_version": 5, "findings": []}
         with (
             mock.patch.object(sys, "argv", [str(SCRIPT)]),
             mock.patch.object(drift, "fetch_live_spec", return_value={}),
@@ -616,7 +616,7 @@ class DriftScriptTests(unittest.TestCase):
     def test_analyzer_receives_the_rust_source_tree(self, run):
         run.return_value = SimpleNamespace(
             returncode=0,
-            stdout=json.dumps({"schema_version": 4, "findings": []}),
+            stdout=json.dumps({"schema_version": 5, "findings": []}),
             stderr="",
         )
 


### PR DESCRIPTION
UDF create and version-create requests silently dropped `deterministic` and `memoryLimitMib` in both executable variants. Add all eight fields with strict request semantics and preserve explicit false, numeric limits and nullable omission.

The drift analyzer now follows inline oneOf/anyOf object branches to actual Rust union payloads through constant discriminators. It checks missing/extra fields and request requiredness in each direction, reports an unmappable branch as actionable, and retains exact JSON pointers. Report schema advances to 5 with synchronized Python consumers; live analysis has zero actionable drift.

Validation: library/analyzer all-target clippy; complete tests for both crates; 91 Python tests; cargo fmt; live OpenAPI dry run. Focused regressions cover all four request variants, HTTP bodies, reordered union payloads, sparse response direction, unmapped branches and report round trips.

Refs #571. CLI exposure follows separately.
