### PR TITLE
feat(clickpipes): expose PostgreSQL TLS controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,11 +1238,17 @@ any request.
 
 #### PostgreSQL ClickPipe prerequisites
 
-TLS and certificate verification are enabled by default and stay on. Pass the CA
-certificate or bundle as PEM with `--ca-certificate <PATH>` for a private or
-self-signed CA, and `--tls-host <HOSTNAME>` only when the certificate names a
-different hostname than `--host` (for example when `--host` is an IP address).
-The CLI reads the file and sends its contents, not the path.
+TLS and certificate verification are enabled by default. The private-CA example
+above is the preferred secure setup: pass the CA certificate or bundle as PEM
+with `--ca-certificate <PATH>`, and `--tls-host <HOSTNAME>` only when the
+certificate names a different hostname than `--host` (for example when `--host`
+is an IP address). The CLI reads the file and sends its contents, not the path.
+
+For controlled diagnosis, add `--skip-cert-verification` to keep the connection
+encrypted while accepting an untrusted or mismatched source certificate. Use
+`--disable-tls` only for a source intentionally configured for plaintext; source
+traffic is then unencrypted. `--disable-tls` cannot be combined with
+`--ca-certificate`, `--tls-host`, or `--skip-cert-verification`.
 
 Before creating a PostgreSQL CDC ClickPipe:
 

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -466,8 +466,8 @@ CONTEXT FOR AGENTS:
   For CDC the source needs logical replication, a publication containing every
   mapped table, and REPLICATION on the source user:
   https://clickhouse.com/docs/integrations/clickpipes/postgres
-  TLS and certificate verification are always on; --ca-certificate and --tls-host
-  adjust them, they cannot disable them.
+  TLS and certificate verification are on by default; prefer --ca-certificate
+  over either security opt-out for a private source CA.
   Only --sync-interval-seconds and --pull-batch-size can change after creation; the
   three <true|false> settings send false when omitted.")]
     Postgres(PostgresCreateArgs),
@@ -938,6 +938,17 @@ pub struct PostgresCreateArgs {
     /// Path to a PEM CA bundle for a private or self-signed source certificate
     #[arg(long, value_name = "PATH")]
     pub ca_certificate: Option<String>,
+
+    /// Disable TLS and send source traffic unencrypted (unsafe)
+    #[arg(
+        long,
+        conflicts_with_all = ["tls_host", "ca_certificate", "skip_cert_verification"]
+    )]
+    pub disable_tls: bool,
+
+    /// Skip certificate verification (unsafe; prefer --ca-certificate)
+    #[arg(long)]
+    pub skip_cert_verification: bool,
 
     /// Postgres publication name
     #[arg(long)]
@@ -2866,6 +2877,21 @@ fn validate_postgres_create_args(
             "--replication-slot-name can only be used with --replication-mode cdc_only",
         ));
     }
+    if args.disable_tls && args.tls_host.is_some() {
+        return Err(CloudError::new(
+            "--tls-host cannot be used with --disable-tls",
+        ));
+    }
+    if args.disable_tls && args.ca_certificate.is_some() {
+        return Err(CloudError::new(
+            "--ca-certificate cannot be used with --disable-tls",
+        ));
+    }
+    if args.disable_tls && args.skip_cert_verification {
+        return Err(CloudError::new(
+            "--skip-cert-verification cannot be used with --disable-tls",
+        ));
+    }
 
     // The simple mappings are sent first, then the JSON ones, each in the
     // order given: clap's derive API does not expose argv indices, so
@@ -2964,8 +2990,8 @@ fn build_postgres_request(
         host: args.host.clone(),
         port: i64::from(args.port),
         database: args.pg_database.clone(),
-        disable_tls: false,
-        skip_cert_verification: false,
+        disable_tls: args.disable_tls,
+        skip_cert_verification: args.skip_cert_verification,
         authentication,
         iam_role: args.iam_role.clone(),
         tls_host: args.tls_host.clone(),
@@ -5209,6 +5235,7 @@ mod tests {
             "tls.example",
             "--ca-certificate",
             "/tmp/ca.pem",
+            "--skip-cert-verification",
             "--publication-name",
             "publication",
             "--replication-slot-name",
@@ -5233,6 +5260,8 @@ mod tests {
         assert_eq!(args.iam_role.as_deref(), Some("arn:role"));
         assert_eq!(args.tls_host.as_deref(), Some("tls.example"));
         assert_eq!(args.ca_certificate.as_deref(), Some("/tmp/ca.pem"));
+        assert!(!args.disable_tls);
+        assert!(args.skip_cert_verification);
         assert_eq!(args.publication_name.as_deref(), Some("publication"));
         assert_eq!(args.replication_slot_name.as_deref(), Some("slot"));
         assert_eq!(args.org_id.as_deref(), Some("org-1"));
@@ -5267,6 +5296,8 @@ mod tests {
         assert_eq!(args.iam_role, None);
         assert_eq!(args.tls_host, None);
         assert_eq!(args.ca_certificate, None);
+        assert!(!args.disable_tls);
+        assert!(!args.skip_cert_verification);
         assert_eq!(args.publication_name, None);
         assert_eq!(args.replication_slot_name, None);
         assert_eq!(args.sync_interval_seconds, None);
@@ -5660,6 +5691,18 @@ mod tests {
                 Some("--replication-slot-name can only be used with --replication-mode cdc_only")
             );
         }
+
+        for tls_only_flag in [
+            vec!["--tls-host", "postgres.internal.example"],
+            vec!["--ca-certificate", "/tmp/postgres-ca.pem"],
+            vec!["--skip-cert-verification"],
+        ] {
+            let mut args = postgres_cli_args(Some("public.events:events"));
+            args.push("--disable-tls");
+            args.extend(tls_only_flag);
+            let error = clickpipe_parse_error(&args);
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     /// `<JSON>` is the value name clap renders for the flag's attribute.
@@ -5691,6 +5734,8 @@ mod tests {
             "--delete-on-merge <true|false>",
             "--ca-certificate <PATH>",
             "--tls-host <HOSTNAME>",
+            "--disable-tls",
+            "--skip-cert-verification",
         ] {
             assert!(help.contains(flag), "missing `{flag}`:\n{help}");
         }
@@ -7430,6 +7475,8 @@ mod tests {
             iam_role: None,
             tls_host: None,
             ca_certificate: None,
+            disable_tls: false,
+            skip_cert_verification: false,
             publication_name: None,
             replication_slot_name: None,
             sync_interval_seconds: None,
@@ -7529,6 +7576,7 @@ mod tests {
         args.iam_role = Some("arn:aws:iam::123456789012:role/clickpipe".into());
         args.tls_host = Some("database.internal".into());
         args.ca_certificate = Some(ca_certificate.to_string_lossy().into_owned());
+        args.skip_cert_verification = true;
         args.publication_name = Some("clickpipe_publication".into());
         args.replication_slot_name = Some("clickpipe_slot".into());
         args.sync_interval_seconds = Some(30);
@@ -7568,6 +7616,8 @@ mod tests {
         );
         assert_eq!(source.tls_host.as_deref(), Some("database.internal"));
         assert_eq!(source.ca_certificate.as_deref(), Some("POSTGRES_CA"));
+        assert!(!source.disable_tls);
+        assert!(source.skip_cert_verification);
         assert_eq!(source.settings.replication_mode.to_string(), "cdc_only");
         assert_eq!(
             source.settings.publication_name.as_deref(),
@@ -7595,6 +7645,23 @@ mod tests {
         assert_eq!(source.table_mappings[1].source_schema_name, "audit");
         assert_eq!(source.table_mappings[1].source_table, "events");
         assert_eq!(source.table_mappings[1].target_table, "audit_events");
+    }
+
+    #[test]
+    fn build_postgres_request_supports_explicit_tls_opt_outs() {
+        let mut args = postgres_builder_args();
+        args.skip_cert_verification = true;
+        let request = build_postgres_request(&args).unwrap();
+        let source = request.source.postgres.as_ref().expect("postgres source");
+        assert!(!source.disable_tls);
+        assert!(source.skip_cert_verification);
+
+        args.skip_cert_verification = false;
+        args.disable_tls = true;
+        let request = build_postgres_request(&args).unwrap();
+        let source = request.source.postgres.as_ref().expect("postgres source");
+        assert!(source.disable_tls);
+        assert!(!source.skip_cert_verification);
     }
 
     #[test]
@@ -7952,6 +8019,27 @@ mod tests {
                 let mut args = postgres_builder_args();
                 args.replication_slot_name = Some("slot".into());
                 (args, "--replication-slot-name can only be used")
+            },
+            {
+                let mut args = postgres_builder_args();
+                args.disable_tls = true;
+                args.tls_host = Some("postgres.internal.example".into());
+                (args, "--tls-host cannot be used with --disable-tls")
+            },
+            {
+                let mut args = postgres_builder_args();
+                args.disable_tls = true;
+                args.ca_certificate = Some("secret-ca-path".into());
+                (args, "--ca-certificate cannot be used with --disable-tls")
+            },
+            {
+                let mut args = postgres_builder_args();
+                args.disable_tls = true;
+                args.skip_cert_verification = true;
+                (
+                    args,
+                    "--skip-cert-verification cannot be used with --disable-tls",
+                )
             },
         ];
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3104,10 +3104,36 @@ async fn postgres_optional_fields_absent_when_flags_omitted() {
     .await;
 
     let pg = &body["source"]["postgres"];
+    assert_eq!(pg["disableTls"], false, "secure TLS default changed: {pg}");
+    assert_eq!(
+        pg["skipCertVerification"], false,
+        "certificate verification default changed: {pg}"
+    );
     for field in ["iamRole", "tlsHost", "caCertificate"] {
         assert!(
             pg.get(field).is_none(),
             "{field} leaked into postgres source body: {pg}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn postgres_tls_opt_outs_change_only_the_selected_wire_field() {
+    for (flag, disable_tls, skip_cert_verification) in [
+        ("--disable-tls", true, false),
+        ("--skip-cert-verification", false, true),
+    ] {
+        let mock = start_mock_clickpipes_api().await;
+        let mut args = postgres_args_minimal();
+        args.push(flag.into());
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let body = invoke_cli_capture_body(&mock, &arg_refs).await;
+        let pg = &body["source"]["postgres"];
+
+        assert_eq!(pg["disableTls"], disable_tls, "{flag}: {pg}");
+        assert_eq!(
+            pg["skipCertVerification"], skip_cert_verification,
+            "{flag}: {pg}"
         );
     }
 }
@@ -3734,17 +3760,19 @@ fn postgres_args_iam_role() -> Vec<String> {
 async fn postgres_invalid_inputs_exit_as_usage_errors_before_auth_file_or_network() {
     let mock = MockServer::start().await;
     let missing_ca = "/missing/postgres-ca.pem";
-    let base = || {
-        let mut args = postgres_args_minimal();
-        args.extend(["--ca-certificate".into(), missing_ca.into()]);
-        args
-    };
+    let secret_password = "postgres-password-must-not-appear";
     let replace_value = |args: &mut Vec<String>, flag: &str, value: &str| {
         let index = args
             .iter()
             .position(|arg| arg == flag)
             .unwrap_or_else(|| panic!("missing test flag {flag}"));
         args[index + 1] = value.into();
+    };
+    let base = || {
+        let mut args = postgres_args_minimal();
+        replace_value(&mut args, "--password", secret_password);
+        args.extend(["--ca-certificate".into(), missing_ca.into()]);
+        args
     };
 
     let mut cases = Vec::new();
@@ -3796,6 +3824,24 @@ async fn postgres_invalid_inputs_exit_as_usage_errors_before_auth_file_or_networ
         ));
     }
 
+    let mut disable_with_ca = base();
+    disable_with_ca.push("--disable-tls".into());
+    cases.push((disable_with_ca, "--disable-tls"));
+
+    for (tls_args, diagnostic) in [
+        (
+            vec!["--tls-host", "postgres.internal.example"],
+            "--tls-host",
+        ),
+        (vec!["--skip-cert-verification"], "--skip-cert-verification"),
+    ] {
+        let mut args = postgres_args_minimal();
+        replace_value(&mut args, "--password", secret_password);
+        args.push("--disable-tls".into());
+        args.extend(tls_args.into_iter().map(String::from));
+        cases.push((args, diagnostic));
+    }
+
     for (args, diagnostic) in cases {
         let output = invoke_cli_without_cloud_credentials(&mock, &args);
         assert_eq!(
@@ -3807,6 +3853,10 @@ async fn postgres_invalid_inputs_exit_as_usage_errors_before_auth_file_or_networ
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(stderr.contains(diagnostic), "{stderr}");
         assert!(!stderr.contains(missing_ca), "CA file was read: {stderr}");
+        assert!(
+            !stderr.contains(secret_password),
+            "password leaked into diagnostic: {stderr}"
+        );
     }
 
     assert!(mock.received_requests().await.unwrap().is_empty());
@@ -4168,11 +4218,19 @@ async fn postgres_ca_certificate_file_contents_flow_to_body() {
         "caCertificate body should contain the file's PEM content, got {}",
         body["source"]["postgres"]["caCertificate"]
     );
+    assert_eq!(body["source"]["postgres"]["disableTls"], false);
+    assert_eq!(body["source"]["postgres"]["skipCertVerification"], false);
 }
 
 #[tokio::test]
 async fn postgres_unknown_authority_error_preserves_api_detail_and_adds_ca_hint() {
     let mock = MockServer::start().await;
+    let directory = tempfile::tempdir().unwrap();
+    let ca_path = directory.path().join("private-ca.pem");
+    let ca_path_display = ca_path.to_string_lossy().into_owned();
+    let ca_contents = "certificate-body-must-not-appear";
+    std::fs::write(&ca_path, ca_contents).unwrap();
+    let password = "postgres-password-must-not-appear";
     let api_error = "BAD_REQUEST: failed to establish connection: tls: failed to verify \
                      certificate: x509: certificate signed by unknown authority";
     Mock::given(method("POST"))
@@ -4186,7 +4244,10 @@ async fn postgres_unknown_authority_error_preserves_api_detail_and_adds_ca_hint(
         .mount(&mock)
         .await;
 
-    let args = postgres_args_minimal();
+    let mut args = postgres_args_minimal();
+    let password_index = args.iter().position(|arg| arg == "--password").unwrap();
+    args[password_index + 1] = password.into();
+    args.extend(["--ca-certificate".into(), ca_path_display.clone()]);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
     let output = invoke_cli_with_cloud_credentials(&mock, &arg_refs);
     assert_eq!(output.status.code(), Some(1));
@@ -4197,6 +4258,12 @@ async fn postgres_unknown_authority_error_preserves_api_detail_and_adds_ca_hint(
         stderr.contains("private or self-signed source CA"),
         "{stderr}"
     );
+    for secret in [password, ca_contents, ca_path_display.as_str()] {
+        assert!(
+            !stderr.contains(secret),
+            "secret leaked into error: {stderr}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #448.

## Summary

- expose PostgreSQL ClickPipe `--disable-tls` and `--skip-cert-verification` controls while preserving the existing secure `false` defaults on the wire
- reject `--disable-tls` with `--tls-host`, `--ca-certificate`, or `--skip-cert-verification` before file access, authentication, or HTTP
- document the security tradeoffs and keep the private-CA path as the recommended configuration
- cover CLI defaults and conflicts, minimal/maximal builders, exact request bodies, CA files, auth variants, error redaction, and no-request validation failures

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl --bin clickhousectl postgres_` (88 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test postgres_` (48 passed)
- `cargo test -p clickhousectl` was run twice. Across both runs every suite passed, but each aggregate run hit one different unrelated timing-sensitive failure in unchanged code:
  - first run: `telemetry_test::a_refused_stdout_write_is_an_io_failure_of_the_response_stream`; exact rerun with `cargo test -p clickhousectl --test telemetry_test a_refused_stdout_write_is_an_io_failure_of_the_response_stream -- --exact` passed
  - second run: `local_structured_errors_test::foreground_child_exit_is_not_wrapped_as_a_local_error`; exact rerun with `cargo test -p clickhousectl --test local_structured_errors_test foreground_child_exit_is_not_wrapped_as_a_local_error -- --exact` passed
