### PR TITLE
feat(clickstack): expose saved-search management

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,19 @@ clickhousectl cloud clickstack source create <service-id> \
   --config-file source.json --org-id <org-id>
 clickhousectl cloud clickstack role create <service-id> \
   --config-file role.json --org-id <org-id>
+clickhousectl cloud clickstack saved-search create <service-id> \
+  --config-file saved-search.json --org-id <org-id>
+clickhousectl cloud clickstack saved-search get <service-id> <saved-search-id> \
+  --org-id <org-id>
+clickhousectl cloud clickstack saved-search update <service-id> <saved-search-id> \
+  --config-file saved-search.json --org-id <org-id>
 ```
 
-Pass `--config-file -` to read the JSON body from stdin. Source IDs and role IDs come from their
-respective `list` commands. `source update` and `role update` use PUT replacement semantics, so the
-configuration must contain the complete desired resource rather than only changed fields.
+Pass `--config-file -` to read the JSON body from stdin. Resource IDs come from the respective
+`list` command. A saved search configuration contains `name` and `sourceId`, plus optional `select`,
+`where`, `whereLanguage`, `orderBy`, `tags`, and structured `filters`; obtain `sourceId` with
+`cloud clickstack source list`. All ClickStack `update` commands use PUT replacement semantics, so
+the configuration must contain the complete desired resource rather than only changed fields.
 
 ## Local
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -159,7 +159,7 @@ CONTEXT FOR AGENTS:
         after_help = "\
 CONTEXT FOR AGENTS:
   Service ID: `clickhousectl cloud service list`.
-  Source and role IDs come from their respective `list` commands.
+  Resource IDs come from their respective `list` commands.
   Everything except list/get is a write and needs API key auth.
   Create/update read complete JSON bodies from --config-file; `-` reads stdin."
     )]

--- a/crates/clickhousectl/src/cloud/clickstack.rs
+++ b/crates/clickhousectl/src/cloud/clickstack.rs
@@ -7,9 +7,10 @@ use clickhouse_cloud_api::models::{
     ClickStackCreateRoleRequest, ClickStackLogSource,
     ClickStackLogSourceUsetextindexforimplicitcolumn, ClickStackMaterializedView,
     ClickStackMaterializedViewMingranularity, ClickStackMetricSource, ClickStackPromqlSource,
-    ClickStackRole, ClickStackSessionSource, ClickStackSource, ClickStackSourceResponse,
-    ClickStackTraceSource, ClickStackTraceSourceUsetextindexforimplicitcolumn,
-    ClickStackUpdateRoleRequest,
+    ClickStackRole, ClickStackSavedSearch, ClickStackSavedSearchFilterType,
+    ClickStackSavedSearchInput, ClickStackSavedSearchInputWherelanguage, ClickStackSessionSource,
+    ClickStackSource, ClickStackSourceResponse, ClickStackTraceSource,
+    ClickStackTraceSourceUsetextindexforimplicitcolumn, ClickStackUpdateRoleRequest,
 };
 use serde_json::Value;
 use tabled::{Table, Tabled, settings::Style};
@@ -27,6 +28,12 @@ pub enum ClickStackCommands {
         #[command(subcommand)]
         command: RoleCommands,
     },
+
+    /// Manage ClickStack saved searches
+    SavedSearch {
+        #[command(subcommand)]
+        command: SavedSearchCommands,
+    },
 }
 
 impl ClickStackCommands {
@@ -34,6 +41,75 @@ impl ClickStackCommands {
         match self {
             Self::Source { command } => command.is_write(),
             Self::Role { command } => command.is_write(),
+            Self::SavedSearch { command } => command.is_write(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum SavedSearchCommands {
+    /// List ClickStack saved searches
+    List {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get ClickStack saved search details
+    Get {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Saved search ID (from `cloud clickstack saved-search list`)
+        saved_search_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Create a ClickStack saved search
+    Create {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Replace a ClickStack saved search
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  This is a full PUT replacement; include every required and desired field.")]
+    Update {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Saved search ID (from `cloud clickstack saved-search list`)
+        saved_search_id: String,
+        /// Complete JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Delete a ClickStack saved search
+    Delete {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Saved search ID (from `cloud clickstack saved-search list`)
+        saved_search_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl SavedSearchCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            Self::List { .. } | Self::Get { .. } => false,
+            Self::Create { .. } | Self::Update { .. } | Self::Delete { .. } => true,
         }
     }
 }
@@ -190,6 +266,37 @@ fn build_update_role_request(config_file: &str) -> CloudResult<ClickStackUpdateR
     read_typed_config(config_file)
 }
 
+fn build_saved_search_request(config_file: &str) -> CloudResult<ClickStackSavedSearchInput> {
+    let request: ClickStackSavedSearchInput = read_typed_config(config_file)?;
+    validate_saved_search_closed_enums(&request, config_file)?;
+    Ok(request)
+}
+
+fn validate_saved_search_closed_enums(
+    request: &ClickStackSavedSearchInput,
+    source: &str,
+) -> CloudResult<()> {
+    if let Some(ClickStackSavedSearchInputWherelanguage::Unknown(value)) = &request.where_language {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {source}: unknown whereLanguage value `{value}`"
+        )));
+    }
+    if let Some((index, value)) = request.filters.as_ref().and_then(|filters| {
+        filters.iter().enumerate().find_map(|(index, filter)| {
+            if let Some(ClickStackSavedSearchFilterType::Unknown(value)) = &filter.r#type {
+                Some((index, value))
+            } else {
+                None
+            }
+        })
+    }) {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {source}: unknown filters[{index}].type value `{value}`"
+        )));
+    }
+    Ok(())
+}
+
 fn parse_source_request(value: Value, source: &str) -> CloudResult<ClickStackSource> {
     let kind = field(&value, "kind").and_then(Value::as_str);
     let request = match kind {
@@ -277,6 +384,73 @@ pub async fn run(client: &CloudClient, command: ClickStackCommands, json: bool) 
     match command {
         ClickStackCommands::Source { command } => run_source(client, command, json).await,
         ClickStackCommands::Role { command } => run_role(client, command, json).await,
+        ClickStackCommands::SavedSearch { command } => {
+            run_saved_search(client, command, json).await
+        }
+    }
+}
+
+async fn run_saved_search(
+    client: &CloudClient,
+    command: SavedSearchCommands,
+    json: bool,
+) -> CloudResult<()> {
+    match command {
+        SavedSearchCommands::List { service_id, org_id } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let searches = client
+                .click_stack_list_saved_searches(&org_id, &service_id)
+                .await?;
+            print_saved_search_list(&searches, json)
+        }
+        SavedSearchCommands::Get {
+            service_id,
+            saved_search_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let search = client
+                .click_stack_get_saved_search(&org_id, &service_id, &saved_search_id)
+                .await?;
+            print_detail(&search, json)
+        }
+        SavedSearchCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_saved_search_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let search = client
+                .click_stack_create_saved_search(&org_id, &service_id, &request)
+                .await?;
+            print_detail(&search, json)
+        }
+        SavedSearchCommands::Update {
+            service_id,
+            saved_search_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_saved_search_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let search = client
+                .click_stack_update_saved_search(&org_id, &service_id, &saved_search_id, &request)
+                .await?;
+            print_detail(&search, json)
+        }
+        SavedSearchCommands::Delete {
+            service_id,
+            saved_search_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            client
+                .click_stack_delete_saved_search(&org_id, &service_id, &saved_search_id)
+                .await?;
+            print_deleted("ClickStack saved search", &saved_search_id, json);
+            Ok(())
+        }
     }
 }
 
@@ -497,7 +671,109 @@ fn print_role_list(roles: &[ClickStackRole], json: bool) -> CloudResult<()> {
     Ok(())
 }
 
+fn print_saved_search_list(searches: &[ClickStackSavedSearch], json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(searches)?);
+        return Ok(());
+    }
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "ID")]
+        id: String,
+        #[tabled(rename = "Source ID")]
+        source_id: String,
+        #[tabled(rename = "Language")]
+        language: String,
+    }
+    let rows = searches
+        .iter()
+        .map(|search| Row {
+            name: or_absent(search.name.as_deref()),
+            id: or_absent(search.id.as_deref()),
+            source_id: or_absent(search.source_id.as_deref()),
+            language: or_absent(search.where_language.as_ref()),
+        })
+        .collect::<Vec<_>>();
+    println!("{}", Table::new(rows).with(Style::rounded()));
+    Ok(())
+}
+
 impl CloudClient {
+    async fn click_stack_list_saved_searches(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> CloudResult<Vec<ClickStackSavedSearch>> {
+        let response = self
+            .api()
+            .click_stack_list_saved_searches(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_create_saved_search(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &ClickStackSavedSearchInput,
+    ) -> CloudResult<ClickStackSavedSearch> {
+        let response = self
+            .api()
+            .click_stack_create_saved_search(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_get_saved_search(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        saved_search_id: &str,
+    ) -> CloudResult<ClickStackSavedSearch> {
+        let response = self
+            .api()
+            .click_stack_get_saved_search(org_id, service_id, saved_search_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_update_saved_search(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        saved_search_id: &str,
+        request: &ClickStackSavedSearchInput,
+    ) -> CloudResult<ClickStackSavedSearch> {
+        let response = self
+            .api()
+            .click_stack_update_saved_search(org_id, service_id, saved_search_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_delete_saved_search(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        saved_search_id: &str,
+    ) -> CloudResult<crate::cloud::types::DeleteResponse> {
+        let response = self
+            .api()
+            .click_stack_delete_saved_search(org_id, service_id, saved_search_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(crate::cloud::types::DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
     async fn click_stack_list_sources(
         &self,
         org_id: &str,
@@ -663,7 +939,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_source_and_role_config_commands() {
+    fn parses_clickstack_config_commands() {
         let command = parse_clickstack(&[
             "clickhousectl",
             "cloud",
@@ -716,10 +992,39 @@ mod tests {
         };
         assert_eq!(config_file, "role.json");
         assert_eq!(role_id, "role-1");
+
+        let command = parse_clickstack(&[
+            "clickhousectl",
+            "cloud",
+            "clickstack",
+            "saved-search",
+            "update",
+            "svc-1",
+            "search-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ]);
+        let ClickStackCommands::SavedSearch {
+            command:
+                SavedSearchCommands::Update {
+                    saved_search_id,
+                    config_file,
+                    org_id,
+                    ..
+                },
+        } = command
+        else {
+            panic!("expected saved search update")
+        };
+        assert_eq!(saved_search_id, "search-1");
+        assert_eq!(config_file, "-");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
     }
 
     #[test]
-    fn classifies_every_source_and_role_operation() {
+    fn classifies_every_clickstack_operation() {
         for (resource, operation, expected) in [
             ("source", "list", false),
             ("source", "get", false),
@@ -731,6 +1036,11 @@ mod tests {
             ("role", "create", true),
             ("role", "update", true),
             ("role", "delete", true),
+            ("saved-search", "list", false),
+            ("saved-search", "get", false),
+            ("saved-search", "create", true),
+            ("saved-search", "update", true),
+            ("saved-search", "delete", true),
         ] {
             let mut args = vec![
                 "clickhousectl",
@@ -838,6 +1148,70 @@ mod tests {
     }
 
     #[test]
+    fn saved_search_builder_preserves_minimal_maximal_and_empty_fields() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("saved-search.json");
+        std::fs::write(&config_file, r#"{"name":"errors","sourceId":"source-1"}"#).unwrap();
+        let minimal = build_saved_search_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(minimal.name, "errors");
+        assert_eq!(minimal.source_id, "source-1");
+        assert_eq!(minimal.select, None);
+        assert_eq!(minimal.r#where, None);
+        assert_eq!(minimal.where_language, None);
+        assert_eq!(minimal.order_by, None);
+        assert_eq!(minimal.tags, None);
+        assert_eq!(minimal.filters, None);
+
+        std::fs::write(
+            &config_file,
+            serde_json::json!({
+                "name": "production errors",
+                "sourceId": "source-2",
+                "select": "Timestamp, Body",
+                "where": "SeverityText = 'ERROR'",
+                "whereLanguage": "sql",
+                "orderBy": "Timestamp DESC",
+                "tags": ["production", "errors"],
+                "filters": [{"type": "sql", "condition": "ServiceName = 'api'"}]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let maximal = build_saved_search_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(maximal.select.as_deref(), Some("Timestamp, Body"));
+        assert_eq!(maximal.r#where.as_deref(), Some("SeverityText = 'ERROR'"));
+        assert_eq!(
+            maximal.where_language,
+            Some(ClickStackSavedSearchInputWherelanguage::Sql)
+        );
+        assert_eq!(maximal.order_by.as_deref(), Some("Timestamp DESC"));
+        assert_eq!(
+            maximal.tags.as_deref(),
+            Some(&["production".into(), "errors".into()][..])
+        );
+        let filter = &maximal.filters.as_ref().unwrap()[0];
+        assert_eq!(filter.condition, "ServiceName = 'api'");
+        assert_eq!(filter.r#type, Some(ClickStackSavedSearchFilterType::Sql));
+
+        std::fs::write(
+            &config_file,
+            r#"{"name":"","sourceId":"source-3","select":"","where":"","whereLanguage":"lucene","orderBy":"","tags":[],"filters":[]}"#,
+        )
+        .unwrap();
+        let empty = build_saved_search_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(empty.name, "");
+        assert_eq!(empty.select.as_deref(), Some(""));
+        assert_eq!(empty.r#where.as_deref(), Some(""));
+        assert_eq!(
+            empty.where_language,
+            Some(ClickStackSavedSearchInputWherelanguage::Lucene)
+        );
+        assert_eq!(empty.order_by.as_deref(), Some(""));
+        assert_eq!(empty.tags, Some(vec![]));
+        assert_eq!(empty.filters, Some(vec![]));
+    }
+
+    #[test]
     fn input_validation_rejects_unknown_discriminator_and_nested_fields() {
         let error = parse_source_request(serde_json::json!({"kind":"logs","naem":"bad"}), "test")
             .unwrap_err();
@@ -853,5 +1227,28 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.message.contains("conditons"), "{error}");
+
+        for (body, expected) in [
+            (
+                serde_json::json!({"name":"bad","sourceId":"s","whereLanguage":"sqlish"}),
+                "unknown whereLanguage",
+            ),
+            (
+                serde_json::json!({"name":"bad","sourceId":"s","filters":[{"type":"lucene","condition":"x"}]}),
+                "unknown filters[0].type",
+            ),
+        ] {
+            let request: ClickStackSavedSearchInput =
+                deserialize_strict_config(body, "test").unwrap();
+            let error = validate_saved_search_closed_enums(&request, "test").unwrap_err();
+            assert!(error.message.contains(expected), "{error}");
+        }
+
+        let error = deserialize_strict_config::<ClickStackSavedSearchInput>(
+            serde_json::json!({"name":"bad","sourceId":"s","orderByy":null}),
+            "test",
+        )
+        .unwrap_err();
+        assert!(error.message.contains("orderByy"), "{error}");
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -14908,3 +14908,377 @@ async fn reverse_private_endpoint_update_rejects_noop_and_conflict_without_http(
         assert!(mock.received_requests().await.unwrap().is_empty());
     }
 }
+
+// ── ClickStack saved-search commands (issue #694) ──────────────────────────
+
+#[tokio::test]
+async fn clickstack_saved_search_all_five_routes_preserve_bodies_and_json_output() {
+    let mock = MockServer::start().await;
+    let searches = "/v1/organizations/org-1/services/svc-1/clickstack/saved-searches";
+    Mock::given(method("GET"))
+        .and(path(searches))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{searches}/search-get")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "search-get", "name": null, "futureField": "kept-compatible"}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(searches))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "search-created"}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(format!("{searches}/search-update")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "search-update", "sourceId": null}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("{searches}/search-delete")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": 200})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let directory = tempfile::tempdir().unwrap();
+    let file = directory.path().join("saved-search.json");
+    let body = serde_json::json!({
+        "name": "production errors",
+        "sourceId": "source-1",
+        "select": "Timestamp, Body",
+        "where": "SeverityText = 'ERROR'",
+        "whereLanguage": "sql",
+        "orderBy": "Timestamp DESC",
+        "tags": ["production", "errors"],
+        "filters": [{"type": "sql", "condition": "ServiceName = 'api'"}]
+    });
+    std::fs::write(&file, body.to_string()).unwrap();
+    let body_stdin = body.to_string();
+    let commands: Vec<(Vec<&str>, Option<&str>)> = vec![
+        (
+            vec![
+                "clickstack",
+                "saved-search",
+                "list",
+                "svc-1",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "saved-search",
+                "get",
+                "svc-1",
+                "search-get",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "saved-search",
+                "create",
+                "svc-1",
+                "--config-file",
+                file.to_str().unwrap(),
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "saved-search",
+                "update",
+                "svc-1",
+                "search-update",
+                "--config-file",
+                "-",
+                "--org-id",
+                "org-1",
+            ],
+            Some(body_stdin.as_str()),
+        ),
+        (
+            vec![
+                "clickstack",
+                "saved-search",
+                "delete",
+                "svc-1",
+                "search-delete",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+    ];
+    for (args, stdin) in commands {
+        let output = invoke_clickstack_cli(&mock, &args, stdin, true);
+        assert_success(&output);
+        serde_json::from_slice::<Value>(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "invalid JSON output for {args:?}: {error}\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            )
+        });
+    }
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 5);
+    for request in &requests {
+        assert!(
+            request
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("Basic "),
+            "{} {}",
+            request.method,
+            request.url.path()
+        );
+    }
+    let write_bodies = requests
+        .iter()
+        .filter(|request| {
+            request.method == wiremock::http::Method::POST
+                || request.method == wiremock::http::Method::PUT
+        })
+        .map(|request| request.body_json::<Value>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(write_bodies, vec![body.clone(), body]);
+}
+
+#[tokio::test]
+async fn clickstack_saved_search_rejects_invalid_file_and_stdin_before_http() {
+    let invalid = [
+        (
+            serde_json::json!({"name":"errors","sourceId":"source-1","whereLanguage":"lucenee"}).to_string(),
+            "unknown whereLanguage",
+        ),
+        (
+            serde_json::json!({"name":"errors","sourceId":"source-1","filters":[{"type":"lucene","condition":"x"}]}).to_string(),
+            "unknown filters[0].type",
+        ),
+        (
+            serde_json::json!({"name":"errors"}).to_string(),
+            "missing field",
+        ),
+        (
+            serde_json::json!({"name":"errors","sourceId":"source-1","selcet":null}).to_string(),
+            "selcet",
+        ),
+        ("{".to_string(), "failed to parse config"),
+    ];
+    for (index, (body, expected)) in invalid.iter().enumerate() {
+        let mock = MockServer::start().await;
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("invalid.json");
+        std::fs::write(&file, body).unwrap();
+        let (config_file, stdin) = if index % 2 == 0 {
+            (file.to_str().unwrap(), None)
+        } else {
+            ("-", Some(body.as_str()))
+        };
+        let output = invoke_clickstack_cli(
+            &mock,
+            &[
+                "clickstack",
+                "saved-search",
+                "create",
+                "svc-1",
+                "--config-file",
+                config_file,
+            ],
+            stdin,
+            false,
+        );
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(expected),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(mock.received_requests().await.unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn clickstack_saved_search_sparse_human_output_and_errors_are_safe() {
+    let mock = MockServer::start().await;
+    let searches = "/v1/organizations/org-1/services/svc-1/clickstack/saved-searches";
+    Mock::given(method("GET"))
+        .and(path(searches))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{searches}/sparse")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "saved-search",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+        None,
+        false,
+    );
+    assert_success(&output);
+    assert!(String::from_utf8_lossy(&output.stdout).contains('-'));
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "saved-search",
+            "get",
+            "svc-1",
+            "sparse",
+            "--org-id",
+            "org-1",
+        ],
+        None,
+        false,
+    );
+    assert_success(&output);
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-sensitive/services/svc-1/clickstack/saved-searches/search-1",
+        ))
+        .respond_with(
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({"error":"NOT_FOUND"})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "saved-search",
+            "get",
+            "svc-1",
+            "search-1",
+            "--org-id",
+            "org-sensitive",
+        ],
+        None,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("org-sensitive") && error.contains("NOT_FOUND"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn clickstack_saved_search_oauth_reads_and_rejects_writes_before_http() {
+    let mock = MockServer::start().await;
+    let searches = "/v1/organizations/org-1/services/svc-1/clickstack/saved-searches";
+    Mock::given(method("GET"))
+        .and(path(searches))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": []
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let invoke = |args: &[&str], stdin: Option<&str>| {
+        let mut command = Command::new(clickhousectl_binary());
+        clear_inherited_env(&mut command);
+        command
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", &home)
+            .current_dir(project.path())
+            .args(["cloud", "--url", &mock.uri()])
+            .args(args);
+        if let Some(input) = stdin {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(input.as_bytes())
+                .unwrap();
+            child.wait_with_output().unwrap()
+        } else {
+            command.output().unwrap()
+        }
+    };
+    let output = invoke(
+        &[
+            "clickstack",
+            "saved-search",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+        None,
+    );
+    assert_success(&output);
+    let output = invoke(
+        &[
+            "clickstack",
+            "saved-search",
+            "create",
+            "svc-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        Some(r#"{"name":"errors","sourceId":"source-1"}"#),
+    );
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}


### PR DESCRIPTION
Closes #694.

Adds `cloud clickstack saved-search list|get|create|update|delete` for the five existing ClickStack saved-search API operations. Create and full-replacement update accept strict typed JSON through `--config-file PATH|-`, preserve omitted versus empty fields, reject unknown request fields and closed-enum values before HTTP, and support human or JSON output with sparse response fields.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl --bin clickhousectl cloud::clickstack::tests`
- `cargo test -p clickhousectl --test cli_request_shape_test clickstack_saved_search`
- `cargo test -p clickhousectl`
