### PR TITLE
feat(cli): manage UDFs, versions, attachments and artifact uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1801,7 +1801,54 @@ To see exactly what would be sent without sending it, set `CHCTL_TELEMETRY_DEBUG
 
 Distribution packagers can compile telemetry out entirely (including the `telemetry` subcommand) with `cargo build --no-default-features`.
 
-UDF API request models preserve `deterministic` and nullable `memoryLimitMib` in both executable variants, including version creation. The OpenAPI analyzer checks inline union payload fields and their request requiredness; its report format is version 5.
+## User-defined functions (Beta)
+
+`cloud udf` manages organization-scoped executable UDFs, versions, and service attachments. All UDF operations are beta. Reads support OAuth; writes require API key authentication.
+
+Create a JSON definition and a [source ZIP archive](https://clickhouse.com/docs/products/cloud/features/sql-console-features/user-defined-functions#manage-udfs-with-the-cloud-api). `--config-file` accepts a file or `-` for stdin. The definition uses the API's field names and excludes `uploadId`, which the CLI obtains from a fresh upload session:
+
+```json
+{
+  "functionName": "my_udf",
+  "type": "executable",
+  "runtime": "native",
+  "arguments": [{"name": "x", "type": "UInt64"}],
+  "returnType": "UInt64",
+  "memoryLimitMib": 128,
+  "deterministic": false
+}
+```
+
+```bash
+clickhousectl cloud udf create --config-file udf.json --artifact source.zip
+clickhousectl cloud udf get my_udf
+# Wait for status ready, then attach the latest ready version (or --version 2)
+clickhousectl cloud udf attach my_udf <service-id>
+clickhousectl cloud udf attachment list my_udf
+clickhousectl cloud udf attachment get my_udf <service-id>
+clickhousectl cloud udf list --limit 20
+# Continue with the returned pagination.nextCursor
+clickhousectl cloud udf list --limit 20 --cursor '<nextCursor>'
+clickhousectl cloud udf version list my_udf
+
+# version.json contains the complete definition without functionName or uploadId
+clickhousectl cloud udf version create my_udf --config-file version.json --artifact source-v2.zip
+clickhousectl cloud udf attach my_udf <service-id> --version 2
+clickhousectl cloud udf detach my_udf <service-id>
+# Detach from every service before deleting an individual version
+clickhousectl cloud udf version delete my_udf 1
+clickhousectl cloud udf delete my_udf
+```
+
+Required definition fields are `type`, `runtime`, `arguments`, and `returnType`; initial creation also requires `functionName`. Supported types are `executable` and `executable_pool`, with runtimes `native` and `python3.11`. Optional fields are `returnName`, `format`, `commandReadTimeout`, `commandWriteTimeout`, `maxCommandExecutionTime`, `memoryLimitMib`, `sendChunkHeader`, `deterministic`, `sandboxType`, `sandboxVersion`, and `poolSize`. Read/write timeouts are milliseconds; maximum execution time is seconds. Memory is 1–1,048,576 MiB or null. `poolSize` accepts a positive integer for `executable_pool` and only null for `executable`. Sandbox type is `basic` or `netenable`; sandbox version is `v1`, `v2`, or `v3`. Set `deterministic` to true only when identical arguments always produce identical results.
+
+Version creation uses defaults for omitted options, without inheriting the previous version's configuration. Supply a complete request definition; GET output includes response-only fields and cannot be used directly as a request. Unknown fields, unsupported enum values, missing required fields and invalid limits fail before upload. Nullable options may be omitted or set to null; both use the API's default behavior.
+
+Creation and version creation each request a new upload URL, stream the ZIP archive, and submit its upload ID once. Failed uploads never submit a create request. Uploads time out after five minutes; rerun the command to obtain a fresh session after any failure. The target service must be running; wake an idle service before attaching. Attachment replaces the service's existing version; omitted `--version` selects the latest ready version. A dependency failure (HTTP 424) exits with an error; inspect the UDF and service before retrying. The latest version and versions still building cannot be deleted individually. Deleting a UDF deletes all its versions and detaches it from every service; service removal finishes asynchronously.
+
+All three list commands expose `--cursor` and `--limit` (1–100) and retain pagination in JSON output. Detail and list output tolerate missing fields and new response status values.
+
+The UDF API request models preserve `deterministic` and nullable `memoryLimitMib` in both executable variants, including version creation. The OpenAPI analyzer checks inline union payload fields and request requiredness; its report format is version 5.
 
 ## Cloud integration testing
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -20,6 +20,7 @@ pub(crate) use crate::cloud::organizations::{InvitationCommands, MemberCommands,
 pub(crate) use crate::cloud::services::{
     PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands,
 };
+use crate::cloud::udfs::UdfArgs;
 use clap::{Args, Subcommand};
 
 #[derive(Args)]
@@ -88,6 +89,15 @@ impl CloudArgs {
 
 #[derive(Subcommand)]
 pub enum CloudCommands {
+    /// Manage user-defined functions (Beta)
+    #[command(after_help = "CONTEXT FOR AGENTS:
+  UDF operations are beta and may change.
+  Writes require API key authentication; list/get support OAuth.
+  Function names: `cloud udf list`; service IDs: `cloud service list`.
+  Create uploads a ZIP archive and starts an asynchronous build.
+  Typical flow: create -> get until ready -> attach -> attachment get.")]
+    Udf(UdfArgs),
+
     /// Manage authentication (OAuth login, API keys)
     Auth {
         #[command(subcommand)]
@@ -233,6 +243,7 @@ impl CloudCommands {
             CloudCommands::Member { command } => command.is_write(),
             CloudCommands::Invitation { command } => command.is_write(),
             CloudCommands::Key { command } => command.is_write(),
+            CloudCommands::Udf(args) => args.is_write(),
             CloudCommands::Activity { command } => command.is_write(),
             CloudCommands::Postgres { command } => command.is_write(),
             CloudCommands::ClickPipe { command } => command.is_write(),

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -16,6 +16,7 @@ pub mod service_query;
 pub mod services;
 mod shared;
 pub mod types;
+pub mod udfs;
 
 #[cfg(test)]
 mod types_test;
@@ -126,6 +127,7 @@ async fn dispatch(client: &CloudClient, command: CloudCommands, json: bool) -> c
             organizations::run_invitation(client, command, json).await
         }
         CloudCommands::Key { command } => api_keys::run(client, command, json).await,
+        CloudCommands::Udf(args) => udfs::run(client, args, json).await,
         CloudCommands::Activity { command } => activity::run(client, command, json).await,
         CloudCommands::Backup { command } => backups::run(client, command, json).await,
         CloudCommands::Postgres { command } => postgres::run(client, command, json).await,

--- a/crates/clickhousectl/src/cloud/udfs.rs
+++ b/crates/clickhousectl/src/cloud/udfs.rs
@@ -1,0 +1,953 @@
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::config::{deserialize_strict_config, read_config_value};
+use crate::cloud::output::{or_absent, print_human};
+use crate::cloud::shared::resolve_org_id;
+use crate::cloud::types::DeleteResponse;
+use clap::{Args, Subcommand};
+use clickhouse_cloud_api::models::*;
+use serde::Serialize;
+use serde_json::Value;
+use std::path::PathBuf;
+use tabled::{Table, Tabled, settings::Style};
+
+#[derive(Args)]
+pub struct UdfArgs {
+    /// Organization ID (auto-detected only if you have one org)
+    #[arg(long, global = true)]
+    org_id: Option<String>,
+    #[command(subcommand)]
+    command: UdfCommands,
+}
+
+#[derive(Subcommand)]
+pub enum UdfCommands {
+    /// List UDFs
+    List(UdfPageArgs),
+    /// Get UDF details
+    Get(UdfNameArgs),
+    /// Create a UDF
+    Create(UdfCreateArgs),
+    /// Delete a UDF
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Deletes every version and detaches the UDF from all services.\n  Service removal completes asynchronously."
+    )]
+    Delete(UdfNameArgs),
+    /// Attach a UDF to a service
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Replaces the service's attached version; omission selects the latest ready version.\n  The service must be running; wake an idle service before attaching."
+    )]
+    Attach {
+        #[command(flatten)]
+        target: UdfAttachmentArgs,
+        /// UDF version number
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..))]
+        version: Option<i64>,
+    },
+    /// Detach a UDF from a service
+    Detach(UdfAttachmentArgs),
+    /// Manage UDF service attachments
+    Attachment {
+        #[command(subcommand)]
+        command: UdfAttachmentCommands,
+    },
+    /// Manage UDF versions
+    Version {
+        #[command(subcommand)]
+        command: UdfVersionCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UdfAttachmentCommands {
+    /// List UDF attachments
+    List {
+        #[command(flatten)]
+        name: UdfNameArgs,
+        #[command(flatten)]
+        page: UdfPageArgs,
+    },
+    /// Get UDF attachment details
+    Get(UdfAttachmentArgs),
+}
+
+#[derive(Subcommand)]
+pub enum UdfVersionCommands {
+    /// List UDF versions
+    List {
+        #[command(flatten)]
+        name: UdfNameArgs,
+        #[command(flatten)]
+        page: UdfPageArgs,
+    },
+    /// Create a UDF version
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Supply the complete definition; omitted options use defaults, not previous values.\n  Each retry uploads a fresh archive and consumes a new upload session."
+    )]
+    Create {
+        #[command(flatten)]
+        name: UdfNameArgs,
+        #[command(flatten)]
+        input: UdfCreateArgs,
+    },
+    /// Delete a UDF version
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Detach the UDF from every service before deleting a version.\n  The latest version and versions still building cannot be deleted."
+    )]
+    Delete {
+        #[command(flatten)]
+        name: UdfNameArgs,
+        /// UDF version number
+        #[arg(value_parser = clap::value_parser!(i64).range(1..))]
+        version: i64,
+    },
+}
+
+#[derive(Args)]
+pub struct UdfNameArgs {
+    /// UDF function name
+    #[arg(value_parser = parse_udf_name)]
+    function_name: String,
+}
+
+#[derive(Args)]
+pub struct UdfAttachmentArgs {
+    #[command(flatten)]
+    name: UdfNameArgs,
+    /// Service ID
+    service_id: String,
+}
+
+#[derive(Args)]
+pub struct UdfPageArgs {
+    /// Cursor from pagination.nextCursor
+    #[arg(long)]
+    cursor: Option<String>,
+    /// Maximum records per page (1–100)
+    #[arg(long, value_parser = clap::value_parser!(i64).range(1..=100))]
+    limit: Option<i64>,
+}
+
+#[derive(Args)]
+pub struct UdfCreateArgs {
+    /// Complete JSON definition without uploadId (file path or - for stdin)
+    #[arg(long = "config-file", alias = "config")]
+    config: String,
+    /// Source archive path in ZIP format
+    #[arg(long)]
+    artifact: PathBuf,
+}
+
+impl UdfArgs {
+    pub fn is_write(&self) -> bool {
+        match &self.command {
+            UdfCommands::List(_) | UdfCommands::Get(_) => false,
+            UdfCommands::Create(_)
+            | UdfCommands::Delete(_)
+            | UdfCommands::Attach { .. }
+            | UdfCommands::Detach(_) => true,
+            UdfCommands::Attachment { command } => match command {
+                UdfAttachmentCommands::List { .. } | UdfAttachmentCommands::Get(_) => false,
+            },
+            UdfCommands::Version { command } => match command {
+                UdfVersionCommands::List { .. } => false,
+                UdfVersionCommands::Create { .. } | UdfVersionCommands::Delete { .. } => true,
+            },
+        }
+    }
+}
+
+fn parse_udf_name(value: &str) -> Result<String, String> {
+    let mut bytes = value.bytes();
+    if !bytes.next().is_some_and(|b| b.is_ascii_alphabetic())
+        || !bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        return Err("Use a letter followed by letters, digits or underscores".into());
+    }
+    Ok(value.to_owned())
+}
+
+pub async fn run(client: &CloudClient, args: UdfArgs, json: bool) -> CloudResult<()> {
+    // Parse and validate input before even auto-resolving the organization.
+    match args.command {
+        UdfCommands::Create(input) => {
+            let mut request =
+                build_udf_create_request(read_config_value(&input.config)?, "pending")?;
+            let file = open_artifact(&input.artifact).await?;
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            let upload_id = upload_artifact(client, &org, file).await?;
+            match &mut request {
+                UdfCreateRequest::UdfCreateRequestV1(body) => body.upload_id = upload_id,
+                UdfCreateRequest::UdfCreateRequestV2(body) => body.upload_id = upload_id,
+                UdfCreateRequest::Unknown(_) => unreachable!("builder accepts known variants only"),
+            }
+            output(&client.create_udf(&org, &request).await?, json)
+        }
+        UdfCommands::Version {
+            command: UdfVersionCommands::Create { name, input },
+        } => {
+            let mut request =
+                build_udf_version_create_request(read_config_value(&input.config)?, "pending")?;
+            let file = open_artifact(&input.artifact).await?;
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            let upload_id = upload_artifact(client, &org, file).await?;
+            match &mut request {
+                UdfVersionCreateRequest::UdfVersionCreateRequestV1(body) => {
+                    body.upload_id = upload_id
+                }
+                UdfVersionCreateRequest::UdfVersionCreateRequestV2(body) => {
+                    body.upload_id = upload_id
+                }
+                UdfVersionCreateRequest::Unknown(_) => {
+                    unreachable!("builder accepts known variants only")
+                }
+            }
+            output(
+                &client
+                    .create_udf_version(&org, &name.function_name, &request)
+                    .await?,
+                json,
+            )
+        }
+        command => {
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            match command {
+                UdfCommands::List(page) => {
+                    let data = client
+                        .list_udfs(&org, page.cursor.as_deref(), page.limit)
+                        .await?;
+                    if json {
+                        output(&data, true)
+                    } else {
+                        print_udfs(data.items, data.pagination)
+                    }
+                }
+                UdfCommands::Get(name) => {
+                    output(&client.get_udf(&org, &name.function_name).await?, json)
+                }
+                UdfCommands::Delete(name) => {
+                    output(&client.delete_udf(&org, &name.function_name).await?, json)
+                }
+                UdfCommands::Attach { target, version } => output(
+                    &client
+                        .attach_udf(
+                            &org,
+                            &target.name.function_name,
+                            &target.service_id,
+                            version,
+                        )
+                        .await?,
+                    json,
+                ),
+                UdfCommands::Detach(target) => output(
+                    &client
+                        .detach_udf(&org, &target.name.function_name, &target.service_id)
+                        .await?,
+                    json,
+                ),
+                UdfCommands::Attachment { command } => match command {
+                    UdfAttachmentCommands::Get(target) => output(
+                        &client
+                            .get_udf_attachment(
+                                &org,
+                                &target.name.function_name,
+                                &target.service_id,
+                            )
+                            .await?,
+                        json,
+                    ),
+                    UdfAttachmentCommands::List { name, page } => {
+                        let data = client
+                            .list_udf_attachments(
+                                &org,
+                                &name.function_name,
+                                page.cursor.as_deref(),
+                                page.limit,
+                            )
+                            .await?;
+                        if json {
+                            output(&data, true)
+                        } else {
+                            print_attachments(data.items, data.pagination)
+                        }
+                    }
+                },
+                UdfCommands::Version { command } => match command {
+                    UdfVersionCommands::List { name, page } => {
+                        let data = client
+                            .list_udf_versions(
+                                &org,
+                                &name.function_name,
+                                page.cursor.as_deref(),
+                                page.limit,
+                            )
+                            .await?;
+                        if json {
+                            output(&data, true)
+                        } else {
+                            print_udfs(data.items, data.pagination)
+                        }
+                    }
+                    UdfVersionCommands::Delete { name, version } => output(
+                        &client
+                            .delete_udf_version(&org, &name.function_name, version)
+                            .await?,
+                        json,
+                    ),
+                    UdfVersionCommands::Create { .. } => unreachable!("handled above"),
+                },
+                UdfCommands::Create(_) => unreachable!("handled above"),
+            }
+        }
+    }
+}
+
+fn output<T: Serialize>(data: &T, json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(data)?);
+    } else {
+        print_human(data)?;
+    }
+    Ok(())
+}
+
+fn print_udfs(items: Option<Vec<Udf>>, pagination: Option<Pagination>) -> CloudResult<()> {
+    #[derive(Tabled)]
+    struct Row {
+        name: String,
+        version: String,
+        runtime: String,
+        status: String,
+    }
+    if let Some(items) = items {
+        let rows = items.into_iter().map(|item| Row {
+            name: or_absent(item.function_name),
+            version: or_absent(item.version),
+            runtime: or_absent(item.runtime),
+            status: or_absent(item.status),
+        });
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    } else {
+        println!("UDFs: -");
+    }
+    if let Some(page) = pagination {
+        print_human(&page)?;
+    }
+    Ok(())
+}
+
+fn print_attachments(
+    items: Option<Vec<UdfAttachment>>,
+    pagination: Option<Pagination>,
+) -> CloudResult<()> {
+    #[derive(Tabled)]
+    struct Row {
+        name: String,
+        service_id: String,
+        version: String,
+        status: String,
+    }
+    if let Some(items) = items {
+        let rows = items.into_iter().map(|item| Row {
+            name: or_absent(item.function_name),
+            service_id: or_absent(item.service_id),
+            version: or_absent(item.version),
+            status: or_absent(item.status),
+        });
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    } else {
+        println!("Attachments: -");
+    }
+    if let Some(page) = pagination {
+        print_human(&page)?;
+    }
+    Ok(())
+}
+
+fn validate_udf_config(value: &mut Value, upload_id: &str, create: bool) -> CloudResult<String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| CloudError::new("UDF definition must be a JSON object"))?;
+    if object.contains_key("uploadId") {
+        return Err(CloudError::new(
+            "Omit uploadId; --artifact creates a fresh upload session",
+        ));
+    }
+    for name in [
+        "commandReadTimeout",
+        "commandWriteTimeout",
+        "maxCommandExecutionTime",
+        "poolSize",
+        "memoryLimitMib",
+    ] {
+        if let Some(value) = object.get(name).filter(|v| !v.is_null()) {
+            let max = if name == "memoryLimitMib" {
+                1_048_576
+            } else {
+                i64::MAX
+            };
+            if !value.as_i64().is_some_and(|v| (1..=max).contains(&v)) {
+                return Err(CloudError::new(format!(
+                    "UDF {name} must be an integer from 1 to {max}"
+                )));
+            }
+        }
+    }
+    let kind = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| CloudError::new("UDF definition requires type"))?
+        .to_owned();
+    // Option<T> is also used for non-nullable optional request fields; reject
+    // explicit null here instead of silently converting it into omission.
+    for name in [
+        "runtime",
+        "type",
+        "deterministic",
+        "sendChunkHeader",
+        "format",
+        "sandboxType",
+        "sandboxVersion",
+        "commandReadTimeout",
+        "commandWriteTimeout",
+    ] {
+        if object.get(name).is_some_and(Value::is_null) {
+            return Err(CloudError::new(format!("UDF {name} cannot be null")));
+        }
+    }
+    if kind == "executable_pool" {
+        for name in ["poolSize", "maxCommandExecutionTime"] {
+            if object.get(name).is_some_and(Value::is_null) {
+                return Err(CloudError::new(format!(
+                    "UDF {name} cannot be null for executable_pool"
+                )));
+            }
+        }
+    }
+    for name in ["returnName", "functionName"] {
+        if let Some(value) = object.get(name).filter(|v| !v.is_null()) {
+            let valid = value.as_str().is_some_and(|v| parse_udf_name(v).is_ok());
+            if !valid {
+                return Err(CloudError::new(format!("Invalid UDF {name}")));
+            }
+        }
+    }
+    if create && !object.get("functionName").is_some_and(Value::is_string) {
+        return Err(CloudError::new("UDF definition requires functionName"));
+    }
+    if let Some(arguments) = object.get("arguments").and_then(Value::as_array) {
+        for argument in arguments {
+            if argument
+                .get("name")
+                .and_then(Value::as_str)
+                .is_none_or(|v| parse_udf_name(v).is_err())
+            {
+                return Err(CloudError::new("Every UDF argument requires a valid name"));
+            }
+        }
+    }
+    object.insert("uploadId".into(), Value::String(upload_id.to_owned()));
+    Ok(kind)
+}
+
+fn validate_udf_enums(
+    runtime: &UdfRuntime,
+    sandbox_type: Option<&UdfSandboxType>,
+    sandbox_version: Option<&UdfSandboxVersion>,
+) -> CloudResult<()> {
+    if matches!(runtime, UdfRuntime::Unknown(_)) {
+        return Err(CloudError::new("Unsupported UDF runtime"));
+    }
+    if matches!(sandbox_type, Some(UdfSandboxType::Unknown(_))) {
+        return Err(CloudError::new("Unsupported UDF sandboxType"));
+    }
+    if matches!(sandbox_version, Some(UdfSandboxVersion::Unknown(_))) {
+        return Err(CloudError::new("Unsupported UDF sandboxVersion"));
+    }
+    Ok(())
+}
+
+fn build_udf_create_request(mut value: Value, upload_id: &str) -> CloudResult<UdfCreateRequest> {
+    match validate_udf_config(&mut value, upload_id, true)?.as_str() {
+        "executable" => {
+            let body: UdfCreateRequestV1 = deserialize_strict_config(value, "UDF definition")?;
+            validate_udf_enums(
+                &body.runtime,
+                body.sandbox_type.as_ref(),
+                body.sandbox_version.as_ref(),
+            )?;
+            Ok(UdfCreateRequest::UdfCreateRequestV1(body))
+        }
+        "executable_pool" => {
+            let body: UdfCreateRequestV2 = deserialize_strict_config(value, "UDF definition")?;
+            validate_udf_enums(
+                &body.runtime,
+                body.sandbox_type.as_ref(),
+                body.sandbox_version.as_ref(),
+            )?;
+            Ok(UdfCreateRequest::UdfCreateRequestV2(body))
+        }
+        _ => Err(CloudError::new("Unsupported UDF type")),
+    }
+}
+
+fn build_udf_version_create_request(
+    mut value: Value,
+    upload_id: &str,
+) -> CloudResult<UdfVersionCreateRequest> {
+    match validate_udf_config(&mut value, upload_id, false)?.as_str() {
+        "executable" => {
+            let body: UdfVersionCreateRequestV1 =
+                deserialize_strict_config(value, "UDF definition")?;
+            validate_udf_enums(
+                &body.runtime,
+                body.sandbox_type.as_ref(),
+                body.sandbox_version.as_ref(),
+            )?;
+            Ok(UdfVersionCreateRequest::UdfVersionCreateRequestV1(body))
+        }
+        "executable_pool" => {
+            let body: UdfVersionCreateRequestV2 =
+                deserialize_strict_config(value, "UDF definition")?;
+            validate_udf_enums(
+                &body.runtime,
+                body.sandbox_type.as_ref(),
+                body.sandbox_version.as_ref(),
+            )?;
+            Ok(UdfVersionCreateRequest::UdfVersionCreateRequestV2(body))
+        }
+        _ => Err(CloudError::new("Unsupported UDF type")),
+    }
+}
+
+async fn open_artifact(path: &std::path::Path) -> CloudResult<tokio::fs::File> {
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|_| CloudError::new("Cannot open UDF ZIP archive"))?;
+    let metadata = file
+        .metadata()
+        .await
+        .map_err(|_| CloudError::new("Cannot inspect UDF ZIP archive"))?;
+    if !metadata.is_file() || metadata.len() == 0 {
+        return Err(CloudError::new("UDF ZIP archive must be a nonempty file"));
+    }
+    Ok(file)
+}
+
+async fn upload_artifact(
+    client: &CloudClient,
+    org: &str,
+    file: tokio::fs::File,
+) -> CloudResult<String> {
+    let session = client.create_udf_upload_session(org).await?;
+    let id = session
+        .upload_id
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            CloudError::new("Upload session omitted uploadId; retry to create a fresh session")
+        })?;
+    let url = session.upload_url.ok_or_else(|| {
+        CloudError::new("Upload session omitted uploadUrl; retry to create a fresh session")
+    })?;
+    let url = reqwest::Url::parse(&url)
+        .map_err(|_| CloudError::new("Upload session returned an invalid URL"))?;
+    let local = url
+        .host_str()
+        .is_some_and(|host| matches!(host, "localhost" | "127.0.0.1" | "[::1]"));
+    if (url.scheme() != "https" && !(cfg!(debug_assertions) && local && url.scheme() == "http"))
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(CloudError::new(
+            "Upload session requires an HTTPS URL without user credentials or a fragment",
+        ));
+    }
+    let length = file
+        .metadata()
+        .await
+        .map_err(|_| CloudError::new("Cannot inspect UDF ZIP archive"))?
+        .len();
+    // Dedicated client: Cloud API authentication never reaches the artifact
+    // host. Do not follow redirects, retry single-use uploads, print the URL,
+    // expose transport errors containing it, or echo storage response bodies.
+    let upload_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .retry(reqwest::retry::never())
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|_| CloudError::new("Cannot initialize artifact upload"))?;
+    let response = upload_client
+        .put(url)
+        .header(reqwest::header::CONTENT_TYPE, "application/zip")
+        .header(reqwest::header::CONTENT_LENGTH, length)
+        .body(file)
+        .send()
+        .await
+        .map_err(|_| CloudError::new("Artifact upload failed; retry to create a fresh session"))?;
+    if !response.status().is_success() {
+        return Err(CloudError::new(format!(
+            "Artifact upload failed (HTTP {}); retry to create a fresh session",
+            response.status().as_u16()
+        )));
+    }
+    Ok(id)
+}
+
+impl CloudClient {
+    async fn list_udfs(
+        &self,
+        org: &str,
+        cursor: Option<&str>,
+        limit: Option<i64>,
+    ) -> CloudResult<UdfListResponse> {
+        let response = self
+            .api()
+            .udf_list(org, cursor, limit)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn get_udf(&self, org: &str, name: &str) -> CloudResult<Udf> {
+        let response = self
+            .api()
+            .udf_get(org, name)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn delete_udf(&self, org: &str, name: &str) -> CloudResult<DeleteResponse> {
+        let response = self
+            .api()
+            .udf_delete(org, name)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+    async fn list_udf_attachments(
+        &self,
+        org: &str,
+        name: &str,
+        cursor: Option<&str>,
+        limit: Option<i64>,
+    ) -> CloudResult<UdfAttachmentListResponse> {
+        let response = self
+            .api()
+            .udf_attachment_list(org, name, cursor, limit)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn get_udf_attachment(
+        &self,
+        org: &str,
+        name: &str,
+        service: &str,
+    ) -> CloudResult<UdfAttachment> {
+        let response = self
+            .api()
+            .udf_attachment_get(org, name, service)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn attach_udf(
+        &self,
+        org: &str,
+        name: &str,
+        service: &str,
+        version: Option<i64>,
+    ) -> CloudResult<UdfAttachment> {
+        let response = self
+            .api()
+            .udf_attach(org, name, service, version)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn detach_udf(
+        &self,
+        org: &str,
+        name: &str,
+        service: &str,
+    ) -> CloudResult<DeleteResponse> {
+        let response = self
+            .api()
+            .udf_detach(org, name, service)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+    async fn list_udf_versions(
+        &self,
+        org: &str,
+        name: &str,
+        cursor: Option<&str>,
+        limit: Option<i64>,
+    ) -> CloudResult<UdfVersionListResponse> {
+        let response = self
+            .api()
+            .udf_version_list(org, name, cursor, limit)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn delete_udf_version(
+        &self,
+        org: &str,
+        name: &str,
+        version: i64,
+    ) -> CloudResult<DeleteResponse> {
+        let response = self
+            .api()
+            .udf_version_delete(org, name, version)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+    async fn create_udf(&self, org: &str, body: &UdfCreateRequest) -> CloudResult<Udf> {
+        let response = self
+            .api()
+            .udf_create(org, body)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn create_udf_version(
+        &self,
+        org: &str,
+        name: &str,
+        body: &UdfVersionCreateRequest,
+    ) -> CloudResult<Udf> {
+        let response = self
+            .api()
+            .udf_version_create(org, name, body)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn create_udf_upload_session(&self, org: &str) -> CloudResult<UdfUploadSession> {
+        let response = self
+            .api()
+            .udf_upload_session_create(org)
+            .await
+            .map_err(|error| {
+                let error = self.convert_error_for_organization(error, org);
+                CloudError {
+                    message: "Could not create UDF upload session; retry to create a fresh session"
+                        .into(),
+                    details: None,
+                    ..error
+                }
+            })?;
+        Self::unwrap_response(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use crate::cloud::cli::CloudCommands;
+    use clap::Parser;
+    use serde_json::json;
+
+    fn definition(kind: &str, create: bool) -> Value {
+        let mut value = json!({"type": kind, "runtime": "native", "arguments": [{"name": "x", "type": "UInt64"}], "returnType": "UInt64"});
+        if create {
+            value["functionName"] = json!("my_udf");
+        }
+        value
+    }
+
+    #[test]
+    fn udf_builders_cover_minimal_and_maximal_variants() {
+        for create in [true, false] {
+            for kind in ["executable", "executable_pool"] {
+                for full in [false, true] {
+                    let mut input = definition(kind, create);
+                    if full {
+                        input.as_object_mut().unwrap().extend(json!({
+                            "commandReadTimeout": 5000, "commandWriteTimeout": 6000,
+                            "memoryLimitMib": 128, "deterministic": false,
+                            "sendChunkHeader": false, "format": "JSONEachRow", "returnName": "result",
+                            "sandboxType": "netenable", "sandboxVersion": "v3",
+                            "maxCommandExecutionTime": 20,
+                            "poolSize": if kind == "executable_pool" { json!(4) } else { Value::Null }
+                        }).as_object().unwrap().clone());
+                    }
+                    let output = if create {
+                        let request = build_udf_create_request(input.clone(), "upload-1").unwrap();
+                        match &request {
+                            UdfCreateRequest::UdfCreateRequestV1(body) => {
+                                assert_eq!(body.upload_id, "upload-1");
+                                assert_eq!(body.deterministic, full.then_some(false));
+                                assert_eq!(body.memory_limit_mib, full.then_some(128));
+                            }
+                            UdfCreateRequest::UdfCreateRequestV2(body) => {
+                                assert_eq!(body.pool_size, full.then_some(4));
+                                assert_eq!(body.memory_limit_mib, full.then_some(128));
+                            }
+                            _ => panic!("unexpected union variant"),
+                        }
+                        serde_json::to_value(request).unwrap()
+                    } else {
+                        let request =
+                            build_udf_version_create_request(input.clone(), "upload-1").unwrap();
+                        match &request {
+                            UdfVersionCreateRequest::UdfVersionCreateRequestV1(body) => {
+                                assert_eq!(body.upload_id, "upload-1");
+                                assert_eq!(body.deterministic, full.then_some(false));
+                                assert_eq!(body.memory_limit_mib, full.then_some(128));
+                            }
+                            UdfVersionCreateRequest::UdfVersionCreateRequestV2(body) => {
+                                assert_eq!(body.pool_size, full.then_some(4));
+                                assert_eq!(body.memory_limit_mib, full.then_some(128));
+                            }
+                            _ => panic!("unexpected union variant"),
+                        }
+                        serde_json::to_value(request).unwrap()
+                    };
+                    input["uploadId"] = json!("upload-1");
+                    if kind == "executable" {
+                        input.as_object_mut().unwrap().remove("poolSize");
+                    }
+                    assert_eq!(output, input);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn udf_builders_reject_lossy_or_incomplete_requests() {
+        for (key, value) in [
+            ("type", json!("future")),
+            ("runtime", json!("future")),
+            ("sandboxType", json!("future")),
+            ("sandboxVersion", json!("future")),
+            ("deterministic", Value::Null),
+            ("deterministic", json!("false")),
+            ("memoryLimitMib", json!(0)),
+            ("memoryLimitMib", json!(1048577)),
+            ("commandReadTimeout", json!(-1)),
+            ("poolSize", json!(2)),
+            ("typo", Value::Null),
+            ("uploadId", json!("old")),
+            (
+                "arguments",
+                json!([{"name": "x", "type": "String", "typo": null}]),
+            ),
+            ("functionName", json!("../oops")),
+        ] {
+            let mut input = definition("executable", true);
+            input[key] = value;
+            assert!(build_udf_create_request(input, "fresh").is_err(), "{key}");
+        }
+        for required in ["type", "runtime", "arguments", "returnType", "functionName"] {
+            let mut input = definition("executable", true);
+            input.as_object_mut().unwrap().remove(required);
+            assert!(
+                build_udf_create_request(input, "fresh").is_err(),
+                "{required}"
+            );
+        }
+        assert!(build_udf_version_create_request(json!({}), "fresh").is_err());
+        assert!(build_udf_version_create_request(definition("executable", true), "fresh").is_err());
+        let mut nullable = definition("executable", true);
+        nullable["memoryLimitMib"] = Value::Null;
+        assert!(build_udf_create_request(nullable, "fresh").is_ok());
+    }
+
+    #[test]
+    fn udf_clap_auth_classification_and_values() {
+        for (args, write) in [
+            (vec!["list", "--cursor", "next", "--limit", "2"], false),
+            (vec!["get", "my_udf"], false),
+            (vec!["delete", "my_udf"], true),
+            (
+                vec!["create", "--config-file", "-", "--artifact", "code.zip"],
+                true,
+            ),
+            (vec!["attach", "my_udf", "svc-1", "--version", "2"], true),
+            (vec!["detach", "my_udf", "svc-1"], true),
+            (
+                vec![
+                    "attachment",
+                    "list",
+                    "my_udf",
+                    "--cursor",
+                    "next",
+                    "--limit",
+                    "100",
+                ],
+                false,
+            ),
+            (vec!["attachment", "get", "my_udf", "svc-1"], false),
+            (vec!["version", "list", "my_udf"], false),
+            (
+                vec![
+                    "version",
+                    "create",
+                    "my_udf",
+                    "--config-file",
+                    "file.json",
+                    "--artifact",
+                    "code.zip",
+                ],
+                true,
+            ),
+            (vec!["version", "delete", "my_udf", "3"], true),
+        ] {
+            let mut all = vec!["chctl", "cloud", "udf"];
+            all.extend(args);
+            all.extend(["--org-id", "org-1"]);
+            let cli = Cli::try_parse_from(all).unwrap();
+            let Commands::Cloud(cloud) = cli.command else {
+                panic!("cloud");
+            };
+            assert_eq!(cloud.command.is_write_command(), write);
+            let CloudCommands::Udf(udf) = cloud.command else {
+                panic!("udf");
+            };
+            assert_eq!(udf.org_id.as_deref(), Some("org-1"));
+            match udf.command {
+                UdfCommands::List(page) => {
+                    assert_eq!(page.cursor.as_deref(), Some("next"));
+                    assert_eq!(page.limit, Some(2));
+                }
+                UdfCommands::Create(input) => {
+                    assert_eq!(input.config, "-");
+                    assert_eq!(input.artifact, PathBuf::from("code.zip"));
+                }
+                UdfCommands::Attach { version, .. } => assert_eq!(version, Some(2)),
+                UdfCommands::Version {
+                    command: UdfVersionCommands::Create { input, .. },
+                } => {
+                    assert_eq!(input.config, "file.json");
+                    assert_eq!(input.artifact, PathBuf::from("code.zip"));
+                }
+                _ => {}
+            }
+        }
+        for args in [
+            vec!["list", "--limit", "0"],
+            vec!["list", "--limit", "101"],
+            vec!["attach", "my_udf", "svc-1", "--version", "0"],
+            vec!["version", "delete", "my_udf", "0"],
+            vec!["get", "../oops"],
+            vec!["create", "--config-file", "config.json"],
+        ] {
+            assert!(
+                Cli::try_parse_from(["chctl", "cloud", "udf"].into_iter().chain(args)).is_err()
+            );
+        }
+    }
+}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -14011,3 +14011,629 @@ async fn clickstack_human_lists_render_sparse_fields_and_api_errors_include_org(
         "{error}"
     );
 }
+
+// UDF operations and artifact uploads run against separate hosts so auth and
+// presigned-query isolation are exercised by the real executable.
+fn udf_test_command(
+    server: &MockServer,
+    project: &Path,
+    oauth: bool,
+    json: bool,
+    args: &[&str],
+) -> Command {
+    let home = project.join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    if oauth {
+        write_oauth_tokens(&cloud_dir, &server.uri());
+    }
+    let mut cmd = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut cmd);
+    cmd.env("HOME", home)
+        .env("DO_NOT_TRACK", "1")
+        .current_dir(project)
+        .args(["cloud", "--url", &server.uri()]);
+    if !oauth {
+        cmd.args(["--api-key", "udf-key", "--api-secret", "udf-secret"]);
+    }
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.args(["udf", "--org-id", "org-1"])
+        .args(args)
+        .stdin(Stdio::null());
+    cmd
+}
+
+fn udf_definition(kind: &str, create: bool) -> Value {
+    let mut value = serde_json::json!({"type": kind, "runtime": "native", "arguments": [{"name": "x", "type": "UInt64"}], "returnType": "UInt64"});
+    if create {
+        value["functionName"] = serde_json::json!("my_udf");
+    }
+    value
+}
+
+#[tokio::test]
+async fn udf_all_reads_preserve_pagination_and_sparse_responses_with_oauth() {
+    for (args, suffix, list) in [
+        (vec!["list"], "", true),
+        (vec!["get", "my_udf"], "/my_udf", false),
+        (
+            vec!["attachment", "list", "my_udf"],
+            "/my_udf/attachments",
+            true,
+        ),
+        (
+            vec!["attachment", "get", "my_udf", "svc-1"],
+            "/my_udf/attachments/svc-1",
+            false,
+        ),
+        (vec!["version", "list", "my_udf"], "/my_udf/versions", true),
+    ] {
+        for sparse in [false, true] {
+            let server = MockServer::start().await;
+            let project = tempfile::tempdir().unwrap();
+            let item = if sparse {
+                serde_json::json!({})
+            } else {
+                serde_json::json!({"functionName":"my_udf", "serviceId":"svc-1", "version":2, "status":"future", "deterministic":false})
+            };
+            let result = if list {
+                serde_json::json!({"items": [item], "pagination":{"nextCursor":"next page", "limit":2, "totalRecords":3}})
+            } else {
+                item
+            };
+            Mock::given(method("GET"))
+                .and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+                .and(header("authorization", "Bearer test-bearer-token"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":result})),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            let mut args = args.clone();
+            if list {
+                args.extend(["--cursor", "page /+?", "--limit", "2"]);
+            }
+            let output = udf_test_command(&server, project.path(), true, true, &args)
+                .output()
+                .unwrap();
+            assert_success(&output);
+            let output: Value = serde_json::from_slice(&output.stdout).unwrap();
+            if list {
+                assert_eq!(output["pagination"], result["pagination"]);
+                assert_eq!(output["items"][0]["status"], result["items"][0]["status"]);
+                let req = server.received_requests().await.unwrap().pop().unwrap();
+                let query: std::collections::HashMap<_, _> =
+                    req.url.query_pairs().into_owned().collect();
+                assert_eq!(query.get("cursor").map(String::as_str), Some("page /+?"));
+                assert_eq!(query.get("limit").map(String::as_str), Some("2"));
+            } else {
+                assert_eq!(output["status"], result["status"]);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn udf_delete_attach_detach_methods_and_auth() {
+    for (args, suffix, verb, expected_body) in [
+        (vec!["delete", "my_udf"], "/my_udf", "DELETE", None),
+        (
+            vec!["version", "delete", "my_udf", "2"],
+            "/my_udf/versions/2",
+            "DELETE",
+            None,
+        ),
+        (
+            vec!["detach", "my_udf", "svc-1"],
+            "/my_udf/attachments/svc-1",
+            "DELETE",
+            None,
+        ),
+        (
+            vec!["attach", "my_udf", "svc-1"],
+            "/my_udf/attachments/svc-1",
+            "PUT",
+            Some(serde_json::json!({})),
+        ),
+        (
+            vec!["attach", "my_udf", "svc-1", "--version", "2"],
+            "/my_udf/attachments/svc-1",
+            "PUT",
+            Some(serde_json::json!({"version":2})),
+        ),
+    ] {
+        let server = MockServer::start().await;
+        let project = tempfile::tempdir().unwrap();
+        Mock::given(method(verb))
+            .and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+            .and(header("authorization", "Basic dWRmLWtleTp1ZGYtc2VjcmV0"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(if verb == "DELETE" {
+                    serde_json::json!({"status":200,"requestId":"delete-request"})
+                } else {
+                    serde_json::json!({"result":{}})
+                }),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        assert_success(
+            &udf_test_command(&server, project.path(), false, true, &args)
+                .output()
+                .unwrap(),
+        );
+        let request = server.received_requests().await.unwrap().pop().unwrap();
+        match expected_body {
+            Some(body) => assert_eq!(
+                serde_json::from_slice::<Value>(&request.body).unwrap(),
+                body
+            ),
+            None => assert!(request.body.is_empty()),
+        }
+    }
+}
+
+#[tokio::test]
+async fn udf_create_and_version_upload_full_definitions_without_auth_leakage() {
+    for create in [true, false] {
+        for kind in ["executable", "executable_pool"] {
+            let server = MockServer::start().await;
+            let storage = MockServer::start().await;
+            let project = tempfile::tempdir().unwrap();
+            let archive = b"PK\x03\x04test archive";
+            std::fs::write(project.path().join("code.zip"), archive).unwrap();
+            let mut definition = udf_definition(kind, create);
+            definition.as_object_mut().unwrap().extend(serde_json::json!({
+                "commandReadTimeout": 5000, "commandWriteTimeout": 6000, "memoryLimitMib": 128,
+                "deterministic": false, "sendChunkHeader": false, "returnName":"result", "format":"JSONEachRow",
+                "sandboxType":"netenable", "sandboxVersion":"v3", "maxCommandExecutionTime":20,
+                "poolSize": if kind == "executable_pool" { serde_json::json!(4) } else { Value::Null }
+            }).as_object().unwrap().clone());
+            std::fs::write(
+                project.path().join("definition.json"),
+                definition.to_string(),
+            )
+            .unwrap();
+            Mock::given(method("POST")).and(path("/v1/organizations/org-1/udfUploads/url"))
+                .and(header("authorization", "Basic dWRmLWtleTp1ZGYtc2VjcmV0"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":{
+                    "uploadId":"fresh-upload", "uploadUrl":format!("{}/artifact?signature=upload-secret", storage.uri())
+                }}))).expect(1).mount(&server).await;
+            Mock::given(method("PUT"))
+                .and(path("/artifact"))
+                .and(header("content-type", "application/zip"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(1)
+                .mount(&storage)
+                .await;
+            let mut expected = definition;
+            expected["uploadId"] = serde_json::json!("fresh-upload");
+            if kind == "executable" {
+                expected.as_object_mut().unwrap().remove("poolSize");
+            }
+            let suffix = if create { "" } else { "/my_udf/versions" };
+            Mock::given(method("POST")).and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+                .and(header("authorization", "Basic dWRmLWtleTp1ZGYtc2VjcmV0"))
+                .and(body_json(expected))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"result":{"functionName":"my_udf","version":2,"status":"building","deterministic":false}})))
+                .expect(1).mount(&server).await;
+            let mut args = if create {
+                vec!["create"]
+            } else {
+                vec!["version", "create", "my_udf"]
+            };
+            args.extend([
+                "--config-file",
+                "definition.json",
+                "--artifact",
+                "code.zip",
+                "--debug",
+            ]);
+            let output = udf_test_command(&server, project.path(), false, true, &args)
+                .output()
+                .unwrap();
+            assert_success(&output);
+            assert_eq!(
+                serde_json::from_slice::<Value>(&output.stdout).unwrap()["deterministic"],
+                false
+            );
+            let upload = storage.received_requests().await.unwrap().pop().unwrap();
+            assert_eq!(upload.body, archive);
+            assert_eq!(upload.url.query(), Some("signature=upload-secret"));
+            assert!(!upload.headers.contains_key("authorization"));
+            assert!(!upload.headers.contains_key("cookie"));
+            let logged = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            for secret in ["upload-secret", "fresh-upload", "udf-key", "udf-secret"] {
+                assert!(!logged.contains(secret), "leaked {secret}");
+            }
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 2);
+            assert!(requests[0].body.is_empty());
+        }
+    }
+}
+
+#[tokio::test]
+async fn udf_upload_failures_never_create_or_leak_presigned_url() {
+    for scenario in [
+        "missing_id",
+        "missing_url",
+        "bad_url",
+        "credentials",
+        "redirect",
+        "storage_error",
+        "connection_error",
+        "session_error",
+    ] {
+        let server = MockServer::start().await;
+        let storage = MockServer::start().await;
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("code.zip"), b"PK\x03\x04archive").unwrap();
+        std::fs::write(
+            project.path().join("definition.json"),
+            udf_definition("executable", true).to_string(),
+        )
+        .unwrap();
+        let url = match scenario {
+            "bad_url" => "not-a-url?signature=upload-secret".to_string(),
+            "credentials" => "https://user:upload-secret@example.com/code".to_string(),
+            "connection_error" => "http://127.0.0.1:1/code?signature=upload-secret".to_string(),
+            _ => format!("{}/code?signature=upload-secret", storage.uri()),
+        };
+        let mut session = serde_json::json!({"uploadId":"upload-1","uploadUrl":url});
+        if scenario == "missing_id" {
+            session.as_object_mut().unwrap().remove("uploadId");
+        }
+        if scenario == "missing_url" {
+            session.as_object_mut().unwrap().remove("uploadUrl");
+        }
+        let response = if scenario == "session_error" {
+            ResponseTemplate::new(503).set_body_json(
+                serde_json::json!({"error":"session unavailable signature=upload-secret"}),
+            )
+        } else {
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":session}))
+        };
+        Mock::given(method("POST"))
+            .and(path("/v1/organizations/org-1/udfUploads/url"))
+            .respond_with(response)
+            .expect(1)
+            .mount(&server)
+            .await;
+        let response = if scenario == "redirect" {
+            ResponseTemplate::new(307).insert_header(
+                "location",
+                format!("{}/redirected?signature=upload-secret", storage.uri()),
+            )
+        } else {
+            ResponseTemplate::new(403).set_body_string("signature=upload-secret")
+        };
+        Mock::given(method("PUT"))
+            .and(path("/code"))
+            .respond_with(response)
+            .mount(&storage)
+            .await;
+        let output = udf_test_command(
+            &server,
+            project.path(),
+            false,
+            true,
+            &[
+                "create",
+                "--config-file",
+                "definition.json",
+                "--artifact",
+                "code.zip",
+                "--debug",
+            ],
+        )
+        .output()
+        .unwrap();
+        assert_eq!(output.status.code(), Some(1), "{scenario}");
+        let logged = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!logged.contains("upload-secret"), "{scenario}: {logged}");
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+        assert!(storage.received_requests().await.unwrap().len() <= 1);
+    }
+}
+
+#[tokio::test]
+async fn udf_invalid_definition_and_artifact_fail_before_api() {
+    let server = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(project.path().join("code.zip"), b"PK\x03\x04archive").unwrap();
+    for definition in [
+        serde_json::json!({}),
+        serde_json::json!({"functionName":"sparse_get","version":3}),
+        serde_json::json!({"type":"future","runtime":"native","arguments":[],"returnType":"UInt64","functionName":"my_udf"}),
+        serde_json::json!({"type":"executable","runtime":"native","arguments":[{"name":"x","type":"UInt64","typo":null}],"returnType":"UInt64","functionName":"my_udf"}),
+    ] {
+        std::fs::write(
+            project.path().join("definition.json"),
+            definition.to_string(),
+        )
+        .unwrap();
+        let output = udf_test_command(
+            &server,
+            project.path(),
+            false,
+            true,
+            &[
+                "create",
+                "--config-file",
+                "definition.json",
+                "--artifact",
+                "code.zip",
+            ],
+        )
+        .output()
+        .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+    }
+    std::fs::write(
+        project.path().join("definition.json"),
+        udf_definition("executable", true).to_string(),
+    )
+    .unwrap();
+    let output = udf_test_command(
+        &server,
+        project.path(),
+        false,
+        true,
+        &[
+            "create",
+            "--config-file",
+            "definition.json",
+            "--artifact",
+            "missing.zip",
+        ],
+    )
+    .output()
+    .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn udf_every_write_rejects_oauth_before_api() {
+    let server = MockServer::start().await;
+    for args in [
+        vec!["delete", "my_udf"],
+        vec!["detach", "my_udf", "svc-1"],
+        vec!["attach", "my_udf", "svc-1"],
+        vec!["version", "delete", "my_udf", "2"],
+        vec![
+            "create",
+            "--config-file",
+            "missing",
+            "--artifact",
+            "missing",
+        ],
+        vec![
+            "version",
+            "create",
+            "my_udf",
+            "--config-file",
+            "missing",
+            "--artifact",
+            "missing",
+        ],
+    ] {
+        let project = tempfile::tempdir().unwrap();
+        assert_eq!(
+            udf_test_command(&server, project.path(), true, true, &args)
+                .output()
+                .unwrap()
+                .status
+                .code(),
+            Some(4)
+        );
+    }
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn udf_all_read_and_action_errors_preserve_exit_codes() {
+    for (args, verb, suffix) in [
+        (vec!["list"], "GET", ""),
+        (vec!["get", "my_udf"], "GET", "/my_udf"),
+        (
+            vec!["attachment", "list", "my_udf"],
+            "GET",
+            "/my_udf/attachments",
+        ),
+        (
+            vec!["attachment", "get", "my_udf", "svc-1"],
+            "GET",
+            "/my_udf/attachments/svc-1",
+        ),
+        (vec!["version", "list", "my_udf"], "GET", "/my_udf/versions"),
+        (vec!["delete", "my_udf"], "DELETE", "/my_udf"),
+        (
+            vec!["detach", "my_udf", "svc-1"],
+            "DELETE",
+            "/my_udf/attachments/svc-1",
+        ),
+        (
+            vec!["version", "delete", "my_udf", "2"],
+            "DELETE",
+            "/my_udf/versions/2",
+        ),
+        (
+            vec!["attach", "my_udf", "svc-1"],
+            "PUT",
+            "/my_udf/attachments/svc-1",
+        ),
+    ] {
+        for status in [403, 424] {
+            let server = MockServer::start().await;
+            let project = tempfile::tempdir().unwrap();
+            Mock::given(method(verb))
+                .and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+                .respond_with(
+                    ResponseTemplate::new(status)
+                        .set_body_json(serde_json::json!({"error":"dependency unavailable"})),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            let output = udf_test_command(&server, project.path(), false, true, &args)
+                .output()
+                .unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(if status == 403 { 4 } else { 1 })
+            );
+            assert!(String::from_utf8_lossy(&output.stderr).contains("dependency unavailable"));
+        }
+    }
+}
+
+#[tokio::test]
+async fn udf_create_api_failures_consume_one_upload_attempt() {
+    for create in [true, false] {
+        let server = MockServer::start().await;
+        let storage = MockServer::start().await;
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("code.zip"), b"PK\x03\x04archive").unwrap();
+        std::fs::write(
+            project.path().join("definition.json"),
+            udf_definition("executable", create).to_string(),
+        )
+        .unwrap();
+        Mock::given(method("POST")).and(path("/v1/organizations/org-1/udfUploads/url"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":{
+                "uploadId":"one-attempt", "uploadUrl":format!("{}/code?signature=upload-secret", storage.uri())
+            }}))).expect(1).mount(&server).await;
+        Mock::given(method("PUT"))
+            .and(path("/code"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&storage)
+            .await;
+        let suffix = if create { "" } else { "/my_udf/versions" };
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+            .respond_with(
+                ResponseTemplate::new(424)
+                    .set_body_json(serde_json::json!({"error":"build dependency unavailable"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut args = if create {
+            vec!["create"]
+        } else {
+            vec!["version", "create", "my_udf"]
+        };
+        args.extend(["--config-file", "definition.json", "--artifact", "code.zip"]);
+        let output = udf_test_command(&server, project.path(), false, true, &args)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("build dependency unavailable"));
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+}
+
+#[tokio::test]
+async fn udf_stdin_minimal_definition_and_sparse_human_output() {
+    let server = MockServer::start().await;
+    let storage = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(project.path().join("code.zip"), b"PK\x03\x04archive").unwrap();
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/udfUploads/url"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":{
+                "uploadId":"fresh-upload", "uploadUrl":format!("{}/code", storage.uri())
+            }})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/code"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&storage)
+        .await;
+    let mut expected = udf_definition("executable", true);
+    expected["uploadId"] = serde_json::json!("fresh-upload");
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/udfs"))
+        .and(body_json(expected))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"result":{}})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let mut cmd = udf_test_command(
+        &server,
+        project.path(),
+        false,
+        false,
+        &["create", "--config-file", "-", "--artifact", "code.zip"],
+    );
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(udf_definition("executable", true).to_string().as_bytes())
+        .unwrap();
+    assert_success(&child.wait_with_output().unwrap());
+    for (args, suffix, result) in [
+        (
+            vec!["get", "my_udf"],
+            "/my_udf",
+            serde_json::json!({"functionName":null}),
+        ),
+        (
+            vec!["list"],
+            "",
+            serde_json::json!({"items":[{}],"pagination":{"nextCursor":"next"}}),
+        ),
+        (
+            vec!["attachment", "list", "my_udf"],
+            "/my_udf/attachments",
+            serde_json::json!({"items":[{}]}),
+        ),
+        (
+            vec!["version", "list", "my_udf"],
+            "/my_udf/versions",
+            serde_json::json!({"items":null,"pagination":null}),
+        ),
+    ] {
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/organizations/org-1/udfs{suffix}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":result})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = udf_test_command(&server, project.path(), false, false, &args)
+            .output()
+            .unwrap();
+        assert_success(&output);
+        if args == vec!["list"] {
+            assert!(String::from_utf8_lossy(&output.stdout).contains("next"));
+        }
+        let request = server.received_requests().await.unwrap().pop().unwrap();
+        assert!(request.url.query().is_none());
+    }
+}

--- a/scripts/classify-cloud-integration.py
+++ b/scripts/classify-cloud-integration.py
@@ -16,6 +16,7 @@ NO_SUITES = frozenset()
 SOURCE_PATH_SUITES = {
     "crates/clickhousectl/src/cloud/clickstack.rs": NO_SUITES,
     "crates/clickhousectl/src/cloud/config.rs": NO_SUITES,
+    "crates/clickhousectl/src/cloud/udfs.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/src/client.rs": ALL_SUITES,
     "crates/clickhouse-cloud-api/src/client/activity.rs": frozenset({"organization"}),
     "crates/clickhouse-cloud-api/src/client/api_keys.rs": frozenset(

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -44,6 +44,7 @@ NON_INSTALL_EXACT_PATHS = frozenset(
     {
         "crates/clickhousectl/src/cloud/clickstack.rs",
         "crates/clickhousectl/src/cloud/config.rs",
+        "crates/clickhousectl/src/cloud/udfs.rs",
         "crates/clickhousectl/src/dotenv.rs",
         "crates/clickhousectl/src/failure.rs",
         "crates/clickhousectl/src/local/config.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -117,6 +117,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
                 {
                     "crates/clickhousectl/src/cloud/clickstack.rs",
                     "crates/clickhousectl/src/cloud/config.rs",
+                    "crates/clickhousectl/src/cloud/udfs.rs",
                     "crates/clickhousectl/src/dotenv.rs",
                     "crates/clickhousectl/src/failure.rs",
                     "crates/clickhousectl/src/local/config.rs",


### PR DESCRIPTION
Add `cloud udf` for the complete beta UDF lifecycle: list/get/create/delete, version list/create/delete, attach/detach, and attachment list/get. Upload-session creation is internal plumbing, covering all 12 existing API operations.

`create` and `version create` accept a complete `--config-file` JSON definition (or `-` for stdin) and a ZIP `--artifact`. Shared strict input validation dispatches to the library's concrete executable variants, rejects unknown fields and enum variants, and preserves all supported definition fields, including explicit false and nullable memory limits. Version creation documents defaults rather than inheriting an earlier version. Each attempt creates a fresh session, streams the archive with application/zip, and submits its upload ID only after a successful upload.

A dedicated upload client sends no Cloud API credentials, refuses redirects, performs no retries, and keeps upload URLs and storage error bodies out of output. Cloud handlers use organization-aware wrappers and existing error conversion. Deletes accept the actual status/requestId-only success envelope. Reads support OAuth; all writes reject it before HTTP. List output retains cursors and pagination, and detail output tolerates sparse responses and future status values.

Validation: cargo fmt; default clippy; complete clickhousectl tests; no-default-features check and all-target clippy; 91 Python tests. New coverage includes all request paths/auth/errors, both complete UDF variants, minimal input, stdin, sparse human/JSON output, all list pagination parameters, every OAuth write restriction, post-upload 424 failures, missing upload metadata, failed/redirected uploads, and credential/presigned-URL isolation.

Depends on the UDF library/analyzer prerequisite (#710) and shared configuration foundation for #692. Closes #571.
