### PR TITLE
feat(cli): add ClickStack source and role management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "reqwest",
  "rpassword",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sha2 0.11.0",
  "tabled",
@@ -3193,6 +3194,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ psql "$POSTGRES_CONNECTION_STRING" --command "SELECT version()"
 
 `postgres create` returns an initial password, which the CLI prints once; store it securely.
 
+Manage ClickStack data sources and roles for an existing service with JSON configuration files:
+
+```bash
+clickhousectl cloud clickstack source list <service-id> --org-id <org-id>
+clickhousectl cloud clickstack source create <service-id> \
+  --config-file source.json --org-id <org-id>
+clickhousectl cloud clickstack role create <service-id> \
+  --config-file role.json --org-id <org-id>
+```
+
+Pass `--config-file -` to read the JSON body from stdin. Source IDs and role IDs come from their
+respective `list` commands. `source update` and `role update` use PUT replacement semantics, so the
+configuration must contain the complete desired resource rather than only changed fields.
+
 ## Local
 
 ### Installing and managing ClickHouse versions

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -55,6 +55,7 @@ rand = "0.10.1"
 dotenvy = "0.15.7"
 tempfile = "3.27.0"
 sha2 = "0.11.0"
+serde_ignored = "0.1.14"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -14,6 +14,7 @@ pub(crate) use crate::cloud::clickpipes::{
     KinesisCreateArgs, KinesisSourceFields, MongoDbCreateArgs, MySqlCreateArgs,
     ObjectStorageCreateArgs, PostgresCreateArgs,
 };
+pub(crate) use crate::cloud::clickstack::ClickStackCommands;
 pub(crate) use crate::cloud::organizations::{InvitationCommands, MemberCommands, OrgCommands};
 #[allow(unused_imports)]
 pub(crate) use crate::cloud::services::{
@@ -142,6 +143,21 @@ CONTEXT FOR AGENTS:
         command: Box<ClickPipeCommands>,
     },
 
+    /// Manage ClickStack observability resources
+    #[command(
+        name = "clickstack",
+        after_help = "\
+CONTEXT FOR AGENTS:
+  Service ID: `clickhousectl cloud service list`.
+  Source and role IDs come from their respective `list` commands.
+  Everything except list/get is a write and needs API key auth.
+  Create/update read complete JSON bodies from --config-file; `-` reads stdin."
+    )]
+    ClickStack {
+        #[command(subcommand)]
+        command: ClickStackCommands,
+    },
+
     /// Manage organization members
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -220,6 +236,7 @@ impl CloudCommands {
             CloudCommands::Activity { command } => command.is_write(),
             CloudCommands::Postgres { command } => command.is_write(),
             CloudCommands::ClickPipe { command } => command.is_write(),
+            CloudCommands::ClickStack { command } => command.is_write(),
         }
     }
 }

--- a/crates/clickhousectl/src/cloud/clickstack.rs
+++ b/crates/clickhousectl/src/cloud/clickstack.rs
@@ -1,0 +1,857 @@
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::config::{deserialize_strict_config, read_config_value, read_typed_config};
+use crate::cloud::output::{or_absent, print_human};
+use crate::cloud::shared::resolve_org_id;
+use clap::Subcommand;
+use clickhouse_cloud_api::models::{
+    ClickStackCreateRoleRequest, ClickStackLogSource,
+    ClickStackLogSourceUsetextindexforimplicitcolumn, ClickStackMaterializedView,
+    ClickStackMaterializedViewMingranularity, ClickStackMetricSource, ClickStackPromqlSource,
+    ClickStackRole, ClickStackSessionSource, ClickStackSource, ClickStackSourceResponse,
+    ClickStackTraceSource, ClickStackTraceSourceUsetextindexforimplicitcolumn,
+    ClickStackUpdateRoleRequest,
+};
+use serde_json::Value;
+use tabled::{Table, Tabled, settings::Style};
+
+#[derive(Subcommand)]
+pub enum ClickStackCommands {
+    /// Manage ClickStack data sources
+    Source {
+        #[command(subcommand)]
+        command: SourceCommands,
+    },
+
+    /// Manage ClickStack roles
+    Role {
+        #[command(subcommand)]
+        command: RoleCommands,
+    },
+}
+
+impl ClickStackCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            Self::Source { command } => command.is_write(),
+            Self::Role { command } => command.is_write(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum SourceCommands {
+    /// List ClickStack sources
+    List {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get ClickStack source details
+    Get {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Source ID (from `cloud clickstack source list`)
+        source_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Create a ClickStack source
+    Create {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Replace a ClickStack source
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  This is a full PUT replacement; include every required and desired field.")]
+    Update {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Source ID (from `cloud clickstack source list`)
+        source_id: String,
+        /// Complete JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Delete a ClickStack source
+    Delete {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Source ID (from `cloud clickstack source list`)
+        source_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl SourceCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            Self::List { .. } | Self::Get { .. } => false,
+            Self::Create { .. } | Self::Update { .. } | Self::Delete { .. } => true,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum RoleCommands {
+    /// List ClickStack roles
+    List {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get ClickStack role details
+    Get {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Role ID (from `cloud clickstack role list`)
+        role_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Create a ClickStack role
+    Create {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Replace a ClickStack role
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  This is a full PUT replacement; permissions is the complete role permission set.")]
+    Update {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Role ID (from `cloud clickstack role list`)
+        role_id: String,
+        /// Complete JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Delete a ClickStack role
+    Delete {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Role ID (from `cloud clickstack role list`)
+        role_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl RoleCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            Self::List { .. } | Self::Get { .. } => false,
+            Self::Create { .. } | Self::Update { .. } | Self::Delete { .. } => true,
+        }
+    }
+}
+
+fn field<'a>(value: &'a Value, name: &str) -> Option<&'a Value> {
+    value.as_object()?.get(name)
+}
+
+fn build_source_request(config_file: &str) -> CloudResult<ClickStackSource> {
+    parse_source_request(read_config_value(config_file)?, config_file)
+}
+
+fn build_create_role_request(config_file: &str) -> CloudResult<ClickStackCreateRoleRequest> {
+    read_typed_config(config_file)
+}
+
+fn build_update_role_request(config_file: &str) -> CloudResult<ClickStackUpdateRoleRequest> {
+    read_typed_config(config_file)
+}
+
+fn parse_source_request(value: Value, source: &str) -> CloudResult<ClickStackSource> {
+    let kind = field(&value, "kind").and_then(Value::as_str);
+    let request = match kind {
+        Some("log") => ClickStackSource::ClickStackLogSource(deserialize_strict_config::<
+            ClickStackLogSource,
+        >(value, source)?),
+        Some("trace") => ClickStackSource::ClickStackTraceSource(deserialize_strict_config::<
+            ClickStackTraceSource,
+        >(value, source)?),
+        Some("metric") => ClickStackSource::ClickStackMetricSource(deserialize_strict_config::<
+            ClickStackMetricSource,
+        >(value, source)?),
+        Some("session") => ClickStackSource::ClickStackSessionSource(deserialize_strict_config::<
+            ClickStackSessionSource,
+        >(value, source)?),
+        Some("promql") => ClickStackSource::ClickStackPromqlSource(deserialize_strict_config::<
+            ClickStackPromqlSource,
+        >(value, source)?),
+        Some(other) => {
+            return Err(CloudError::new(format!(
+                "invalid request body in config {source}: unknown source discriminator `{other}`; expected log, trace, metric, session, or promql"
+            )));
+        }
+        None => {
+            return Err(CloudError::new(format!(
+                "invalid request body in config {source}: source `kind` must be one of log, trace, metric, session, or promql"
+            )));
+        }
+    };
+    validate_source_closed_enums(&request, source)?;
+    Ok(request)
+}
+
+fn validate_materialized_views(
+    views: Option<&Vec<ClickStackMaterializedView>>,
+    source: &str,
+) -> CloudResult<()> {
+    if let Some((index, value)) = views.and_then(|views| {
+        views.iter().enumerate().find_map(|(index, view)| {
+            if let ClickStackMaterializedViewMingranularity::Unknown(value) = &view.min_granularity
+            {
+                Some((index, value))
+            } else {
+                None
+            }
+        })
+    }) {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {source}: unknown materializedViews[{index}].minGranularity value `{value}`"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_source_closed_enums(request: &ClickStackSource, source: &str) -> CloudResult<()> {
+    match request {
+        ClickStackSource::ClickStackLogSource(log) => {
+            if let Some(ClickStackLogSourceUsetextindexforimplicitcolumn::Unknown(value)) =
+                &log.use_text_index_for_implicit_column
+            {
+                return Err(CloudError::new(format!(
+                    "invalid request body in config {source}: unknown useTextIndexForImplicitColumn value `{value}`"
+                )));
+            }
+            validate_materialized_views(log.materialized_views.as_ref(), source)
+        }
+        ClickStackSource::ClickStackTraceSource(trace) => {
+            if let Some(ClickStackTraceSourceUsetextindexforimplicitcolumn::Unknown(value)) =
+                &trace.use_text_index_for_implicit_column
+            {
+                return Err(CloudError::new(format!(
+                    "invalid request body in config {source}: unknown useTextIndexForImplicitColumn value `{value}`"
+                )));
+            }
+            validate_materialized_views(trace.materialized_views.as_ref(), source)
+        }
+        ClickStackSource::ClickStackMetricSource(_)
+        | ClickStackSource::ClickStackSessionSource(_)
+        | ClickStackSource::ClickStackPromqlSource(_) => Ok(()),
+        ClickStackSource::Unknown(_) => unreachable!("source is built from a concrete variant"),
+    }
+}
+
+pub async fn run(client: &CloudClient, command: ClickStackCommands, json: bool) -> CloudResult<()> {
+    match command {
+        ClickStackCommands::Source { command } => run_source(client, command, json).await,
+        ClickStackCommands::Role { command } => run_role(client, command, json).await,
+    }
+}
+
+async fn run_source(client: &CloudClient, command: SourceCommands, json: bool) -> CloudResult<()> {
+    match command {
+        SourceCommands::List { service_id, org_id } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let sources = client
+                .click_stack_list_sources(&org_id, &service_id)
+                .await?;
+            print_source_list(&sources, json)
+        }
+        SourceCommands::Get {
+            service_id,
+            source_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let source = client
+                .click_stack_get_source(&org_id, &service_id, &source_id)
+                .await?;
+            print_detail(&source, json)
+        }
+        SourceCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_source_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let source = client
+                .click_stack_create_source(&org_id, &service_id, &request)
+                .await?;
+            print_detail(&source, json)
+        }
+        SourceCommands::Update {
+            service_id,
+            source_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_source_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let source = client
+                .click_stack_update_source(&org_id, &service_id, &source_id, &request)
+                .await?;
+            print_detail(&source, json)
+        }
+        SourceCommands::Delete {
+            service_id,
+            source_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            client
+                .click_stack_delete_source(&org_id, &service_id, &source_id)
+                .await?;
+            print_deleted("ClickStack source", &source_id, json);
+            Ok(())
+        }
+    }
+}
+
+async fn run_role(client: &CloudClient, command: RoleCommands, json: bool) -> CloudResult<()> {
+    match command {
+        RoleCommands::List { service_id, org_id } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let roles = client.click_stack_list_roles(&org_id, &service_id).await?;
+            print_role_list(&roles, json)
+        }
+        RoleCommands::Get {
+            service_id,
+            role_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let role = client
+                .click_stack_get_role(&org_id, &service_id, &role_id)
+                .await?;
+            print_detail(&role, json)
+        }
+        RoleCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_create_role_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let role = client
+                .click_stack_create_role(&org_id, &service_id, &request)
+                .await?;
+            print_detail(&role, json)
+        }
+        RoleCommands::Update {
+            service_id,
+            role_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_update_role_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let role = client
+                .click_stack_update_role(&org_id, &service_id, &role_id, &request)
+                .await?;
+            print_detail(&role, json)
+        }
+        RoleCommands::Delete {
+            service_id,
+            role_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            client
+                .click_stack_delete_role(&org_id, &service_id, &role_id)
+                .await?;
+            print_deleted("ClickStack role", &role_id, json);
+            Ok(())
+        }
+    }
+}
+
+fn print_detail<T: serde::Serialize>(value: &T, json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(value)?);
+    } else {
+        print_human(value)?;
+    }
+    Ok(())
+}
+
+fn print_deleted(noun: &str, id: &str, json: bool) {
+    if json {
+        println!("{}", serde_json::json!({ "deleted": id }));
+    } else {
+        println!("{noun} {id} deleted");
+    }
+}
+
+fn source_summary(source: &ClickStackSourceResponse) -> (Option<&str>, Option<&str>, String) {
+    macro_rules! known {
+        ($source:expr) => {{
+            (
+                $source.id.as_deref(),
+                $source.name.as_deref(),
+                or_absent($source.kind.as_ref()),
+            )
+        }};
+    }
+    match source {
+        ClickStackSourceResponse::ClickStackLogSource(source) => known!(source),
+        ClickStackSourceResponse::ClickStackTraceSource(source) => known!(source),
+        ClickStackSourceResponse::ClickStackMetricSource(source) => known!(source),
+        ClickStackSourceResponse::ClickStackSessionSource(source) => known!(source),
+        ClickStackSourceResponse::ClickStackPromqlSource(source) => known!(source),
+        ClickStackSourceResponse::Unknown(value) => (
+            field(value, "id").and_then(Value::as_str),
+            field(value, "name").and_then(Value::as_str),
+            or_absent(field(value, "kind").and_then(Value::as_str)),
+        ),
+    }
+}
+
+fn print_source_list(sources: &[ClickStackSourceResponse], json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(sources)?);
+        return Ok(());
+    }
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "ID")]
+        id: String,
+        #[tabled(rename = "Kind")]
+        kind: String,
+    }
+    let rows = sources
+        .iter()
+        .map(|source| {
+            let (id, name, kind) = source_summary(source);
+            Row {
+                name: or_absent(name),
+                id: or_absent(id),
+                kind,
+            }
+        })
+        .collect::<Vec<_>>();
+    println!("{}", Table::new(rows).with(Style::rounded()));
+    Ok(())
+}
+
+fn print_role_list(roles: &[ClickStackRole], json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(roles)?);
+        return Ok(());
+    }
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "ID")]
+        id: String,
+        #[tabled(rename = "Predefined")]
+        predefined: String,
+        #[tabled(rename = "Description")]
+        description: String,
+    }
+    let rows = roles
+        .iter()
+        .map(|role| Row {
+            name: or_absent(role.name.as_deref()),
+            id: or_absent(role.id.as_deref()),
+            predefined: or_absent(role.is_predefined),
+            description: or_absent(role.description.as_deref()),
+        })
+        .collect::<Vec<_>>();
+    println!("{}", Table::new(rows).with(Style::rounded()));
+    Ok(())
+}
+
+impl CloudClient {
+    async fn click_stack_list_sources(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> CloudResult<Vec<ClickStackSourceResponse>> {
+        let response = self
+            .api()
+            .click_stack_list_sources(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_create_source(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &ClickStackSource,
+    ) -> CloudResult<ClickStackSourceResponse> {
+        let response = self
+            .api()
+            .click_stack_create_source(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_get_source(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        source_id: &str,
+    ) -> CloudResult<ClickStackSourceResponse> {
+        let response = self
+            .api()
+            .click_stack_get_source(org_id, service_id, source_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_update_source(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        source_id: &str,
+        request: &ClickStackSource,
+    ) -> CloudResult<ClickStackSourceResponse> {
+        let response = self
+            .api()
+            .click_stack_update_source(org_id, service_id, source_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_delete_source(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        source_id: &str,
+    ) -> CloudResult<crate::cloud::types::DeleteResponse> {
+        let response = self
+            .api()
+            .click_stack_delete_source(org_id, service_id, source_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(crate::cloud::types::DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
+    async fn click_stack_list_roles(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> CloudResult<Vec<ClickStackRole>> {
+        let response = self
+            .api()
+            .click_stack_list_roles(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_create_role(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &ClickStackCreateRoleRequest,
+    ) -> CloudResult<ClickStackRole> {
+        let response = self
+            .api()
+            .click_stack_create_role(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_get_role(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        role_id: &str,
+    ) -> CloudResult<ClickStackRole> {
+        let response = self
+            .api()
+            .click_stack_get_role(org_id, service_id, role_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_update_role(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        role_id: &str,
+        request: &ClickStackUpdateRoleRequest,
+    ) -> CloudResult<ClickStackRole> {
+        let response = self
+            .api()
+            .click_stack_update_role(org_id, service_id, role_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_delete_role(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        role_id: &str,
+    ) -> CloudResult<crate::cloud::types::DeleteResponse> {
+        let response = self
+            .api()
+            .click_stack_delete_role(org_id, service_id, role_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(crate::cloud::types::DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use clap::Parser;
+
+    fn parse_clickstack(args: &[&str]) -> ClickStackCommands {
+        let cli = Cli::try_parse_from(args).unwrap();
+        let Commands::Cloud(cloud) = cli.command else {
+            panic!("expected cloud command")
+        };
+        let crate::cloud::cli::CloudCommands::ClickStack { command } = cloud.command else {
+            panic!("expected clickstack command")
+        };
+        command
+    }
+
+    #[test]
+    fn parses_source_and_role_config_commands() {
+        let command = parse_clickstack(&[
+            "clickhousectl",
+            "cloud",
+            "clickstack",
+            "source",
+            "create",
+            "svc-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ]);
+        let ClickStackCommands::Source {
+            command:
+                SourceCommands::Create {
+                    config_file,
+                    org_id,
+                    ..
+                },
+        } = command
+        else {
+            panic!("expected source create")
+        };
+        assert_eq!(config_file, "-");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let command = parse_clickstack(&[
+            "clickhousectl",
+            "cloud",
+            "clickstack",
+            "role",
+            "update",
+            "svc-1",
+            "role-1",
+            "--config-file",
+            "role.json",
+            "--org-id",
+            "org-1",
+        ]);
+        let ClickStackCommands::Role {
+            command:
+                RoleCommands::Update {
+                    config_file,
+                    role_id,
+                    ..
+                },
+        } = command
+        else {
+            panic!("expected role update")
+        };
+        assert_eq!(config_file, "role.json");
+        assert_eq!(role_id, "role-1");
+    }
+
+    #[test]
+    fn classifies_every_source_and_role_operation() {
+        for (resource, operation, expected) in [
+            ("source", "list", false),
+            ("source", "get", false),
+            ("source", "create", true),
+            ("source", "update", true),
+            ("source", "delete", true),
+            ("role", "list", false),
+            ("role", "get", false),
+            ("role", "create", true),
+            ("role", "update", true),
+            ("role", "delete", true),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "clickstack",
+                resource,
+                operation,
+                "svc-1",
+            ];
+            if matches!(operation, "get" | "update" | "delete") {
+                args.push("resource-1");
+            }
+            if matches!(operation, "create" | "update") {
+                args.extend(["--config-file", "body.json"]);
+            }
+            let command = parse_clickstack(&args);
+            assert_eq!(command.is_write(), expected, "{resource} {operation}");
+        }
+    }
+
+    #[test]
+    fn source_builders_accept_minimal_and_maximal_variants() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("source.json");
+        std::fs::write(
+            &config_file,
+            r#"{"kind":"promql","name":"p","connection":"c","from":{"databaseName":"d","tableName":"t"},"timestampValueExpression":"ts"}"#,
+        )
+        .unwrap();
+        let minimal = build_source_request(config_file.to_str().unwrap()).unwrap();
+        assert!(matches!(
+            minimal,
+            ClickStackSource::ClickStackPromqlSource(_)
+        ));
+
+        let maximal = serde_json::json!({
+            "kind": "log", "id": "src", "name": "logs", "section": "prod", "disabled": false,
+            "connection": "conn", "from": {"databaseName": "db", "tableName": "logs"},
+            "querySettings": [{"setting": "max_threads", "value": "4"}],
+            "filterSettings": {"databaseName": "db", "tableName": "filters", "columns": [
+                {"name": "service", "label": "Service", "valueExpression": "ServiceName", "allowAll": true}
+            ]},
+            "defaultTableSelectExpression": "*", "timestampValueExpression": "Timestamp",
+            "serviceNameExpression": "ServiceName", "serviceVersionExpression": "ServiceVersion",
+            "severityTextExpression": "SeverityText", "bodyExpression": "Body",
+            "eventAttributesExpression": "Events", "resourceAttributesExpression": "ResourceAttributes",
+            "displayedTimestampValueExpression": "Timestamp", "metricSourceId": "metrics",
+            "traceSourceId": "traces", "traceIdExpression": "TraceId", "spanIdExpression": "SpanId",
+            "implicitColumnExpression": "Attributes", "knownColumnsListExpression": "known",
+            "useTextIndexForImplicitColumn": "enabled",
+            "highlightedTraceAttributeExpressions": [{"sqlExpression": "TraceId", "luceneExpression": "trace.id", "alias": "trace"}],
+            "highlightedRowAttributeExpressions": [{"sqlExpression": "Body", "luceneExpression": "body", "alias": "body"}],
+            "materializedViews": [{"databaseName": "db", "tableName": "mv", "dimensionColumns": "ServiceName",
+                "minGranularity": "1m", "minDate": "2026-01-01T00:00:00Z", "timestampColumn": "Timestamp",
+                "aggregatedColumns": [{"sourceColumn": "Body", "aggFn": "count", "mvColumn": "count"}]}],
+            "metadataMaterializedViews": {"keyRollupTable": "keys", "kvRollupTable": "kv", "granularity": "1m"}
+        });
+        std::fs::write(&config_file, maximal.to_string()).unwrap();
+        let source = build_source_request(config_file.to_str().unwrap()).unwrap();
+        let ClickStackSource::ClickStackLogSource(source) = source else {
+            panic!("expected log")
+        };
+        assert_eq!(
+            source.service_version_expression.as_deref(),
+            Some("ServiceVersion")
+        );
+        let column = &source.filter_settings.unwrap().columns[0];
+        assert_eq!(column.allow_all, Some(true));
+        assert_eq!(column.value_expression.as_deref(), Some("ServiceName"));
+    }
+
+    #[test]
+    fn every_source_variant_deserializes_as_its_request_type() {
+        let bodies = [
+            serde_json::json!({"kind":"log","name":"l","connection":"c","from":{"databaseName":"d","tableName":"t"},"defaultTableSelectExpression":"*","timestampValueExpression":"ts"}),
+            serde_json::json!({"kind":"trace","name":"t","connection":"c","from":{"databaseName":"d","tableName":"t"},"defaultTableSelectExpression":"*","timestampValueExpression":"ts","durationExpression":"dur","durationPrecision":9,"traceIdExpression":"trace","spanIdExpression":"span","parentSpanIdExpression":"parent","spanNameExpression":"name","spanKindExpression":"kind"}),
+            serde_json::json!({"kind":"metric","name":"m","connection":"c","from":{"databaseName":"d"},"metricTables":{"gauge":"g","histogram":"h","sum":"s","summary":"summary","exponential histogram":"eh"},"timestampValueExpression":"ts","resourceAttributesExpression":"r"}),
+            serde_json::json!({"kind":"session","name":"s","connection":"c","from":{"databaseName":"d","tableName":"t"},"traceSourceId":"trace"}),
+            serde_json::json!({"kind":"promql","name":"p","connection":"c","from":{"databaseName":"d","tableName":"t"},"timestampValueExpression":"ts"}),
+        ];
+        for body in bodies {
+            let source = parse_source_request(body, "test").unwrap();
+            assert!(!matches!(source, ClickStackSource::Unknown(_)));
+        }
+    }
+
+    #[test]
+    fn role_builders_cover_minimal_and_complete_permissions() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("role.json");
+        std::fs::write(&config_file, r#"{"name":"reader","permissions":[]}"#).unwrap();
+        let minimal = build_create_role_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(minimal.name, "reader");
+
+        let maximal = r#"{"name":"ops","description":"operators","permissions":[{"action":"manage","subject":"Dashboard","inverted":true,"integration":"slack","conditions":{"teamId":"team-1"}}]}"#;
+        std::fs::write(&config_file, maximal).unwrap();
+        let create = build_create_role_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(create.permissions[0].integration.as_deref(), Some("slack"));
+        assert_eq!(
+            create.permissions[0].conditions.as_ref().unwrap()["teamId"],
+            "team-1"
+        );
+        let update = build_update_role_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(update.permissions[0].inverted, Some(true));
+    }
+
+    #[test]
+    fn input_validation_rejects_unknown_discriminator_and_nested_fields() {
+        let error = parse_source_request(serde_json::json!({"kind":"logs","naem":"bad"}), "test")
+            .unwrap_err();
+        assert!(
+            error
+                .message
+                .contains("unknown source discriminator `logs`")
+        );
+
+        let error = deserialize_strict_config::<ClickStackCreateRoleRequest>(
+            serde_json::json!({"name":"r","permissions":[{"action":"read","subject":"x","conditons":{}}]}),
+            "test",
+        )
+        .unwrap_err();
+        assert!(error.message.contains("conditons"), "{error}");
+    }
+}

--- a/crates/clickhousectl/src/cloud/config.rs
+++ b/crates/clickhousectl/src/cloud/config.rs
@@ -1,0 +1,108 @@
+use crate::cloud::client::{CloudError, Result as CloudResult};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::io::Read as _;
+
+/// Read a JSON request body from a file or stdin.
+pub(crate) fn read_config_value(config_file: &str) -> CloudResult<Value> {
+    let contents = if config_file == "-" {
+        let mut contents = String::new();
+        std::io::stdin()
+            .read_to_string(&mut contents)
+            .map_err(|error| {
+                CloudError::new(format!("failed to read config from stdin: {error}"))
+            })?;
+        contents
+    } else {
+        std::fs::read_to_string(config_file).map_err(|error| {
+            CloudError::new(format!("failed to read config file {config_file}: {error}"))
+        })?
+    };
+
+    serde_json::from_str(&contents).map_err(|error| {
+        CloudError::new(format!(
+            "failed to parse config {config_file} as JSON: {error}"
+        ))
+    })
+}
+
+/// Strictly deserialize a raw request body into a library request type.
+///
+/// Published response models intentionally ignore unknown fields. CLI request
+/// input needs the opposite policy, so this wrapper reports every field serde
+/// ignored, including nested fields, without changing the library's models.
+pub(crate) fn deserialize_strict_config<T>(value: Value, source: &str) -> CloudResult<T>
+where
+    T: DeserializeOwned,
+{
+    let encoded = serde_json::to_vec(&value)?;
+    let mut deserializer = serde_json::Deserializer::from_slice(&encoded);
+    let mut ignored = Vec::new();
+    let request = serde_ignored::deserialize(&mut deserializer, |path| {
+        ignored.push(path.to_string());
+    })
+    .map_err(|error| {
+        CloudError::new(format!("invalid request body in config {source}: {error}"))
+    })?;
+
+    if ignored.is_empty() {
+        Ok(request)
+    } else {
+        Err(CloudError::new(format!(
+            "invalid request body in config {source}: unknown field{} {}",
+            if ignored.len() == 1 { "" } else { "s" },
+            ignored
+                .iter()
+                .map(|path| format!("`{path}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )))
+    }
+}
+
+pub(crate) fn read_typed_config<T>(config_file: &str) -> CloudResult<T>
+where
+    T: DeserializeOwned,
+{
+    deserialize_strict_config(read_config_value(config_file)?, config_file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Nested {
+        enabled: Option<bool>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Example {
+        name: String,
+        nested: Option<Nested>,
+    }
+
+    #[test]
+    fn strict_config_rejects_ignored_nested_fields_including_null() {
+        let parsed: Example = deserialize_strict_config(
+            serde_json::json!({"name": "ok", "nested": {"enabled": null}}),
+            "test",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            Example {
+                name: "ok".into(),
+                nested: Some(Nested { enabled: None })
+            }
+        );
+
+        let error = deserialize_strict_config::<Example>(
+            serde_json::json!({"name": "bad", "nested": {"enabeld": null}}),
+            "test",
+        )
+        .unwrap_err();
+        assert!(error.message.contains("enabeld"), "{error}");
+    }
+}

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -5,7 +5,9 @@ pub mod backups;
 pub mod cli;
 pub mod clickpipe_endpoints;
 pub mod clickpipes;
+pub mod clickstack;
 pub mod client;
+mod config;
 pub mod credentials;
 pub mod organizations;
 pub mod output;
@@ -128,6 +130,7 @@ async fn dispatch(client: &CloudClient, command: CloudCommands, json: bool) -> c
         CloudCommands::Backup { command } => backups::run(client, command, json).await,
         CloudCommands::Postgres { command } => postgres::run(client, command, json).await,
         CloudCommands::ClickPipe { command } => clickpipes::run(client, *command, json).await,
+        CloudCommands::ClickStack { command } => clickstack::run(client, command, json).await,
     }
 }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -13506,3 +13506,508 @@ async fn postgres_config_files_preserve_explicit_empty_sections() {
         assert_success(&output);
     }
 }
+
+// ── ClickStack source and role commands (issue #692) ────────────────────────
+
+fn invoke_clickstack_cli(
+    mock: &MockServer,
+    cli_args: &[&str],
+    stdin: Option<&str>,
+    json: bool,
+) -> std::process::Output {
+    let directory = tempfile::tempdir().unwrap();
+    let home = directory.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = mock.uri();
+    let mut args = vec!["cloud", "--url", url.as_str()];
+    if json {
+        args.push("--json");
+    }
+    args.extend_from_slice(cli_args);
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(directory.path())
+        .args(args);
+    if let Some(input) = stdin {
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn clickhousectl");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .unwrap();
+        child.wait_with_output().unwrap()
+    } else {
+        command.output().expect("failed to spawn clickhousectl")
+    }
+}
+
+async fn mount_clickstack_success_routes(mock: &MockServer) {
+    let sources = "/v1/organizations/org-1/services/svc-1/clickstack/sources";
+    let roles = "/v1/organizations/org-1/services/svc-1/clickstack/roles";
+    Mock::given(method("GET"))
+        .and(path(sources))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{}]
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{sources}/source-get")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"kind": "log", "name": null}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(sources))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"kind": "promql", "id": "source-created"}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(format!("{sources}/source-update")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"kind": "promql", "id": "source-update"}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("{sources}/source-delete")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": 200})))
+        .expect(1)
+        .mount(mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(roles))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{}]
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{roles}/role-get")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"name": null}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(roles))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "role-created"}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(format!("{roles}/role-update")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "role-update"}
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("{roles}/role-delete")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": 200})))
+        .expect(1)
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn clickstack_all_ten_routes_use_service_org_auth_and_full_bodies() {
+    let mock = MockServer::start().await;
+    mount_clickstack_success_routes(&mock).await;
+    let directory = tempfile::tempdir().unwrap();
+    let source_file = directory.path().join("source.json");
+    let role_file = directory.path().join("role.json");
+    let source = serde_json::json!({
+        "kind": "promql",
+        "name": "Prometheus",
+        "connection": "connection-1",
+        "from": {"databaseName": "default", "tableName": "metrics"},
+        "timestampValueExpression": "timestamp",
+        "section": "production",
+        "disabled": false,
+        "querySettings": [{"setting": "max_threads", "value": "2"}]
+    });
+    let role = serde_json::json!({
+        "name": "Operators",
+        "description": "Production operators",
+        "permissions": [{
+            "action": "manage",
+            "subject": "Dashboard",
+            "inverted": false,
+            "integration": "slack",
+            "conditions": {"teamId": "team-1"}
+        }]
+    });
+    std::fs::write(&source_file, source.to_string()).unwrap();
+    std::fs::write(&role_file, role.to_string()).unwrap();
+    let source_path = source_file.to_str().unwrap();
+    let role_path = role_file.to_str().unwrap();
+    let role_stdin = role.to_string();
+    let commands: Vec<(Vec<&str>, Option<&str>)> = vec![
+        (
+            vec!["clickstack", "source", "list", "svc-1", "--org-id", "org-1"],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "source",
+                "get",
+                "svc-1",
+                "source-get",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "source",
+                "create",
+                "svc-1",
+                "--config-file",
+                source_path,
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "source",
+                "update",
+                "svc-1",
+                "source-update",
+                "--config-file",
+                source_path,
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "source",
+                "delete",
+                "svc-1",
+                "source-delete",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec!["clickstack", "role", "list", "svc-1", "--org-id", "org-1"],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "role",
+                "get",
+                "svc-1",
+                "role-get",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "role",
+                "create",
+                "svc-1",
+                "--config-file",
+                role_path,
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "role",
+                "update",
+                "svc-1",
+                "role-update",
+                "--config-file",
+                "-",
+                "--org-id",
+                "org-1",
+            ],
+            Some(role_stdin.as_str()),
+        ),
+        (
+            vec![
+                "clickstack",
+                "role",
+                "delete",
+                "svc-1",
+                "role-delete",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+    ];
+    for (args, stdin) in commands {
+        let output = invoke_clickstack_cli(&mock, &args, stdin, true);
+        assert_success(&output);
+        serde_json::from_slice::<Value>(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "invalid JSON output for {args:?}: {error}\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        });
+    }
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 10);
+    for request in &requests {
+        assert!(
+            request
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("Basic "),
+            "{} {}",
+            request.method,
+            request.url.path()
+        );
+    }
+    let write_bodies = requests
+        .iter()
+        .filter(|request| {
+            request.method == wiremock::http::Method::POST
+                || request.method == wiremock::http::Method::PUT
+        })
+        .map(|request| request.body_json::<Value>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        write_bodies,
+        vec![source.clone(), source, role.clone(), role]
+    );
+}
+
+#[tokio::test]
+async fn clickstack_source_create_accepts_all_variants_and_nested_log_fields() {
+    let bodies = vec![
+        serde_json::json!({
+            "kind":"log", "name":"logs", "connection":"c",
+            "from":{"databaseName":"d","tableName":"logs"},
+            "defaultTableSelectExpression":"*", "timestampValueExpression":"Timestamp",
+            "serviceVersionExpression":"ServiceVersion",
+            "filterSettings":{"databaseName":"d","tableName":"filters","columns":[
+                {"name":"service","label":"Service","allowAll":true,"valueExpression":"ServiceName"}
+            ]},
+            "materializedViews":[{"databaseName":"d","tableName":"mv","dimensionColumns":"ServiceName",
+                "minGranularity":"1m","timestampColumn":"Timestamp","aggregatedColumns":[
+                    {"aggFn":"count","mvColumn":"count"}
+                ]}],
+            "metadataMaterializedViews":{"keyRollupTable":"keys","kvRollupTable":"kv","granularity":"1m"}
+        }),
+        serde_json::json!({"kind":"trace","name":"traces","connection":"c","from":{"databaseName":"d","tableName":"traces"},"defaultTableSelectExpression":"*","timestampValueExpression":"ts","durationExpression":"duration","durationPrecision":9,"traceIdExpression":"trace","spanIdExpression":"span","parentSpanIdExpression":"parent","spanNameExpression":"name","spanKindExpression":"kind","serviceVersionExpression":"version"}),
+        serde_json::json!({"kind":"metric","name":"metrics","connection":"c","from":{"databaseName":"d"},"metricTables":{"gauge":"g","histogram":"h","sum":"s","summary":"summary","exponential histogram":"eh"},"timestampValueExpression":"ts","resourceAttributesExpression":"resource"}),
+        serde_json::json!({"kind":"session","name":"sessions","connection":"c","from":{"databaseName":"d","tableName":"sessions"},"traceSourceId":"traces"}),
+        serde_json::json!({"kind":"promql","name":"promql","connection":"c","from":{"databaseName":"d","tableName":"metrics"},"timestampValueExpression":"ts"}),
+    ];
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/sources",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"kind": "promql"}
+        })))
+        .expect(5)
+        .mount(&mock)
+        .await;
+    let directory = tempfile::tempdir().unwrap();
+    for (index, body) in bodies.iter().enumerate() {
+        let file = directory.path().join(format!("source-{index}.json"));
+        std::fs::write(&file, body.to_string()).unwrap();
+        let output = invoke_clickstack_cli(
+            &mock,
+            &[
+                "clickstack",
+                "source",
+                "create",
+                "svc-1",
+                "--config-file",
+                file.to_str().unwrap(),
+                "--org-id",
+                "org-1",
+            ],
+            None,
+            true,
+        );
+        assert_success(&output);
+    }
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.body_json::<Value>().unwrap())
+            .collect::<Vec<_>>(),
+        bodies
+    );
+}
+
+#[tokio::test]
+async fn clickstack_invalid_config_fails_before_org_discovery_or_resource_request() {
+    let invalid = [
+        (
+            serde_json::json!({"kind":"logs"}),
+            "unknown source discriminator",
+        ),
+        (
+            serde_json::json!({"kind":"promql","name":"p","connection":"c","from":{"databaseName":"d","tableName":"t","tableNaem":null},"timestampValueExpression":"ts"}),
+            "tableNaem",
+        ),
+        (
+            serde_json::json!({"kind":"log","name":"l"}),
+            "missing field",
+        ),
+        (
+            serde_json::json!({"kind":"log","name":"l","connection":"c","from":{"databaseName":"d","tableName":"t"},"defaultTableSelectExpression":"*","timestampValueExpression":"ts","useTextIndexForImplicitColumn":"enabledd"}),
+            "unknown useTextIndexForImplicitColumn",
+        ),
+    ];
+    for (body, expected) in invalid {
+        let mock = MockServer::start().await;
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("invalid.json");
+        std::fs::write(&file, body.to_string()).unwrap();
+        let output = invoke_clickstack_cli(
+            &mock,
+            &[
+                "clickstack",
+                "source",
+                "create",
+                "svc-1",
+                "--config-file",
+                file.to_str().unwrap(),
+            ],
+            None,
+            false,
+        );
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(expected),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(mock.received_requests().await.unwrap().is_empty());
+    }
+
+    let mock = MockServer::start().await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "role",
+            "create",
+            "svc-1",
+            "--config-file",
+            "-",
+        ],
+        Some(
+            r#"{"name":"reader","permissions":[{"action":"read","subject":"Dashboard","conditons":null}]}"#,
+        ),
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("conditons"));
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn clickstack_human_lists_render_sparse_fields_and_api_errors_include_org() {
+    for (resource, result) in [
+        ("source", serde_json::json!([{}])),
+        ("role", serde_json::json!([{}])),
+    ] {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/v1/organizations/org-1/services/svc-1/clickstack/{resource}s"
+            )))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": result})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_clickstack_cli(
+            &mock,
+            &["clickstack", resource, "list", "svc-1", "--org-id", "org-1"],
+            None,
+            false,
+        );
+        assert_success(&output);
+        assert!(String::from_utf8_lossy(&output.stdout).contains('-'));
+    }
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-sensitive/services/svc-1/clickstack/roles/role-1",
+        ))
+        .respond_with(
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({"error":"NOT_FOUND"})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "role",
+            "get",
+            "svc-1",
+            "role-1",
+            "--org-id",
+            "org-sensitive",
+        ],
+        None,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("org-sensitive") && error.contains("NOT_FOUND"),
+        "{error}"
+    );
+}

--- a/scripts/classify-cloud-integration.py
+++ b/scripts/classify-cloud-integration.py
@@ -14,6 +14,8 @@ NO_SUITES = frozenset()
 
 # Retain mappings when files are deleted or renamed so old diff paths stay classified.
 SOURCE_PATH_SUITES = {
+    "crates/clickhousectl/src/cloud/clickstack.rs": NO_SUITES,
+    "crates/clickhousectl/src/cloud/config.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/src/client.rs": ALL_SUITES,
     "crates/clickhouse-cloud-api/src/client/activity.rs": frozenset({"organization"}),
     "crates/clickhouse-cloud-api/src/client/api_keys.rs": frozenset(

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -42,6 +42,8 @@ INSTALL_PREFIXES = ("crates/clickhousectl/src/version_manager/",)
 # inventory test to reject an unclassified new shared/local source or test.
 NON_INSTALL_EXACT_PATHS = frozenset(
     {
+        "crates/clickhousectl/src/cloud/clickstack.rs",
+        "crates/clickhousectl/src/cloud/config.rs",
         "crates/clickhousectl/src/dotenv.rs",
         "crates/clickhousectl/src/failure.rs",
         "crates/clickhousectl/src/local/config.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -115,6 +115,8 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
             classifier.NON_INSTALL_EXACT_PATHS,
             frozenset(
                 {
+                    "crates/clickhousectl/src/cloud/clickstack.rs",
+                    "crates/clickhousectl/src/cloud/config.rs",
                     "crates/clickhousectl/src/dotenv.rs",
                     "crates/clickhousectl/src/failure.rs",
                     "crates/clickhousectl/src/local/config.rs",


### PR DESCRIPTION
## Summary

Add native `cloud clickstack source` and `cloud clickstack role` list/get/create/update/delete commands for service-scoped ClickStack resources. Create and update consume complete typed JSON bodies from a file or stdin, reject malformed bodies, unknown nested fields, unknown source discriminators, and closed request enum values before organization discovery or any resource request, while preserving the API library's tolerant response models.

The shared CLI config loader is reusable by later ClickStack command slices. Source input supports all five library variants, including service version expressions, filter column `allowAll`/`valueExpression`, source links, query settings, and materialized view configuration; role input preserves complete CASL permissions and open conditions. Human output tolerates sparse responses, JSON/agent output remains structured, and update help plus README examples describe PUT replacement semantics.

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `python3 -m unittest scripts.tests.test_classify_cloud_integration scripts.tests.test_classify_install_integration`

Closes #692
