### PR TITLE
feat(cli): add explicit service wake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,9 @@ clickhousectl cloud service create --name my-service \
   --profile v1-highmem-xs --compliance-type hipaa \
   --encryption-key <kms-key-arn> --encryption-role <kms-role-arn> --enable-tde
 
-# Start/stop a service
+# Start, wake, or stop a service
 clickhousectl cloud service start <service-id>
+clickhousectl cloud service wake <service-id>   # Explicitly wake an idled service
 clickhousectl cloud service stop <service-id>
 
 # Run SQL over HTTP via the Query API (no local clickhouse binary needed)

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -244,6 +244,20 @@ CONTEXT FOR AGENTS:
         org_id: Option<String>,
     },
 
+    /// Wake an idled service
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Wakes an idle service; use `cloud service start <id>` for a stopped service.
+  Returns as soon as the wake is accepted: poll `cloud service get <id>` until state is `running`.")]
+    Wake {
+        /// Service ID
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
     /// Stop a service
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -621,6 +635,7 @@ impl ServiceCommands {
             ServiceCommands::Create { .. } => true,
             ServiceCommands::Delete { .. } => true,
             ServiceCommands::Start { .. } => true,
+            ServiceCommands::Wake { .. } => true,
             ServiceCommands::Stop { .. } => true,
             ServiceCommands::Update { .. } => true,
             ServiceCommands::Scale { .. } => true,
@@ -714,6 +729,9 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
         } => service_delete(client, &service_id, force, org_id.as_deref(), json).await,
         ServiceCommands::Start { service_id, org_id } => {
             service_start(client, &service_id, org_id.as_deref(), json).await
+        }
+        ServiceCommands::Wake { service_id, org_id } => {
+            service_wake(client, &service_id, org_id.as_deref(), json).await
         }
         ServiceCommands::Stop { service_id, org_id } => {
             service_stop(client, &service_id, org_id.as_deref(), json).await
@@ -1738,6 +1756,29 @@ async fn service_stop(
     } else {
         println!(
             "Service {} stopping (state: {})",
+            or_absent(service.name.as_deref()),
+            or_absent(service.state.as_ref())
+        );
+    }
+    Ok(())
+}
+
+async fn service_wake(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let service = client
+        .change_service_state(&org_id, service_id, ServiceStatePatchRequestCommand::Awake)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&service)?);
+    } else {
+        println!(
+            "Service {} waking (state: {})",
             or_absent(service.name.as_deref()),
             or_absent(service.state.as_ref())
         );
@@ -4744,7 +4785,7 @@ mod tests {
         assert_eq!(service_id, "svc-1");
         assert_eq!(org_id.as_deref(), Some("org-1"));
 
-        for action in ["start", "stop"] {
+        for action in ["start", "wake", "stop"] {
             let command = parse_service(&[
                 "clickhousectl",
                 "cloud",
@@ -4756,6 +4797,7 @@ mod tests {
             ]);
             match command {
                 crate::cloud::cli::ServiceCommands::Start { service_id, org_id }
+                | crate::cloud::cli::ServiceCommands::Wake { service_id, org_id }
                 | crate::cloud::cli::ServiceCommands::Stop { service_id, org_id } => {
                     assert_eq!(service_id, "svc-1");
                     assert_eq!(org_id.as_deref(), Some("org-1"));
@@ -4841,6 +4883,7 @@ mod tests {
         for action in [
             "delete",
             "start",
+            "wake",
             "stop",
             "update",
             "scale",
@@ -6491,12 +6534,14 @@ mod tests {
     }
 
     #[test]
-    fn build_service_state_patch_request_preserves_start_and_stop() {
+    fn build_service_state_patch_request_preserves_every_command() {
         let start = build_service_state_patch_request(ServiceStatePatchRequestCommand::Start);
         let stop = build_service_state_patch_request(ServiceStatePatchRequestCommand::Stop);
+        let awake = build_service_state_patch_request(ServiceStatePatchRequestCommand::Awake);
 
         assert_eq!(start.command, Some(ServiceStatePatchRequestCommand::Start));
         assert_eq!(stop.command, Some(ServiceStatePatchRequestCommand::Stop));
+        assert_eq!(awake.command, Some(ServiceStatePatchRequestCommand::Awake));
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -906,6 +906,160 @@ async fn service_get_preserves_a_detailed_not_found_error() {
     );
 }
 
+fn invoke_service_wake(mock: &MockServer, json: bool, agent: bool) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = mock.uri();
+    let mut args = vec![
+        "cloud", "--url", &url, "service", "wake", "svc-1", "--org-id", "org-1",
+    ];
+    if json {
+        args.push("--json");
+    }
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    if agent {
+        command.env("AGENT", "opencode");
+    }
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "wake-test-key")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "wake-test-secret")
+        .current_dir(dir.path())
+        .args(args)
+        .output()
+        .expect("failed to run service wake")
+}
+
+#[tokio::test]
+async fn service_wake_sends_awake_with_basic_auth_and_prints_json() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/services/svc-1/state"))
+        .and(wiremock::matchers::basic_auth(
+            "wake-test-key",
+            "wake-test-secret",
+        ))
+        .and(body_json(serde_json::json!({"command": "awake"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "11111111-2222-3333-4444-555555555555", "name": "demo", "state": "awaking"},
+            "status": 200,
+            "requestId": "stub-service-wake",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_service_wake(&mock, true, false);
+    assert_success(&output);
+    assert!(output.stderr.is_empty());
+    let service: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(service["name"], "demo");
+    assert_eq!(service["state"], "awaking");
+    assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn service_wake_handles_a_sparse_response_in_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/services/svc-1/state"))
+        .and(body_json(serde_json::json!({"command": "awake"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {}, "status": 200, "requestId": "stub-service-wake",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_service_wake(&mock, false, false);
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Service - waking (state: -)\n"
+    );
+}
+
+#[tokio::test]
+async fn service_wake_uses_json_output_for_a_detected_agent() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/services/svc-1/state"))
+        .and(body_json(serde_json::json!({"command": "awake"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"name": "demo", "state": "awaking"},
+            "status": 200,
+            "requestId": "stub-service-wake",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_service_wake(&mock, false, true);
+    assert_success(&output);
+    let service: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(service["name"], "demo");
+    assert_eq!(service["state"], "awaking");
+}
+
+#[tokio::test]
+async fn service_wake_preserves_api_errors() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/services/svc-1/state"))
+        .and(body_json(serde_json::json!({"command": "awake"})))
+        .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+            "status": 503, "error": "wake temporarily unavailable",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_service_wake(&mock, true, false);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: wake temporarily unavailable\n"
+    );
+}
+
+#[tokio::test]
+async fn service_wake_rejects_oauth_before_http() {
+    let mock = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", &home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "service",
+            "wake",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run OAuth service wake");
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
 // ── Credential precedence visibility (issue #336) ─────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
Adds `cloud service wake <SERVICE_ID>` so an idled ClickHouse Cloud service can be explicitly woken through the management API. The command sends `{"command":"awake"}` through the existing service state wrapper, is classified as a write for OAuth fail-fast behavior, and follows the existing lifecycle conventions for human, JSON, and coding-agent output.

The README now documents wake alongside start and stop. Coverage verifies clap parsing, exhaustive write classification, request building, the exact authenticated wire payload, sparse human output, explicit and agent-selected JSON, API errors, and OAuth rejection before HTTP.

Validation:

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/chctl-target-575 cargo clippy -p clickhousectl -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/chctl-target-575 cargo check -p clickhousectl --no-default-features`
- `CARGO_TARGET_DIR=/tmp/chctl-target-575 cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/chctl-target-575 cargo test -p clickhousectl -- --test-threads=1` (unit: 1034 passed, 1 ignored; Cloud request-shape: 263 passed, 1 ignored; all local and telemetry integration tests passed)

Closes #575
