### PR TITLE
feat(cli): explicitly clear Cloud roles, allowlists, tags and DNS mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,10 @@ clickhousectl cloud postgres update <pg-id> \
   --size c6gd.4xlarge \
   --ha-type sync \
   --add-tag env=prod --remove-tag legacy
+clickhousectl cloud postgres update <pg-id> --clear-tags
+
+# --clear-tags replaces the tag list with an empty list and conflicts with
+# --add-tag and --remove-tag; omitting all three leaves tags unchanged.
 
 # Delete (works from any state, including running; no stop needed first)
 clickhousectl cloud postgres delete <pg-id>
@@ -1418,9 +1422,11 @@ clickhousectl cloud clickpipe reverse-private-endpoint create <service-id> \
   --custom-private-dns-mapping db.example.com \
   --custom-private-dns-mapping '*.example.com'
 
-# Replace the custom private DNS mappings, or delete the endpoint
+# Replace or clear the custom private DNS mappings, or delete the endpoint
 clickhousectl cloud clickpipe reverse-private-endpoint update <service-id> <endpoint-id> \
   --custom-private-dns-mapping db.example.com
+clickhousectl cloud clickpipe reverse-private-endpoint update <service-id> <endpoint-id> \
+  --clear-custom-private-dns-mappings
 clickhousectl cloud clickpipe reverse-private-endpoint delete <service-id> <endpoint-id>
 
 # Reference a Ready endpoint from a Kafka pipe
@@ -1461,7 +1467,8 @@ leading-wildcard name (`*.example.com`). The API does not support it for
 PrivateLink types it has to be enabled for the service by ClickHouse support.
 The custom private DNS mappings are the only field the API's PATCH accepts, so
 `update` sends the complete list given on the command line: repeat every mapping
-the endpoint should keep.
+the endpoint should keep, or pass `--clear-custom-private-dns-mappings` to remove
+all mappings. The replace and clear flags conflict.
 
 #### Discovering a source schema (beta)
 
@@ -1516,8 +1523,12 @@ Role IDs used by member, invitation, and API-key commands currently come from th
 clickhousectl cloud member list
 clickhousectl cloud member get <user-id>
 clickhousectl cloud member update <user-id> --role-id <role-id>
+clickhousectl cloud member update <user-id> --clear-roles
 clickhousectl cloud member remove <user-id>
 ```
+
+Omitting both member role flags leaves assigned roles unchanged.
+`--clear-roles` removes them all and conflicts with `--role-id`.
 
 ### Invitations
 
@@ -1545,10 +1556,13 @@ clickhousectl cloud key update <key-id> \
   --state disabled
 clickhousectl cloud key update <key-id> --expires-at 2030-12-31T23:59:59Z
 clickhousectl cloud key update <key-id> --clear-expiry
+clickhousectl cloud key update <key-id> --clear-roles --clear-ip-allow
 clickhousectl cloud key delete <key-id>
 ```
 
-On update, omitting both expiry flags keeps the current expiry. `--clear-expiry` removes it and conflicts with `--expires-at`; other key settings change only when their flags are supplied.
+On update, omitting expiry, role, or IP allowlist flags keeps that setting.
+`--clear-expiry`, `--clear-roles`, and `--clear-ip-allow` remove the respective
+setting and conflict with the corresponding set flag.
 
 ### Activity
 

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -78,9 +78,13 @@ pub enum KeyCommands {
         #[arg(long)]
         name: Option<String>,
 
-        /// Role UUID to assign (repeatable)
-        #[arg(long)]
+        /// Role UUID to assign (repeatable; conflicts with --clear-roles)
+        #[arg(long, conflicts_with = "clear_roles")]
         role_id: Vec<String>,
+
+        /// Remove all assigned roles; conflicts with --role-id
+        #[arg(long, conflicts_with = "role_id")]
+        clear_roles: bool,
 
         /// New expiry as RFC 3339; conflicts with --clear-expiry
         #[arg(long, value_parser = parse_datetime, conflicts_with = "clear_expiry")]
@@ -94,9 +98,13 @@ pub enum KeyCommands {
         #[arg(long)]
         state: Option<String>,
 
-        /// IP or CIDR allowed to use the key (repeatable)
-        #[arg(long = "ip-allow")]
+        /// IP or CIDR to allow (repeatable; conflicts with --clear-ip-allow)
+        #[arg(long = "ip-allow", conflicts_with = "clear_ip_allow")]
         ip_allow: Vec<String>,
+
+        /// Clear the IP allowlist; conflicts with --ip-allow
+        #[arg(long, conflicts_with = "ip_allow")]
+        clear_ip_allow: bool,
 
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
@@ -160,19 +168,23 @@ pub async fn run(client: &CloudClient, command: KeyCommands, json: bool) -> Clou
             key_id,
             name,
             role_id,
+            clear_roles,
             expires_at,
             clear_expiry,
             state,
             ip_allow,
+            clear_ip_allow,
             org_id,
         } => {
             let options = KeyUpdateOptions {
                 name,
                 role_ids: role_id,
+                clear_roles,
                 expires_at,
                 clear_expiry,
                 state,
                 ip_allow,
+                clear_ip_allow,
                 org_id,
             };
             key_update(client, &key_id, options, json).await
@@ -200,10 +212,12 @@ struct KeyCreateOptions {
 struct KeyUpdateOptions {
     name: Option<String>,
     role_ids: Vec<String>,
+    clear_roles: bool,
     expires_at: Option<String>,
     clear_expiry: bool,
     state: Option<String>,
     ip_allow: Vec<String>,
+    clear_ip_allow: bool,
     org_id: Option<String>,
 }
 
@@ -315,7 +329,9 @@ fn build_api_key_update_request(options: &KeyUpdateOptions) -> CloudResult<ApiKe
     }
     Ok(ApiKeyPatchRequest {
         name: options.name.clone(),
-        assigned_role_ids: if options.role_ids.is_empty() {
+        assigned_role_ids: if options.clear_roles {
+            Some(Vec::new())
+        } else if options.role_ids.is_empty() {
             None
         } else {
             Some(parse_uuid_list(&options.role_ids, "role_id")?)
@@ -335,7 +351,11 @@ fn build_api_key_update_request(options: &KeyUpdateOptions) -> CloudResult<ApiKe
             .as_deref()
             .map(parse_api_key_state_patch)
             .transpose()?,
-        ip_access_list: parse_ip_access_entries(&options.ip_allow),
+        ip_access_list: if options.clear_ip_allow {
+            Some(Vec::new())
+        } else {
+            parse_ip_access_entries(&options.ip_allow)
+        },
         #[cfg(feature = "deprecated-fields")]
         roles: None,
     })
@@ -748,10 +768,12 @@ mod tests {
             key_id,
             name,
             role_id,
+            clear_roles,
             expires_at,
             clear_expiry,
             state,
             ip_allow,
+            clear_ip_allow,
             org_id,
         } = parse_top_level_key(&["clickhousectl", "cloud", "key", "update", "key-1"])
         else {
@@ -760,10 +782,12 @@ mod tests {
         assert_eq!(key_id, "key-1");
         assert!(name.is_none());
         assert!(role_id.is_empty());
+        assert!(!clear_roles);
         assert!(expires_at.is_none());
         assert!(!clear_expiry);
         assert!(state.is_none());
         assert!(ip_allow.is_empty());
+        assert!(!clear_ip_allow);
         assert!(org_id.is_none());
     }
 
@@ -853,10 +877,12 @@ mod tests {
             key_id,
             name,
             role_id,
+            clear_roles,
             expires_at,
             clear_expiry,
             state,
             ip_allow,
+            clear_ip_allow,
             org_id,
         } = command
         else {
@@ -865,11 +891,60 @@ mod tests {
         assert_eq!(key_id, "key-1");
         assert_eq!(name.as_deref(), Some("renamed"));
         assert_eq!(role_id, vec!["role-1", "role-2"]);
+        assert!(!clear_roles);
         assert_eq!(expires_at.as_deref(), Some("2025-01-01T00:00:00Z"));
         assert!(!clear_expiry);
         assert_eq!(state.as_deref(), Some("enabled"));
         assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert!(!clear_ip_allow);
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_key_update_list_clear_flags() {
+        let command = parse_top_level_key(&[
+            "clickhousectl",
+            "cloud",
+            "key",
+            "update",
+            "key-1",
+            "--clear-roles",
+            "--clear-ip-allow",
+        ]);
+        let KeyCommands::Update {
+            role_id,
+            clear_roles,
+            ip_allow,
+            clear_ip_allow,
+            ..
+        } = command
+        else {
+            panic!("expected key update");
+        };
+        assert!(role_id.is_empty());
+        assert!(clear_roles);
+        assert!(ip_allow.is_empty());
+        assert!(clear_ip_allow);
+    }
+
+    #[test]
+    fn rejects_conflicting_key_update_list_flags() {
+        for flags in [
+            ["--role-id", "role-1", "--clear-roles"],
+            ["--clear-roles", "--role-id", "role-1"],
+            ["--ip-allow", "10.0.0.0/8", "--clear-ip-allow"],
+            ["--clear-ip-allow", "--ip-allow", "10.0.0.0/8"],
+        ] {
+            let result = Cli::try_parse_from(
+                ["clickhousectl", "cloud", "key", "update", "key-1"]
+                    .into_iter()
+                    .chain(flags),
+            );
+            let Err(error) = result else {
+                panic!("set and clear flags must conflict");
+            };
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     #[test]
@@ -994,6 +1069,23 @@ mod tests {
     }
 
     #[test]
+    fn build_api_key_update_request_clears_lists_explicitly() {
+        let request = build_api_key_update_request(&KeyUpdateOptions {
+            clear_roles: true,
+            clear_ip_allow: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(request.assigned_role_ids, Some(Vec::new()));
+        assert_eq!(request.ip_access_list, Some(Vec::new()));
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({"assignedRoleIds": [], "ipAccessList": []})
+        );
+    }
+
+    #[test]
     fn build_api_key_update_request_combines_clear_with_explicit_changes() {
         let role_id = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
         let request = build_api_key_update_request(&KeyUpdateOptions {
@@ -1104,10 +1196,12 @@ mod tests {
         let update = build_api_key_update_request(&KeyUpdateOptions {
             name: Some("renamed".to_string()),
             role_ids: vec![role_id.to_string()],
+            clear_roles: false,
             expires_at: Some("2025-01-01T00:00:00Z".to_string()),
             clear_expiry: false,
             state: Some("disabled".to_string()),
             ip_allow: vec!["0.0.0.0/0".to_string()],
+            clear_ip_allow: false,
             org_id: None,
         })
         .unwrap();

--- a/crates/clickhousectl/src/cloud/clickpipe_endpoints.rs
+++ b/crates/clickhousectl/src/cloud/clickpipe_endpoints.rs
@@ -12,7 +12,7 @@ use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_serde_enum, resolve_org_id};
 use clap::builder::PossibleValuesParser;
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
 use clickhouse_cloud_api::models::{
     CreateReversePrivateEndpoint, CreateReversePrivateEndpointMskauthentication,
     CreateReversePrivateEndpointType, CustomPrivateDnsMapping, UpdateReversePrivateEndpoint,
@@ -55,6 +55,11 @@ pub enum ReversePrivateEndpointCommands {
     Create(Box<ReversePrivateEndpointCreateArgs>),
 
     /// Replace the custom private DNS mappings of a reverse private endpoint
+    #[command(group(
+        ArgGroup::new("mapping_change")
+            .required(true)
+            .args(["custom_private_dns_mappings", "clear_custom_private_dns_mappings"])
+    ))]
     Update {
         /// Service ID
         service_id: String,
@@ -63,8 +68,12 @@ pub enum ReversePrivateEndpointCommands {
         endpoint_id: String,
 
         /// Custom private DNS name (repeatable; replaces the whole list)
-        #[arg(long = "custom-private-dns-mapping", required = true)]
+        #[arg(long = "custom-private-dns-mapping")]
         custom_private_dns_mappings: Vec<String>,
+
+        /// Remove all custom private DNS mappings
+        #[arg(long)]
+        clear_custom_private_dns_mappings: bool,
 
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
@@ -179,6 +188,7 @@ pub async fn run(
             service_id,
             endpoint_id,
             custom_private_dns_mappings,
+            clear_custom_private_dns_mappings,
             org_id,
         } => {
             endpoint_update(
@@ -186,6 +196,7 @@ pub async fn run(
                 &service_id,
                 &endpoint_id,
                 &custom_private_dns_mappings,
+                clear_custom_private_dns_mappings,
                 org_id.as_deref(),
                 json,
             )
@@ -304,11 +315,15 @@ async fn endpoint_update(
     service_id: &str,
     endpoint_id: &str,
     custom_private_dns_mappings: &[String],
+    clear_custom_private_dns_mappings: bool,
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let request = build_update_reverse_private_endpoint_request(custom_private_dns_mappings);
+    let request = build_update_reverse_private_endpoint_request(
+        custom_private_dns_mappings,
+        clear_custom_private_dns_mappings,
+    );
     let endpoint = client
         .update_clickpipe_reverse_private_endpoint(&org_id, service_id, endpoint_id, &request)
         .await?;
@@ -477,9 +492,16 @@ fn build_create_reverse_private_endpoint_request(
     })
 }
 
-fn build_update_reverse_private_endpoint_request(names: &[String]) -> UpdateReversePrivateEndpoint {
+fn build_update_reverse_private_endpoint_request(
+    names: &[String],
+    clear_custom_private_dns_mappings: bool,
+) -> UpdateReversePrivateEndpoint {
     UpdateReversePrivateEndpoint {
-        custom_private_dns_mappings: build_custom_private_dns_mappings(names),
+        custom_private_dns_mappings: if clear_custom_private_dns_mappings {
+            Some(Vec::new())
+        } else {
+            build_custom_private_dns_mappings(names)
+        },
     }
 }
 
@@ -670,6 +692,7 @@ mod tests {
             service_id,
             endpoint_id,
             custom_private_dns_mappings,
+            clear_custom_private_dns_mappings,
             org_id,
         } = parse_endpoint_command(&[
             "update",
@@ -691,13 +714,46 @@ mod tests {
             custom_private_dns_mappings,
             vec!["db.example.com".to_string(), "*.example.com".to_string()]
         );
+        assert!(!clear_custom_private_dns_mappings);
         assert_eq!(org_id.as_deref(), Some("org-1"));
     }
 
-    /// The PATCH body only carries the mappings, so an update with none would
-    /// send `{}`: clap must reject it instead.
     #[test]
-    fn update_requires_at_least_one_mapping() {
+    fn parses_update_clear_custom_private_dns_mappings() {
+        let ReversePrivateEndpointCommands::Update {
+            custom_private_dns_mappings,
+            clear_custom_private_dns_mappings,
+            ..
+        } = parse_endpoint_command(&[
+            "update",
+            "svc-1",
+            "rpe-1",
+            "--clear-custom-private-dns-mappings",
+        ])
+        else {
+            panic!("expected update command");
+        };
+        assert!(custom_private_dns_mappings.is_empty());
+        assert!(clear_custom_private_dns_mappings);
+    }
+
+    #[test]
+    fn update_rejects_set_and_clear_mappings_together() {
+        let error = parse_error(&[
+            "update",
+            "svc-1",
+            "rpe-1",
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--clear-custom-private-dns-mappings",
+        ]);
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    /// The PATCH body only carries mappings, so clap must reject an update
+    /// without either a replacement list or an explicit clear.
+    #[test]
+    fn update_requires_a_mapping_change() {
         let error = parse_error(&["update", "svc-1", "rpe-1"]);
         assert_eq!(
             error.kind(),
@@ -1049,10 +1105,10 @@ mod tests {
 
     #[test]
     fn build_update_request_sends_the_complete_mapping_list() {
-        let request = build_update_reverse_private_endpoint_request(&[
-            "db.example.com".to_string(),
-            "*.example.com".to_string(),
-        ]);
+        let request = build_update_reverse_private_endpoint_request(
+            &["db.example.com".to_string(), "*.example.com".to_string()],
+            false,
+        );
         assert_eq!(
             request.custom_private_dns_mappings,
             Some(vec![
@@ -1065,11 +1121,15 @@ mod tests {
             ])
         );
 
-        // Clap requires a mapping, so this shape is unreachable from the CLI;
-        // pinned so the builder never invents an empty array either.
+        // The required clap group makes this omitted shape unreachable, while
+        // the builder still preserves omitted versus explicitly cleared.
         assert_eq!(
-            build_update_reverse_private_endpoint_request(&[]).custom_private_dns_mappings,
+            build_update_reverse_private_endpoint_request(&[], false).custom_private_dns_mappings,
             None
+        );
+        assert_eq!(
+            build_update_reverse_private_endpoint_request(&[], true).custom_private_dns_mappings,
+            Some(Vec::new())
         );
     }
 

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -130,9 +130,13 @@ pub enum MemberCommands {
         /// User ID
         user_id: String,
 
-        /// Role ID to assign (repeatable)
-        #[arg(long)]
+        /// Role ID to assign (repeatable; conflicts with --clear-roles)
+        #[arg(long, conflicts_with = "clear_roles")]
         role_id: Vec<String>,
+
+        /// Remove all assigned roles; conflicts with --role-id
+        #[arg(long, conflicts_with = "role_id")]
+        clear_roles: bool,
 
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
@@ -268,8 +272,19 @@ pub async fn run_member(
         MemberCommands::Update {
             user_id,
             role_id,
+            clear_roles,
             org_id,
-        } => member_update(client, &user_id, &role_id, org_id.as_deref(), json).await,
+        } => {
+            member_update(
+                client,
+                &user_id,
+                &role_id,
+                clear_roles,
+                org_id.as_deref(),
+                json,
+            )
+            .await
+        }
         MemberCommands::Remove { user_id, org_id } => {
             member_remove(client, &user_id, org_id.as_deref(), json).await
         }
@@ -396,9 +411,11 @@ fn build_org_update_request(options: &OrgUpdateOptions) -> CloudResult<Organizat
     })
 }
 
-fn build_member_update_request(role_ids: &[String]) -> MemberPatchRequest {
+fn build_member_update_request(role_ids: &[String], clear_roles: bool) -> MemberPatchRequest {
     MemberPatchRequest {
-        assigned_role_ids: if role_ids.is_empty() {
+        assigned_role_ids: if clear_roles {
+            Some(Vec::new())
+        } else if role_ids.is_empty() {
             None
         } else {
             Some(role_ids.to_vec())
@@ -612,11 +629,12 @@ async fn member_update(
     client: &CloudClient,
     user_id: &str,
     role_ids: &[String],
+    clear_roles: bool,
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let request = build_member_update_request(role_ids);
+    let request = build_member_update_request(role_ids, clear_roles);
     let member = client.update_member(&org_id, user_id, &request).await?;
 
     if json {
@@ -991,6 +1009,7 @@ mod tests {
         let MemberCommands::Update {
             user_id,
             role_id,
+            clear_roles,
             org_id,
         } = command
         else {
@@ -998,6 +1017,7 @@ mod tests {
         };
         assert_eq!(user_id, "user-1");
         assert!(role_id.is_empty());
+        assert!(!clear_roles);
         assert!(org_id.is_none());
 
         let CloudCommands::Invitation { command } = parse_cloud_command(&[
@@ -1080,6 +1100,7 @@ mod tests {
         let MemberCommands::Update {
             user_id,
             role_id,
+            clear_roles,
             org_id,
         } = command
         else {
@@ -1087,6 +1108,7 @@ mod tests {
         };
         assert_eq!(user_id, "user-1");
         assert_eq!(role_id, vec!["role-1", "role-2"]);
+        assert!(!clear_roles);
         assert_eq!(org_id.as_deref(), Some("org-1"));
 
         let CloudCommands::Invitation { command } = parse_cloud_command(&[
@@ -1116,6 +1138,48 @@ mod tests {
         assert_eq!(email, "user@example.com");
         assert_eq!(role_id, vec!["role-1", "role-2"]);
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_member_clear_roles() {
+        let CloudCommands::Member { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "member",
+            "update",
+            "user-1",
+            "--clear-roles",
+        ]) else {
+            panic!("expected member command");
+        };
+        let MemberCommands::Update {
+            role_id,
+            clear_roles,
+            ..
+        } = command
+        else {
+            panic!("expected member update");
+        };
+        assert!(role_id.is_empty());
+        assert!(clear_roles);
+    }
+
+    #[test]
+    fn rejects_conflicting_member_role_changes() {
+        for flags in [
+            ["--role-id", "role-1", "--clear-roles"],
+            ["--clear-roles", "--role-id", "role-1"],
+        ] {
+            let result = Cli::try_parse_from(
+                ["clickhousectl", "cloud", "member", "update", "user-1"]
+                    .into_iter()
+                    .chain(flags),
+            );
+            let Err(error) = result else {
+                panic!("set and clear flags must conflict");
+            };
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     #[test]
@@ -1468,7 +1532,7 @@ mod tests {
 
     #[test]
     fn build_member_update_request_supports_minimal_fields() {
-        let request = build_member_update_request(&[]);
+        let request = build_member_update_request(&[], false);
 
         assert!(request.assigned_role_ids.is_none());
         #[cfg(feature = "deprecated-fields")]
@@ -1477,7 +1541,8 @@ mod tests {
 
     #[test]
     fn build_member_update_request_supports_maximal_fields() {
-        let request = build_member_update_request(&["role-1".to_string(), "role-2".to_string()]);
+        let request =
+            build_member_update_request(&["role-1".to_string(), "role-2".to_string()], false);
 
         assert_eq!(
             request.assigned_role_ids,
@@ -1485,6 +1550,17 @@ mod tests {
         );
         #[cfg(feature = "deprecated-fields")]
         assert!(request.role.is_none());
+    }
+
+    #[test]
+    fn build_member_update_request_clears_roles_explicitly() {
+        let request = build_member_update_request(&[], true);
+
+        assert_eq!(request.assigned_role_ids, Some(Vec::new()));
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({"assignedRoleIds": []})
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -97,12 +97,15 @@ CONTEXT FOR AGENTS:
         /// New high-availability type
         #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgHaType::VALUES))]
         ha_type: Option<String>,
-        /// Add a tag (repeatable), e.g. --add-tag env=prod
-        #[arg(long)]
+        /// Add a tag (repeatable; conflicts with --clear-tags)
+        #[arg(long, conflicts_with = "clear_tags")]
         add_tag: Vec<String>,
-        /// Remove a tag by key (repeatable)
-        #[arg(long)]
+        /// Remove a tag by key (repeatable; conflicts with --clear-tags)
+        #[arg(long, conflicts_with = "clear_tags")]
         remove_tag: Vec<String>,
+        /// Remove all tags; conflicts with --add-tag and --remove-tag
+        #[arg(long, conflicts_with_all = ["add_tag", "remove_tag"])]
+        clear_tags: bool,
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
         org_id: Option<String>,
@@ -393,6 +396,7 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
             ha_type,
             add_tag,
             remove_tag,
+            clear_tags,
             org_id,
         } => {
             let opts = PostgresUpdateOptions {
@@ -401,6 +405,7 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
                 ha_type: ha_type.as_deref(),
                 add_tag: &add_tag,
                 remove_tag: &remove_tag,
+                clear_tags,
                 org_id: org_id.as_deref(),
             };
             postgres_update(client, &postgres_id, opts, json).await
@@ -994,6 +999,7 @@ pub struct PostgresUpdateOptions<'a> {
     pub ha_type: Option<&'a str>,
     pub add_tag: &'a [String],
     pub remove_tag: &'a [String],
+    pub clear_tags: bool,
     pub org_id: Option<&'a str>,
 }
 
@@ -1250,8 +1256,11 @@ pub async fn postgres_update(
         .map(|v| parse_serde_enum::<PgHaType>(v, "ha-type", PgHaType::VALUES))
         .transpose()?;
 
-    // Merge tag add/remove against current tags if any tag changes requested.
-    let tags = if !opts.add_tag.is_empty() || !opts.remove_tag.is_empty() {
+    // Clearing is already a complete replacement, so it never needs a GET.
+    // Add/remove still merges against a complete current tag snapshot.
+    let tags = if opts.clear_tags {
+        Some(Vec::new())
+    } else if !opts.add_tag.is_empty() || !opts.remove_tag.is_empty() {
         let current = client
             .api()
             .postgres_service_get(&org_id, postgres_id)
@@ -2194,6 +2203,7 @@ mod tests {
             size,
             add_tag,
             remove_tag,
+            clear_tags,
             ..
         } = cmd
         else {
@@ -2203,6 +2213,7 @@ mod tests {
         assert_eq!(size.as_deref(), Some("c6gd.large"));
         assert_eq!(add_tag, vec!["env=prod", "team=data"]);
         assert_eq!(remove_tag, vec!["old"]);
+        assert!(!clear_tags);
     }
 
     #[test]
@@ -2212,6 +2223,10 @@ mod tests {
             postgres_id,
             name,
             size,
+            add_tag,
+            remove_tag,
+            clear_tags,
+            org_id,
             ..
         } = cmd
         else {
@@ -2220,6 +2235,54 @@ mod tests {
         assert_eq!(postgres_id, "pg-1");
         assert!(name.is_none());
         assert!(size.is_none());
+        assert!(add_tag.is_empty());
+        assert!(remove_tag.is_empty());
+        assert!(!clear_tags);
+        assert!(org_id.is_none());
+    }
+
+    #[test]
+    fn parses_postgres_update_clear_tags() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "update",
+            "pg-1",
+            "--clear-tags",
+        ]);
+        let PostgresCommands::Update {
+            add_tag,
+            remove_tag,
+            clear_tags,
+            ..
+        } = cmd
+        else {
+            panic!("expected update");
+        };
+        assert!(add_tag.is_empty());
+        assert!(remove_tag.is_empty());
+        assert!(clear_tags);
+    }
+
+    #[test]
+    fn rejects_conflicting_postgres_tag_changes() {
+        for flags in [
+            ["--add-tag", "env=prod", "--clear-tags"],
+            ["--clear-tags", "--add-tag", "env=prod"],
+            ["--remove-tag", "env", "--clear-tags"],
+            ["--clear-tags", "--remove-tag", "env"],
+        ] {
+            let result = Cli::try_parse_from(
+                ["clickhousectl", "cloud", "postgres", "update", "pg-1"]
+                    .into_iter()
+                    .chain(flags),
+            );
+            let Err(error) = result else {
+                panic!("tag diff and clear flags must conflict");
+            };
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     #[test]
@@ -2983,6 +3046,17 @@ mod tests {
         assert!(req.size.is_none());
         assert!(req.ha_type.is_none());
         assert!(req.tags.is_none());
+    }
+
+    #[test]
+    fn build_postgres_update_request_clears_tags_explicitly() {
+        let req = build_postgres_update_request(None, None, None, Some(Vec::new()));
+
+        assert_eq!(req.tags, Some(Vec::new()));
+        assert_eq!(
+            serde_json::to_value(req).unwrap(),
+            serde_json::json!({"tags": []})
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -12934,8 +12934,8 @@ async fn pgbouncer_config_get_json_preserves_values_and_tolerates_absent_section
     }
 }
 
-// API key nullable expiry updates (#698).
-async fn invoke_key_update_expiry(server: &MockServer, flags: &[&str]) -> std::process::Output {
+// API key nullable expiry (#698) and explicit list clearing (#597).
+async fn invoke_key_update(server: &MockServer, flags: &[&str]) -> std::process::Output {
     let project = tempfile::tempdir().unwrap();
     let mut command = Command::new(clickhousectl_binary());
     clear_inherited_env(&mut command);
@@ -12963,7 +12963,7 @@ async fn invoke_key_update_expiry(server: &MockServer, flags: &[&str]) -> std::p
 }
 
 #[tokio::test]
-async fn key_update_expiry_sends_exact_omitted_set_and_clear_bodies() {
+async fn key_update_sends_exact_omitted_set_and_clear_bodies() {
     let cases: &[(&[&str], Value)] = &[
         (&[], serde_json::json!({})),
         (
@@ -12971,6 +12971,10 @@ async fn key_update_expiry_sends_exact_omitted_set_and_clear_bodies() {
             serde_json::json!({"name": "renamed"}),
         ),
         (&["--clear-expiry"], serde_json::json!({"expireAt": null})),
+        (
+            &["--clear-roles", "--clear-ip-allow"],
+            serde_json::json!({"assignedRoleIds": [], "ipAccessList": []}),
+        ),
         (
             &["--expires-at", "2030-01-01T00:00:00Z"],
             serde_json::json!({"expireAt": "2030-01-01T00:00:00Z"}),
@@ -13009,7 +13013,7 @@ async fn key_update_expiry_sends_exact_omitted_set_and_clear_bodies() {
             .expect(1)
             .mount(&server)
             .await;
-        let output = invoke_key_update_expiry(&server, flags).await;
+        let output = invoke_key_update(&server, flags).await;
         assert_success(&output);
         let result: Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(result, serde_json::json!({"name": "updated"}));
@@ -13018,30 +13022,36 @@ async fn key_update_expiry_sends_exact_omitted_set_and_clear_bodies() {
 }
 
 #[tokio::test]
-async fn key_update_expiry_conflict_sends_no_http() {
-    let server = MockServer::start().await;
-    let output = invoke_key_update_expiry(
-        &server,
-        &["--clear-expiry", "--expires-at", "2030-01-01T00:00:00Z"],
-    )
-    .await;
-    assert_eq!(output.status.code(), Some(2));
-    assert!(server.received_requests().await.unwrap().is_empty());
+async fn key_update_conflicts_send_no_http() {
+    for flags in [
+        vec!["--clear-expiry", "--expires-at", "2030-01-01T00:00:00Z"],
+        vec![
+            "--clear-roles",
+            "--role-id",
+            "11111111-2222-3333-4444-555555555555",
+        ],
+        vec!["--clear-ip-allow", "--ip-allow", "10.0.0.0/8"],
+    ] {
+        let server = MockServer::start().await;
+        let output = invoke_key_update(&server, &flags).await;
+        assert_eq!(output.status.code(), Some(2));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
 }
 
 #[tokio::test]
-async fn key_update_expiry_preserves_auth_error_conversion() {
+async fn key_update_preserves_auth_error_conversion() {
     let server = MockServer::start().await;
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/keys/key-1"))
-        .and(body_json(serde_json::json!({"expireAt": null})))
+        .and(body_json(serde_json::json!({"assignedRoleIds": []})))
         .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
             "error": "not permitted", "status": 403,
         })))
         .expect(1)
         .mount(&server)
         .await;
-    let output = invoke_key_update_expiry(&server, &["--clear-expiry"]).await;
+    let output = invoke_key_update(&server, &["--clear-roles"]).await;
     assert_eq!(output.status.code(), Some(4));
     assert!(output.stdout.is_empty());
 }
@@ -14635,5 +14645,266 @@ async fn udf_stdin_minimal_definition_and_sparse_human_output() {
         }
         let request = server.received_requests().await.unwrap().pop().unwrap();
         assert!(request.url.query().is_none());
+    }
+}
+
+// Explicit list clearing (#597).
+
+#[tokio::test]
+async fn member_update_preserves_omitted_set_and_clear_role_lists() {
+    let cases: &[(&[&str], Value)] = &[
+        (&[], serde_json::json!({})),
+        (
+            &["--role-id", "role-1", "--role-id", "role-2"],
+            serde_json::json!({"assignedRoleIds": ["role-1", "role-2"]}),
+        ),
+        (
+            &["--clear-roles"],
+            serde_json::json!({"assignedRoleIds": []}),
+        ),
+    ];
+
+    for (flags, expected_body) in cases {
+        let mock = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/v1/organizations/org-1/members/user-1"))
+            .and(body_json(expected_body.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {"email": "member@example.com"},
+                "status": 200,
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let mut args = vec!["member", "update", "user-1", "--org-id", "org-1"];
+        args.extend_from_slice(flags);
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_success(&output);
+        assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn member_update_role_conflict_sends_no_http() {
+    let mock = MockServer::start().await;
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "member",
+            "update",
+            "user-1",
+            "--org-id",
+            "org-1",
+            "--role-id",
+            "role-1",
+            "--clear-roles",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+const CLEAR_TAGS_POSTGRES_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+#[tokio::test]
+async fn postgres_update_clear_tags_sends_an_empty_array_without_a_get() {
+    let mock = MockServer::start().await;
+    let postgres_path = format!("/v1/organizations/org-1/postgres/{CLEAR_TAGS_POSTGRES_ID}");
+    Mock::given(method("PATCH"))
+        .and(path(postgres_path.clone()))
+        .and(body_json(serde_json::json!({"tags": []})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": CLEAR_TAGS_POSTGRES_ID, "name": "pg-clear-tags"},
+            "status": 200,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "update",
+            CLEAR_TAGS_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+            "--clear-tags",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("PATCH".to_string(), postgres_path)],
+        "clearing a complete list must not fetch the current service"
+    );
+}
+
+#[tokio::test]
+async fn postgres_update_tag_diff_refuses_a_sparse_get_without_writing() {
+    let mock = MockServer::start().await;
+    let postgres_path = format!("/v1/organizations/org-1/postgres/{CLEAR_TAGS_POSTGRES_ID}");
+    Mock::given(method("GET"))
+        .and(path(postgres_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": CLEAR_TAGS_POSTGRES_ID, "name": "pg-sparse"},
+            "status": 200,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path(postgres_path.clone()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "update",
+            CLEAR_TAGS_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+            "--add-tag",
+            "env=prod",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("omitted the tags field"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("GET".to_string(), postgres_path)]
+    );
+}
+
+#[tokio::test]
+async fn postgres_update_clear_tags_conflict_sends_no_http() {
+    let mock = MockServer::start().await;
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "update",
+            CLEAR_TAGS_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+            "--clear-tags",
+            "--remove-tag",
+            "env",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn postgres_update_clear_tags_propagates_api_errors_without_retrying() {
+    let mock = MockServer::start().await;
+    let postgres_path = format!("/v1/organizations/org-1/postgres/{CLEAR_TAGS_POSTGRES_ID}");
+    Mock::given(method("PATCH"))
+        .and(path(postgres_path.clone()))
+        .and(body_json(serde_json::json!({"tags": []})))
+        .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+            "error": "update failed",
+            "status": 500,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "update",
+            CLEAR_TAGS_POSTGRES_ID,
+            "--org-id",
+            "org-1",
+            "--clear-tags",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("PATCH".to_string(), postgres_path)]
+    );
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_update_clears_the_mapping_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path(reverse_private_endpoint_path()))
+        .and(body_json(serde_json::json!({
+            "customPrivateDnsMappings": []
+        })))
+        .respond_with(reverse_private_endpoint_envelope(
+            reverse_private_endpoint_json(),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "reverse-private-endpoint",
+            "update",
+            "svc-1",
+            RPE_ID,
+            "--clear-custom-private-dns-mappings",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("PATCH".to_string(), reverse_private_endpoint_path())]
+    );
+}
+
+#[tokio::test]
+async fn reverse_private_endpoint_update_rejects_noop_and_conflict_without_http() {
+    for flags in [
+        Vec::<&str>::new(),
+        vec![
+            "--custom-private-dns-mapping",
+            "db.example.com",
+            "--clear-custom-private-dns-mappings",
+        ],
+    ] {
+        let mock = MockServer::start().await;
+        let mut args = vec![
+            "clickpipe",
+            "reverse-private-endpoint",
+            "update",
+            "svc-1",
+            RPE_ID,
+            "--org-id",
+            "org-1",
+        ];
+        args.extend(flags);
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(mock.received_requests().await.unwrap().is_empty());
     }
 }


### PR DESCRIPTION
Several Cloud update commands could replace list-valued fields but could not explicitly empty them because an empty CLI value was serialized as an omitted field. Add explicit clear flags for API key roles and IP allowlists, member roles, Postgres tags, and reverse private endpoint custom DNS mappings while preserving omission as no change.

Postgres tag clearing now sends an empty list directly without fetching current tags. Add/remove tag updates retain their safe read/merge behavior and refuse to PATCH when the API omits the current tag snapshot. Reverse private endpoint updates require either replacement mappings or `--clear-custom-private-dns-mappings`, and reject both together.

Closes #597.

Validation:

- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl`
