### PR TITLE
feat(clickstack): expose dashboard management and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ psql "$POSTGRES_CONNECTION_STRING" --command "SELECT version()"
 
 `postgres create` returns an initial password, which the CLI prints once; store it securely.
 
-Manage ClickStack data sources and roles for an existing service with JSON configuration files:
+Manage ClickStack data sources, roles, and dashboards for an existing service with JSON configuration files:
 
 ```bash
 clickhousectl cloud clickstack source list <service-id> --org-id <org-id>
@@ -162,6 +162,10 @@ clickhousectl cloud clickstack saved-search get <service-id> <saved-search-id> \
   --org-id <org-id>
 clickhousectl cloud clickstack saved-search update <service-id> <saved-search-id> \
   --config-file saved-search.json --org-id <org-id>
+clickhousectl cloud clickstack dashboard validate <service-id> \
+  --config-file dashboard.json --org-id <org-id>
+clickhousectl cloud clickstack dashboard create <service-id> \
+  --config-file dashboard.json --org-id <org-id>
 ```
 
 Pass `--config-file -` to read the JSON body from stdin. Resource IDs come from the respective
@@ -169,6 +173,49 @@ Pass `--config-file -` to read the JSON body from stdin. Resource IDs come from 
 `where`, `whereLanguage`, `orderBy`, `tags`, and structured `filters`; obtain `sourceId` with
 `cloud clickstack source list`. All ClickStack `update` commands use PUT replacement semantics, so
 the configuration must contain the complete desired resource rather than only changed fields.
+
+A dashboard configuration contains the complete tile layout and typed chart configuration. Filters may
+broadcast selections, expose variables to tile queries, or do both:
+
+```json
+{
+  "name": "Service health",
+  "tiles": [
+    {
+      "name": "Request rate",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 3,
+      "config": {
+        "displayType": "line",
+        "sourceId": "<source-id>",
+        "select": [{ "aggFn": "count" }],
+        "formulas": [{ "expression": "A * 60", "alias": "Requests/min" }],
+        "showOperandSeries": false
+      }
+    }
+  ],
+  "filters": [
+    {
+      "name": "Service",
+      "expression": "ServiceName",
+      "sourceId": "<source-id>",
+      "type": "QUERY_EXPRESSION",
+      "isBroadcastEnabled": true,
+      "isVariableEnabled": true,
+      "variableName": "service"
+    }
+  ],
+  "savedFilterValues": [
+    { "type": "variable", "name": "service", "values": ["api"] }
+  ]
+}
+```
+
+Run `dashboard validate` before create or update to check the same dashboard body without saving it.
+`dashboard update <service-id> <dashboard-id> --config-file dashboard.json` is a full PUT replacement:
+include every tile, filter, container, tag, and saved query value that should remain.
 
 ## Local
 

--- a/crates/clickhousectl/src/cloud/clickstack.rs
+++ b/crates/clickhousectl/src/cloud/clickstack.rs
@@ -4,13 +4,14 @@ use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::resolve_org_id;
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
-    ClickStackCreateRoleRequest, ClickStackLogSource,
-    ClickStackLogSourceUsetextindexforimplicitcolumn, ClickStackMaterializedView,
-    ClickStackMaterializedViewMingranularity, ClickStackMetricSource, ClickStackPromqlSource,
-    ClickStackRole, ClickStackSavedSearch, ClickStackSavedSearchFilterType,
+    ClickStackCreateDashboardRequest, ClickStackCreateRoleRequest, ClickStackDashboardResponse,
+    ClickStackLogSource, ClickStackLogSourceUsetextindexforimplicitcolumn,
+    ClickStackMaterializedView, ClickStackMaterializedViewMingranularity, ClickStackMetricSource,
+    ClickStackPromqlSource, ClickStackRole, ClickStackSavedSearch, ClickStackSavedSearchFilterType,
     ClickStackSavedSearchInput, ClickStackSavedSearchInputWherelanguage, ClickStackSessionSource,
     ClickStackSource, ClickStackSourceResponse, ClickStackTraceSource,
-    ClickStackTraceSourceUsetextindexforimplicitcolumn, ClickStackUpdateRoleRequest,
+    ClickStackTraceSourceUsetextindexforimplicitcolumn, ClickStackUpdateDashboardRequest,
+    ClickStackUpdateRoleRequest, ClickStackValidateDashboardResponse,
 };
 use serde_json::Value;
 use tabled::{Table, Tabled, settings::Style};
@@ -29,6 +30,11 @@ pub enum ClickStackCommands {
         command: RoleCommands,
     },
 
+    /// Manage ClickStack dashboards
+    Dashboard {
+        #[command(subcommand)]
+        command: DashboardCommands,
+    },
     /// Manage ClickStack saved searches
     SavedSearch {
         #[command(subcommand)]
@@ -41,7 +47,97 @@ impl ClickStackCommands {
         match self {
             Self::Source { command } => command.is_write(),
             Self::Role { command } => command.is_write(),
+            Self::Dashboard { command } => command.is_write(),
             Self::SavedSearch { command } => command.is_write(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum DashboardCommands {
+    /// List ClickStack dashboards
+    List {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get ClickStack dashboard details
+    Get {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Dashboard ID (from `cloud clickstack dashboard list`)
+        dashboard_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Create a ClickStack dashboard
+    Create {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Replace a ClickStack dashboard
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  This is a full PUT replacement; include every required and desired field.
+  Serialize edits to one dashboard; concurrent updates can overwrite each other.")]
+    Update {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Dashboard ID (from `cloud clickstack dashboard list`)
+        dashboard_id: String,
+        /// Complete JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Delete a ClickStack dashboard
+    Delete {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// Dashboard ID (from `cloud clickstack dashboard list`)
+        dashboard_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Validate a ClickStack dashboard without saving it
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Validation never persists the dashboard.
+  Uses API key authentication under the CLI's write-command policy.")]
+    Validate {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl DashboardCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            Self::List { .. } | Self::Get { .. } => false,
+            // Validation is side-effect-free, but the Cloud API exposes it as POST;
+            // classify it consistently with API-key-only mutation-style endpoints.
+            Self::Create { .. }
+            | Self::Update { .. }
+            | Self::Delete { .. }
+            | Self::Validate { .. } => true,
         }
     }
 }
@@ -266,6 +362,909 @@ fn build_update_role_request(config_file: &str) -> CloudResult<ClickStackUpdateR
     read_typed_config(config_file)
 }
 
+fn build_create_dashboard_request(
+    config_file: &str,
+) -> CloudResult<ClickStackCreateDashboardRequest> {
+    let value = read_config_value(config_file)?;
+    validate_dashboard_unions(&value, config_file)?;
+    let request = deserialize_strict_config(value, config_file)?;
+    validate_create_dashboard_enums(&request, config_file)?;
+    Ok(request)
+}
+
+fn build_update_dashboard_request(
+    config_file: &str,
+) -> CloudResult<ClickStackUpdateDashboardRequest> {
+    let value = read_config_value(config_file)?;
+    validate_dashboard_unions(&value, config_file)?;
+    let request = deserialize_strict_config(value, config_file)?;
+    validate_update_dashboard_enums(&request, config_file)?;
+    Ok(request)
+}
+
+fn invalid_dashboard(source: &str, message: impl std::fmt::Display) -> CloudError {
+    CloudError::new(format!(
+        "invalid dashboard request body in config {source}: {message}"
+    ))
+}
+
+fn require_discriminator<'a>(
+    value: &'a Value,
+    key: &str,
+    path: &str,
+    source: &str,
+) -> CloudResult<&'a str> {
+    field(value, key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_dashboard(source, format!("{path}.{key} must be a string")))
+}
+
+fn strict_dashboard_variant<T>(value: &Value, path: &str, source: &str) -> CloudResult<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    deserialize_strict_config::<T>(value.clone(), source)
+        .map_err(|error| invalid_dashboard(source, format!("invalid {path}: {}", error.message)))
+}
+
+macro_rules! reject_unknown_enum {
+    ($value:expr, $variant:path, $binding:ident, $path:expr, $source:expr) => {
+        #[allow(clippy::collapsible_match)]
+        match $value {
+            $variant($binding) => {
+                return Err(invalid_dashboard(
+                    $source,
+                    format!("unknown {} value `{}`", $path, $binding),
+                ))
+            }
+            _ => {}
+        }
+    };
+}
+
+fn validate_number_format(
+    format: &clickhouse_cloud_api::models::ClickStackNumberFormat,
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackNumberFormatNumericunit, ClickStackNumberFormatOutput,
+    };
+    reject_unknown_enum!(
+        &format.numeric_unit,
+        ClickStackNumberFormatNumericunit::Unknown,
+        value,
+        format!("{path}.numericUnit"),
+        source
+    );
+    reject_unknown_enum!(
+        &format.output,
+        ClickStackNumberFormatOutput::Unknown,
+        value,
+        format!("{path}.output"),
+        source
+    );
+    Ok(())
+}
+
+fn validate_formulas(
+    formulas: Option<&Vec<clickhouse_cloud_api::models::ClickStackFormula>>,
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    for (index, formula) in formulas.into_iter().flatten().enumerate() {
+        if let Some(format) = &formula.number_format {
+            validate_number_format(format, &format!("{path}[{index}].numberFormat"), source)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_select_items(
+    items: &[clickhouse_cloud_api::models::ClickStackSelectItem],
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackSelectItemAggfn, ClickStackSelectItemLevel, ClickStackSelectItemMetrictype,
+        ClickStackSelectItemPeriodaggfn, ClickStackSelectItemWherelanguage,
+    };
+    for (index, item) in items.iter().enumerate() {
+        let item_path = format!("{path}[{index}]");
+        reject_unknown_enum!(
+            &item.agg_fn,
+            ClickStackSelectItemAggfn::Unknown,
+            value,
+            format!("{item_path}.aggFn"),
+            source
+        );
+        if let Some(level) = &item.level {
+            reject_unknown_enum!(
+                level,
+                ClickStackSelectItemLevel::Unknown,
+                value,
+                format!("{item_path}.level"),
+                source
+            );
+        }
+        if let Some(metric_type) = &item.metric_type {
+            reject_unknown_enum!(
+                metric_type,
+                ClickStackSelectItemMetrictype::Unknown,
+                value,
+                format!("{item_path}.metricType"),
+                source
+            );
+        }
+        if let Some(period_agg_fn) = &item.period_agg_fn {
+            reject_unknown_enum!(
+                period_agg_fn,
+                ClickStackSelectItemPeriodaggfn::Unknown,
+                value,
+                format!("{item_path}.periodAggFn"),
+                source
+            );
+        }
+        if let Some(where_language) = &item.where_language {
+            reject_unknown_enum!(
+                where_language,
+                ClickStackSelectItemWherelanguage::Unknown,
+                value,
+                format!("{item_path}.whereLanguage"),
+                source
+            );
+        }
+        if let Some(format) = &item.number_format {
+            validate_number_format(format, &format!("{item_path}.numberFormat"), source)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_on_click_filters(
+    filters: Option<&Vec<clickhouse_cloud_api::models::ClickStackOnClickFilterTemplate>>,
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::ClickStackOnClickFilterTemplateKind;
+    for (index, filter) in filters.into_iter().flatten().enumerate() {
+        reject_unknown_enum!(
+            &filter.kind,
+            ClickStackOnClickFilterTemplateKind::Unknown,
+            value,
+            format!("{path}[{index}].kind"),
+            source
+        );
+    }
+    Ok(())
+}
+
+fn validate_on_click(value: &Value, path: &str, source: &str) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackOnClickDashboard, ClickStackOnClickDashboardType,
+        ClickStackOnClickDashboardWherelanguage, ClickStackOnClickExternal,
+        ClickStackOnClickExternalType, ClickStackOnClickSearch, ClickStackOnClickSearchType,
+        ClickStackOnClickSearchWherelanguage, ClickStackOnClickTargetIdVariant,
+        ClickStackOnClickTargetIdVariantMode, ClickStackOnClickTargetTemplateVariant,
+        ClickStackOnClickTargetTemplateVariantMode,
+    };
+
+    match require_discriminator(value, "type", path, source)? {
+        "search" => {
+            let on_click =
+                strict_dashboard_variant::<ClickStackOnClickSearch>(value, path, source)?;
+            reject_unknown_enum!(
+                &on_click.r#type,
+                ClickStackOnClickSearchType::Unknown,
+                value,
+                format!("{path}.type"),
+                source
+            );
+            if let Some(language) = &on_click.where_language {
+                reject_unknown_enum!(
+                    language,
+                    ClickStackOnClickSearchWherelanguage::Unknown,
+                    value,
+                    format!("{path}.whereLanguage"),
+                    source
+                );
+            }
+            validate_on_click_filters(
+                on_click.filters.as_ref(),
+                &format!("{path}.filters"),
+                source,
+            )?;
+        }
+        "dashboard" => {
+            let on_click =
+                strict_dashboard_variant::<ClickStackOnClickDashboard>(value, path, source)?;
+            reject_unknown_enum!(
+                &on_click.r#type,
+                ClickStackOnClickDashboardType::Unknown,
+                value,
+                format!("{path}.type"),
+                source
+            );
+            if let Some(language) = &on_click.where_language {
+                reject_unknown_enum!(
+                    language,
+                    ClickStackOnClickDashboardWherelanguage::Unknown,
+                    value,
+                    format!("{path}.whereLanguage"),
+                    source
+                );
+            }
+            validate_on_click_filters(
+                on_click.filters.as_ref(),
+                &format!("{path}.filters"),
+                source,
+            )?;
+        }
+        "external" => {
+            let on_click =
+                strict_dashboard_variant::<ClickStackOnClickExternal>(value, path, source)?;
+            reject_unknown_enum!(
+                &on_click.r#type,
+                ClickStackOnClickExternalType::Unknown,
+                value,
+                format!("{path}.type"),
+                source
+            );
+        }
+        other => {
+            return Err(invalid_dashboard(
+                source,
+                format!("unknown {path}.type `{other}`; expected search, dashboard, or external"),
+            ));
+        }
+    }
+
+    if let Some(target) = field(value, "target") {
+        let target_path = format!("{path}.target");
+        match require_discriminator(target, "mode", &target_path, source)? {
+            "id" => {
+                let target = strict_dashboard_variant::<ClickStackOnClickTargetIdVariant>(
+                    target,
+                    &target_path,
+                    source,
+                )?;
+                reject_unknown_enum!(
+                    &target.mode,
+                    ClickStackOnClickTargetIdVariantMode::Unknown,
+                    value,
+                    format!("{target_path}.mode"),
+                    source
+                );
+            }
+            "template" => {
+                let target = strict_dashboard_variant::<ClickStackOnClickTargetTemplateVariant>(
+                    target,
+                    &target_path,
+                    source,
+                )?;
+                reject_unknown_enum!(
+                    &target.mode,
+                    ClickStackOnClickTargetTemplateVariantMode::Unknown,
+                    value,
+                    format!("{target_path}.mode"),
+                    source
+                );
+            }
+            other => {
+                return Err(invalid_dashboard(
+                    source,
+                    format!("unknown {target_path}.mode `{other}`; expected id or template"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_number_color_rules(value: &Value, path: &str, source: &str) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackBetweenColorCondition, ClickStackBetweenColorConditionOperator,
+        ClickStackChartColor, ClickStackEqualityColorCondition,
+        ClickStackEqualityColorConditionOperator, ClickStackNumericColorCondition,
+        ClickStackNumericColorConditionOperator,
+    };
+    let Some(rules) = field(value, "colorRules").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for (index, rule) in rules.iter().enumerate() {
+        let rule_path = format!("{path}.colorRules[{index}]");
+        match require_discriminator(rule, "operator", &rule_path, source)? {
+            "gt" | "gte" | "lt" | "lte" => {
+                let condition = strict_dashboard_variant::<ClickStackNumericColorCondition>(
+                    rule, &rule_path, source,
+                )?;
+                reject_unknown_enum!(
+                    &condition.color,
+                    ClickStackChartColor::Unknown,
+                    value,
+                    format!("{rule_path}.color"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &condition.operator,
+                    ClickStackNumericColorConditionOperator::Unknown,
+                    value,
+                    format!("{rule_path}.operator"),
+                    source
+                );
+            }
+            "between" => {
+                let condition = strict_dashboard_variant::<ClickStackBetweenColorCondition>(
+                    rule, &rule_path, source,
+                )?;
+                reject_unknown_enum!(
+                    &condition.color,
+                    ClickStackChartColor::Unknown,
+                    value,
+                    format!("{rule_path}.color"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &condition.operator,
+                    ClickStackBetweenColorConditionOperator::Unknown,
+                    value,
+                    format!("{rule_path}.operator"),
+                    source
+                );
+            }
+            "eq" | "neq" => {
+                let condition = strict_dashboard_variant::<ClickStackEqualityColorCondition>(
+                    rule, &rule_path, source,
+                )?;
+                reject_unknown_enum!(
+                    &condition.color,
+                    ClickStackChartColor::Unknown,
+                    value,
+                    format!("{rule_path}.color"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &condition.operator,
+                    ClickStackEqualityColorConditionOperator::Unknown,
+                    value,
+                    format!("{rule_path}.operator"),
+                    source
+                );
+                let valid_value = condition.value.as_str().is_some()
+                    || condition.value.as_f64().is_some_and(f64::is_finite);
+                if !valid_value {
+                    return Err(invalid_dashboard(
+                        source,
+                        format!("{rule_path}.value must be a finite number or string"),
+                    ));
+                }
+            }
+            other => {
+                return Err(invalid_dashboard(
+                    source,
+                    format!("unknown {rule_path}.operator `{other}`"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_optional_number_format(
+    format: Option<&clickhouse_cloud_api::models::ClickStackNumberFormat>,
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    if let Some(format) = format {
+        validate_number_format(format, path, source)?;
+    }
+    Ok(())
+}
+
+fn validate_common_builder_fields(
+    formulas: Option<&Vec<clickhouse_cloud_api::models::ClickStackFormula>>,
+    select: &[clickhouse_cloud_api::models::ClickStackSelectItem],
+    number_format: Option<&clickhouse_cloud_api::models::ClickStackNumberFormat>,
+    path: &str,
+    source: &str,
+) -> CloudResult<()> {
+    validate_formulas(formulas, &format!("{path}.formulas"), source)?;
+    validate_select_items(select, &format!("{path}.select"), source)?;
+    validate_optional_number_format(number_format, &format!("{path}.numberFormat"), source)
+}
+
+fn validate_chart_config(value: &Value, path: &str, source: &str) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::*;
+
+    let display_type = require_discriminator(value, "displayType", path, source)?;
+    let config_type = field(value, "configType");
+    if let Some(config_type) = config_type
+        && config_type.as_str() != Some("sql")
+    {
+        let rendered = config_type
+            .as_str()
+            .map(str::to_owned)
+            .unwrap_or_else(|| config_type.to_string());
+        return Err(invalid_dashboard(
+            source,
+            format!("unknown {path}.configType `{rendered}`; expected sql or omission"),
+        ));
+    }
+
+    match display_type {
+        "line" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackLineRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackLineRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackLineRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackLineBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackLineBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_common_builder_fields(
+                    config.formulas.as_ref(),
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+        }
+        "stacked_bar" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackBarRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackBarRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackBarRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackBarBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackBarBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_common_builder_fields(
+                    config.formulas.as_ref(),
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+        }
+        "bar" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackCategoricalBarRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackCategoricalBarRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackCategoricalBarRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackCategoricalBarBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackCategoricalBarBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_common_builder_fields(
+                    None,
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+        }
+        "table" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackTableRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackTableRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackTableRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackTableBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackTableBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_common_builder_fields(
+                    config.formulas.as_ref(),
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+            if let Some(on_click) = field(value, "onClick") {
+                validate_on_click(on_click, &format!("{path}.onClick"), source)?;
+            }
+        }
+        "number" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackNumberRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackNumberRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackNumberRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                if let Some(color) = &config.color {
+                    reject_unknown_enum!(
+                        color,
+                        ClickStackChartColor::Unknown,
+                        unknown,
+                        format!("{path}.color"),
+                        source
+                    );
+                }
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackNumberBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackNumberBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                if let Some(color) = &config.color {
+                    reject_unknown_enum!(
+                        color,
+                        ClickStackChartColor::Unknown,
+                        unknown,
+                        format!("{path}.color"),
+                        source
+                    );
+                }
+                if let Some(background) = &config.background_chart {
+                    reject_unknown_enum!(
+                        &background.r#type,
+                        ClickStackBackgroundChartType::Unknown,
+                        unknown,
+                        format!("{path}.backgroundChart.type"),
+                        source
+                    );
+                    if let Some(color) = &background.color {
+                        reject_unknown_enum!(
+                            color,
+                            ClickStackChartColor::Unknown,
+                            unknown,
+                            format!("{path}.backgroundChart.color"),
+                            source
+                        );
+                    }
+                }
+                validate_common_builder_fields(
+                    config.formulas.as_ref(),
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+            validate_number_color_rules(value, path, source)?;
+        }
+        "pie" => {
+            if config_type.is_some() {
+                let config = strict_dashboard_variant::<ClickStackPieRawSqlChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.config_type,
+                    ClickStackPieRawSqlChartConfigConfigtype::Unknown,
+                    unknown,
+                    format!("{path}.configType"),
+                    source
+                );
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackPieRawSqlChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_optional_number_format(
+                    config.number_format.as_ref(),
+                    &format!("{path}.numberFormat"),
+                    source,
+                )?;
+            } else {
+                let config = strict_dashboard_variant::<ClickStackPieBuilderChartConfig>(
+                    value, path, source,
+                )?;
+                reject_unknown_enum!(
+                    &config.display_type,
+                    ClickStackPieBuilderChartConfigDisplaytype::Unknown,
+                    unknown,
+                    format!("{path}.displayType"),
+                    source
+                );
+                validate_common_builder_fields(
+                    None,
+                    &config.select,
+                    config.number_format.as_ref(),
+                    path,
+                    source,
+                )?;
+            }
+        }
+        "heatmap" => {
+            let config =
+                strict_dashboard_variant::<ClickStackHeatmapChartConfig>(value, path, source)?;
+            reject_unknown_enum!(
+                &config.display_type,
+                ClickStackHeatmapChartConfigDisplaytype::Unknown,
+                unknown,
+                format!("{path}.displayType"),
+                source
+            );
+            if let Some(language) = &config.where_language {
+                reject_unknown_enum!(
+                    language,
+                    ClickStackHeatmapChartConfigWherelanguage::Unknown,
+                    unknown,
+                    format!("{path}.whereLanguage"),
+                    source
+                );
+            }
+            for (index, item) in config.select.iter().enumerate() {
+                if let Some(scale) = &item.heatmap_scale_type {
+                    reject_unknown_enum!(
+                        scale,
+                        ClickStackHeatmapSelectItemHeatmapscaletype::Unknown,
+                        unknown,
+                        format!("{path}.select[{index}].heatmapScaleType"),
+                        source
+                    );
+                }
+            }
+            validate_optional_number_format(
+                config.number_format.as_ref(),
+                &format!("{path}.numberFormat"),
+                source,
+            )?;
+        }
+        "search" => {
+            let config =
+                strict_dashboard_variant::<ClickStackSearchChartConfig>(value, path, source)?;
+            reject_unknown_enum!(
+                &config.display_type,
+                ClickStackSearchChartConfigDisplaytype::Unknown,
+                unknown,
+                format!("{path}.displayType"),
+                source
+            );
+            reject_unknown_enum!(
+                &config.where_language,
+                ClickStackSearchChartConfigWherelanguage::Unknown,
+                unknown,
+                format!("{path}.whereLanguage"),
+                source
+            );
+        }
+        "event_patterns" => {
+            let config = strict_dashboard_variant::<ClickStackEventPatternsChartConfig>(
+                value, path, source,
+            )?;
+            reject_unknown_enum!(
+                &config.display_type,
+                ClickStackEventPatternsChartConfigDisplaytype::Unknown,
+                unknown,
+                format!("{path}.displayType"),
+                source
+            );
+            if let Some(language) = &config.where_language {
+                reject_unknown_enum!(
+                    language,
+                    ClickStackEventPatternsChartConfigWherelanguage::Unknown,
+                    unknown,
+                    format!("{path}.whereLanguage"),
+                    source
+                );
+            }
+        }
+        "markdown" => {
+            let config =
+                strict_dashboard_variant::<ClickStackMarkdownChartConfig>(value, path, source)?;
+            reject_unknown_enum!(
+                &config.display_type,
+                ClickStackMarkdownChartConfigDisplaytype::Unknown,
+                unknown,
+                format!("{path}.displayType"),
+                source
+            );
+        }
+        other => {
+            return Err(invalid_dashboard(
+                source,
+                format!(
+                    "unknown {path}.displayType `{other}`; expected line, stacked_bar, bar, table, number, pie, heatmap, search, event_patterns, or markdown"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_saved_filter_value(value: &Value, path: &str, source: &str) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackSavedFilterValueType, ClickStackSqlSavedFilterValue,
+        ClickStackVariableSavedFilterValue, ClickStackVariableSavedFilterValueType,
+    };
+    match field(value, "type") {
+        None => {
+            let saved =
+                strict_dashboard_variant::<ClickStackSqlSavedFilterValue>(value, path, source)?;
+            if let Some(kind) = &saved.r#type {
+                reject_unknown_enum!(
+                    kind,
+                    ClickStackSavedFilterValueType::Unknown,
+                    unknown,
+                    format!("{path}.type"),
+                    source
+                );
+            }
+            Ok(())
+        }
+        Some(Value::String(kind)) if kind == "sql" => {
+            let saved =
+                strict_dashboard_variant::<ClickStackSqlSavedFilterValue>(value, path, source)?;
+            if let Some(kind) = &saved.r#type {
+                reject_unknown_enum!(
+                    kind,
+                    ClickStackSavedFilterValueType::Unknown,
+                    unknown,
+                    format!("{path}.type"),
+                    source
+                );
+            }
+            Ok(())
+        }
+        Some(Value::String(kind)) if kind == "variable" => {
+            let saved = strict_dashboard_variant::<ClickStackVariableSavedFilterValue>(
+                value, path, source,
+            )?;
+            reject_unknown_enum!(
+                &saved.r#type,
+                ClickStackVariableSavedFilterValueType::Unknown,
+                unknown,
+                format!("{path}.type"),
+                source
+            );
+            Ok(())
+        }
+        Some(other) => Err(invalid_dashboard(
+            source,
+            format!("unknown {path}.type `{other}`; expected sql, variable, or omission"),
+        )),
+    }
+}
+
+fn validate_dashboard_unions(value: &Value, source: &str) -> CloudResult<()> {
+    let Some(tiles) = field(value, "tiles").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for (index, tile) in tiles.iter().enumerate() {
+        if let Some(config) = field(tile, "config") {
+            validate_chart_config(config, &format!("tiles[{index}].config"), source)?;
+        }
+    }
+    if let Some(values) = field(value, "savedFilterValues").and_then(Value::as_array) {
+        for (index, saved) in values.iter().enumerate() {
+            validate_saved_filter_value(saved, &format!("savedFilterValues[{index}]"), source)?;
+        }
+    }
+    Ok(())
+}
+
 fn build_saved_search_request(config_file: &str) -> CloudResult<ClickStackSavedSearchInput> {
     let request: ClickStackSavedSearchInput = read_typed_config(config_file)?;
     validate_saved_search_closed_enums(&request, config_file)?;
@@ -293,6 +1292,102 @@ fn validate_saved_search_closed_enums(
         return Err(CloudError::new(format!(
             "invalid request body in config {source}: unknown filters[{index}].type value `{value}`"
         )));
+    }
+    Ok(())
+}
+
+fn validate_create_dashboard_enums(
+    request: &ClickStackCreateDashboardRequest,
+    source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackCreateDashboardRequestSavedquerylanguage, ClickStackFilterInputSourcemetrictype,
+        ClickStackFilterInputType, ClickStackFilterInputWherelanguage,
+    };
+    if let Some(language) = &request.saved_query_language {
+        reject_unknown_enum!(
+            language,
+            ClickStackCreateDashboardRequestSavedquerylanguage::Unknown,
+            unknown,
+            "savedQueryLanguage",
+            source
+        );
+    }
+    for (index, filter) in request.filters.iter().flatten().enumerate() {
+        let path = format!("filters[{index}]");
+        if let Some(metric_type) = &filter.source_metric_type {
+            reject_unknown_enum!(
+                metric_type,
+                ClickStackFilterInputSourcemetrictype::Unknown,
+                unknown,
+                format!("{path}.sourceMetricType"),
+                source
+            );
+        }
+        reject_unknown_enum!(
+            &filter.r#type,
+            ClickStackFilterInputType::Unknown,
+            unknown,
+            format!("{path}.type"),
+            source
+        );
+        if let Some(language) = &filter.where_language {
+            reject_unknown_enum!(
+                language,
+                ClickStackFilterInputWherelanguage::Unknown,
+                unknown,
+                format!("{path}.whereLanguage"),
+                source
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_update_dashboard_enums(
+    request: &ClickStackUpdateDashboardRequest,
+    source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickStackFilterSourcemetrictype, ClickStackFilterType, ClickStackFilterWherelanguage,
+        ClickStackUpdateDashboardRequestSavedquerylanguage,
+    };
+    if let Some(language) = &request.saved_query_language {
+        reject_unknown_enum!(
+            language,
+            ClickStackUpdateDashboardRequestSavedquerylanguage::Unknown,
+            unknown,
+            "savedQueryLanguage",
+            source
+        );
+    }
+    for (index, filter) in request.filters.iter().flatten().enumerate() {
+        let path = format!("filters[{index}]");
+        if let Some(metric_type) = &filter.source_metric_type {
+            reject_unknown_enum!(
+                metric_type,
+                ClickStackFilterSourcemetrictype::Unknown,
+                unknown,
+                format!("{path}.sourceMetricType"),
+                source
+            );
+        }
+        reject_unknown_enum!(
+            &filter.r#type,
+            ClickStackFilterType::Unknown,
+            unknown,
+            format!("{path}.type"),
+            source
+        );
+        if let Some(language) = &filter.where_language {
+            reject_unknown_enum!(
+                language,
+                ClickStackFilterWherelanguage::Unknown,
+                unknown,
+                format!("{path}.whereLanguage"),
+                source
+            );
+        }
     }
     Ok(())
 }
@@ -384,8 +1479,85 @@ pub async fn run(client: &CloudClient, command: ClickStackCommands, json: bool) 
     match command {
         ClickStackCommands::Source { command } => run_source(client, command, json).await,
         ClickStackCommands::Role { command } => run_role(client, command, json).await,
+        ClickStackCommands::Dashboard { command } => run_dashboard(client, command, json).await,
         ClickStackCommands::SavedSearch { command } => {
             run_saved_search(client, command, json).await
+        }
+    }
+}
+
+async fn run_dashboard(
+    client: &CloudClient,
+    command: DashboardCommands,
+    json: bool,
+) -> CloudResult<()> {
+    match command {
+        DashboardCommands::List { service_id, org_id } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let dashboards = client
+                .click_stack_list_dashboards(&org_id, &service_id)
+                .await?;
+            print_dashboard_list(&dashboards, json)
+        }
+        DashboardCommands::Get {
+            service_id,
+            dashboard_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let dashboard = client
+                .click_stack_get_dashboard(&org_id, &service_id, &dashboard_id)
+                .await?;
+            print_detail(&dashboard, json)
+        }
+        DashboardCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_create_dashboard_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let dashboard = client
+                .click_stack_create_dashboard(&org_id, &service_id, &request)
+                .await?;
+            print_detail(&dashboard, json)
+        }
+        DashboardCommands::Update {
+            service_id,
+            dashboard_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_update_dashboard_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let dashboard = client
+                .click_stack_update_dashboard(&org_id, &service_id, &dashboard_id, &request)
+                .await?;
+            print_detail(&dashboard, json)
+        }
+        DashboardCommands::Delete {
+            service_id,
+            dashboard_id,
+            org_id,
+        } => {
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            client
+                .click_stack_delete_dashboard(&org_id, &service_id, &dashboard_id)
+                .await?;
+            print_deleted("ClickStack dashboard", &dashboard_id, json);
+            Ok(())
+        }
+        DashboardCommands::Validate {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_create_dashboard_request(&config_file)?;
+            let org_id = resolve_org_id(client, org_id.as_deref()).await?;
+            let validation = client
+                .click_stack_validate_dashboard(&org_id, &service_id, &request)
+                .await?;
+            print_detail(&validation, json)
         }
     }
 }
@@ -671,6 +1843,44 @@ fn print_role_list(roles: &[ClickStackRole], json: bool) -> CloudResult<()> {
     Ok(())
 }
 
+fn print_dashboard_list(dashboards: &[ClickStackDashboardResponse], json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(dashboards)?);
+        return Ok(());
+    }
+    #[derive(Tabled)]
+    struct Row {
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "ID")]
+        id: String,
+        #[tabled(rename = "Tiles")]
+        tiles: String,
+        #[tabled(rename = "Tags")]
+        tags: String,
+    }
+    let rows = dashboards
+        .iter()
+        .map(|dashboard| Row {
+            name: or_absent(dashboard.name.as_deref()),
+            id: or_absent(dashboard.id.as_deref()),
+            tiles: dashboard
+                .tiles
+                .as_ref()
+                .map(|tiles| tiles.len().to_string())
+                .unwrap_or_else(|| "-".into()),
+            tags: dashboard
+                .tags
+                .as_ref()
+                .map(|tags| tags.join(", "))
+                .filter(|tags| !tags.is_empty())
+                .unwrap_or_else(|| "-".into()),
+        })
+        .collect::<Vec<_>>();
+    println!("{}", Table::new(rows).with(Style::rounded()));
+    Ok(())
+}
+
 fn print_saved_search_list(searches: &[ClickStackSavedSearch], json: bool) -> CloudResult<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(searches)?);
@@ -701,6 +1911,93 @@ fn print_saved_search_list(searches: &[ClickStackSavedSearch], json: bool) -> Cl
 }
 
 impl CloudClient {
+    async fn click_stack_list_dashboards(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> CloudResult<Vec<ClickStackDashboardResponse>> {
+        let response = self
+            .api()
+            .click_stack_list_dashboards(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_create_dashboard(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &ClickStackCreateDashboardRequest,
+    ) -> CloudResult<ClickStackDashboardResponse> {
+        let response = self
+            .api()
+            .click_stack_create_dashboard(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_get_dashboard(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        dashboard_id: &str,
+    ) -> CloudResult<ClickStackDashboardResponse> {
+        let response = self
+            .api()
+            .click_stack_get_dashboard(org_id, service_id, dashboard_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_update_dashboard(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        dashboard_id: &str,
+        request: &ClickStackUpdateDashboardRequest,
+    ) -> CloudResult<ClickStackDashboardResponse> {
+        let response = self
+            .api()
+            .click_stack_update_dashboard(org_id, service_id, dashboard_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    async fn click_stack_delete_dashboard(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        dashboard_id: &str,
+    ) -> CloudResult<crate::cloud::types::DeleteResponse> {
+        let response = self
+            .api()
+            .click_stack_delete_dashboard(org_id, service_id, dashboard_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(crate::cloud::types::DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
+    async fn click_stack_validate_dashboard(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &ClickStackCreateDashboardRequest,
+    ) -> CloudResult<ClickStackValidateDashboardResponse> {
+        let response = self
+            .api()
+            .click_stack_validate_dashboard(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
     async fn click_stack_list_saved_searches(
         &self,
         org_id: &str,
@@ -1024,6 +2321,60 @@ mod tests {
     }
 
     #[test]
+    fn parses_dashboard_config_commands() {
+        let command = parse_clickstack(&[
+            "clickhousectl",
+            "cloud",
+            "clickstack",
+            "dashboard",
+            "validate",
+            "svc-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ]);
+        let ClickStackCommands::Dashboard {
+            command:
+                DashboardCommands::Validate {
+                    config_file,
+                    org_id,
+                    ..
+                },
+        } = command
+        else {
+            panic!("expected dashboard validate")
+        };
+        assert_eq!(config_file, "-");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let command = parse_clickstack(&[
+            "clickhousectl",
+            "cloud",
+            "clickstack",
+            "dashboard",
+            "update",
+            "svc-1",
+            "dash-1",
+            "--config-file",
+            "dashboard.json",
+        ]);
+        let ClickStackCommands::Dashboard {
+            command:
+                DashboardCommands::Update {
+                    dashboard_id,
+                    config_file,
+                    ..
+                },
+        } = command
+        else {
+            panic!("expected dashboard update")
+        };
+        assert_eq!(dashboard_id, "dash-1");
+        assert_eq!(config_file, "dashboard.json");
+    }
+
+    #[test]
     fn classifies_every_clickstack_operation() {
         for (resource, operation, expected) in [
             ("source", "list", false),
@@ -1058,6 +2409,272 @@ mod tests {
             }
             let command = parse_clickstack(&args);
             assert_eq!(command.is_write(), expected, "{resource} {operation}");
+        }
+    }
+
+    #[test]
+    fn classifies_every_dashboard_operation() {
+        for (operation, expected) in [
+            ("list", false),
+            ("get", false),
+            ("create", true),
+            ("update", true),
+            ("delete", true),
+            ("validate", true),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "clickstack",
+                "dashboard",
+                operation,
+                "svc-1",
+            ];
+            if matches!(operation, "get" | "update" | "delete") {
+                args.push("dash-1");
+            }
+            if matches!(operation, "create" | "update" | "validate") {
+                args.extend(["--config-file", "dashboard.json"]);
+            }
+            let command = parse_clickstack(&args);
+            assert_eq!(command.is_write(), expected, "dashboard {operation}");
+        }
+    }
+
+    fn number_format() -> Value {
+        serde_json::json!({
+            "output":"number", "mantissa":2, "thousandSeparated":true,
+            "average":false, "decimalBytes":false, "factor":1.0,
+            "currencySymbol":"$", "numericUnit":"bytes_iec", "unit":"requests"
+        })
+    }
+
+    fn dashboard_tile(name: &str, x: i64, config: Value) -> Value {
+        serde_json::json!({"name":name,"x":x,"y":0,"w":4,"h":3,"config":config})
+    }
+
+    fn complete_dashboard(update: bool) -> Value {
+        let select = serde_json::json!([{
+            "aggFn":"quantile", "valueExpression":"Duration", "alias":"duration", "level":"0.95",
+            "where":"service = 'api'", "whereLanguage":"sql", "metricName":"latency",
+            "metricType":"gauge", "periodAggFn":"delta", "numberFormat":number_format()
+        }]);
+        let raw = |display: &str| {
+            serde_json::json!({
+                "configType":"sql", "displayType":display, "connectionId":"conn-1",
+                "sourceId":"src-1", "sqlTemplate":"SELECT 1", "numberFormat":number_format()
+            })
+        };
+        let mut tiles = vec![
+            dashboard_tile(
+                "line-builder",
+                0,
+                serde_json::json!({
+                    "displayType":"line", "sourceId":"src-1", "select":select,
+                    "groupBy":"service", "asRatio":false, "alignDateRangeToGranularity":true,
+                    "fillNulls":true, "fitYAxisToData":true, "compareToPreviousPeriod":true,
+                    "seriesLimit":5, "showOperandSeries":false,
+                    "formulas":[{"expression":"A * 100", "alias":"percent", "numberFormat":number_format()}]
+                }),
+            ),
+            dashboard_tile("line-sql", 1, raw("line")),
+            dashboard_tile(
+                "stacked-builder",
+                2,
+                serde_json::json!({
+                    "displayType":"stacked_bar", "sourceId":"src-1", "select":select,
+                    "seriesLimit":0, "showOperandSeries":true,
+                    "formulas":[{"expression":"A", "numberFormat":number_format()}]
+                }),
+            ),
+            dashboard_tile("stacked-sql", 3, raw("stacked_bar")),
+            dashboard_tile(
+                "bar-builder",
+                4,
+                serde_json::json!({
+                    "displayType":"bar", "sourceId":"src-1", "select":select,
+                    "groupBy":"service", "limit":10, "orderBy":"duration", "numberFormat":number_format()
+                }),
+            ),
+            dashboard_tile("bar-sql", 5, raw("bar")),
+            dashboard_tile(
+                "table-builder",
+                6,
+                serde_json::json!({
+                    "displayType":"table", "sourceId":"src-1", "select":select,
+                    "showOperandSeries":false, "formulas":[{"expression":"A"}],
+                    "onClick":{"type":"search","target":{"mode":"id","id":"src-2"},
+                        "whereTemplate":"service = '{{service}}'","whereLanguage":"sql",
+                        "filters":[{"kind":"expressionTemplate","expression":"service","template":"{{service}}"}]}
+                }),
+            ),
+            dashboard_tile("table-sql", 7, {
+                let mut config = raw("table");
+                config["onClick"] = serde_json::json!({"type":"dashboard","target":{"mode":"template","template":"{{dashboard}}"},"whereLanguage":"lucene"});
+                config
+            }),
+            dashboard_tile("table-external", 8, {
+                let mut config = raw("table");
+                config["onClick"] = serde_json::json!({"type":"external","urlTemplate":"https://example.com/{{id}}"});
+                config
+            }),
+            dashboard_tile(
+                "number-builder",
+                9,
+                serde_json::json!({
+                    "displayType":"number", "sourceId":"src-1", "select":select,
+                    "formulas":[{"expression":"A","alias":"total"}], "color":"chart-blue",
+                    "backgroundChart":{"type":"area","color":"chart-green"},
+                    "colorRules":[
+                    {"operator":"gt","value":100.0,"color":"chart-error","label":"high"},
+                    {"operator":"between","value":[50.0,100.0],"color":"chart-warning"},
+                        {"operator":"eq","value":"ok","color":"chart-success"}
+                    ], "numberFormat":number_format()
+                }),
+            ),
+            dashboard_tile("number-sql", 10, raw("number")),
+            dashboard_tile(
+                "pie-builder",
+                11,
+                serde_json::json!({
+                    "displayType":"pie", "sourceId":"src-1", "select":select,
+                    "groupBy":"service", "limit":5, "orderBy":"duration", "numberFormat":number_format()
+                }),
+            ),
+            dashboard_tile("pie-sql", 12, raw("pie")),
+            dashboard_tile(
+                "heatmap",
+                13,
+                serde_json::json!({
+                    "displayType":"heatmap", "sourceId":"src-1", "where":"true",
+                    "whereLanguage":"sql", "numberFormat":number_format(),
+                    "select":[{"valueExpression":"Duration","countExpression":"count()","heatmapScaleType":"log"}]
+                }),
+            ),
+            dashboard_tile(
+                "search",
+                14,
+                serde_json::json!({
+                    "displayType":"search", "sourceId":"src-1", "select":"*",
+                    "where":"level:error", "whereLanguage":"lucene"
+                }),
+            ),
+            dashboard_tile(
+                "event-patterns",
+                15,
+                serde_json::json!({
+                    "displayType":"event_patterns", "sourceId":"src-1", "select":"Body",
+                    "where":"level:error", "whereLanguage":"lucene"
+                }),
+            ),
+            dashboard_tile(
+                "markdown",
+                16,
+                serde_json::json!({
+                    "displayType":"markdown", "markdown":"# Service health"
+                }),
+            ),
+        ];
+        tiles[0]["id"] = Value::String("tile-1".into());
+        tiles[0]["containerId"] = Value::String("health".into());
+        tiles[0]["tabId"] = Value::String("errors".into());
+        let mut filter = serde_json::json!({
+            "name":"Service", "expression":"ServiceName", "sourceId":"src-1",
+            "type":"QUERY_EXPRESSION", "where":"true", "whereLanguage":"sql",
+            "sourceMetricType":"gauge", "appliesToSourceIds":["src-1"],
+            "isBroadcastEnabled":true, "isVariableEnabled":true, "variableName":"service"
+        });
+        if update {
+            filter["id"] = Value::String("filter-1".into());
+        }
+        serde_json::json!({
+            "name":"Service overview", "tiles":tiles, "tags":["production","api"],
+            "filters":[filter], "savedQuery":"level:error", "savedQueryLanguage":"lucene",
+            "savedFilterValues":[
+                {"type":"sql","condition":"ServiceName = 'api'"},
+                {"type":"variable","name":"service","values":["api","worker"]}
+            ],
+            "containers":[{"id":"health","title":"Health","collapsed":false,"collapsible":true,
+                "bordered":true,"tabs":[{"id":"errors","title":"Errors"}]}]
+        })
+    }
+
+    #[test]
+    fn dashboard_builders_cover_minimal_and_every_configuration_variant() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("dashboard.json");
+        std::fs::write(&config_file, r#"{"name":"empty","tiles":[]}"#).unwrap();
+        let minimal = build_create_dashboard_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(minimal.name, "empty");
+        assert!(minimal.tiles.is_empty());
+
+        let create_body = complete_dashboard(false);
+        std::fs::write(&config_file, create_body.to_string()).unwrap();
+        let create = build_create_dashboard_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(create.tiles.len(), 17);
+        assert_eq!(
+            create.filters.as_ref().unwrap()[0].variable_name.as_deref(),
+            Some("service")
+        );
+        assert_eq!(create.saved_filter_values.as_ref().unwrap().len(), 2);
+        assert_eq!(serde_json::to_value(&create).unwrap(), create_body);
+
+        let update_body = complete_dashboard(true);
+        std::fs::write(&config_file, update_body.to_string()).unwrap();
+        let update = build_update_dashboard_request(config_file.to_str().unwrap()).unwrap();
+        assert_eq!(update.filters.as_ref().unwrap()[0].id, "filter-1");
+        assert_eq!(
+            update.containers.as_ref().unwrap()[0]
+                .tabs
+                .as_ref()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(serde_json::to_value(&update).unwrap(), update_body);
+    }
+
+    #[test]
+    fn dashboard_builder_rejects_unknown_nested_union_enum_and_field() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("dashboard.json");
+        for (body, expected) in [
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"map"}}]}),
+                "displayType",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"table","sourceId":"s","select":[],"onClick":{"type":"popup","target":{"mode":"id","id":"x"}}}}]}),
+                "onClick.type",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"heatmap","sourceId":"s","select":[{"valueExpression":"v","heatmapScaleType":"logg"}]}}]}),
+                "heatmapScaleType",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"line","sourceId":"s","select":[],"numberFormat":{"output":"custom","mantissa":0,"thousandSeparated":false,"average":false,"decimalBytes":false,"factor":1.0,"currencySymbol":"","numericUnit":"bytes_iec","unit":""}}}]}),
+                "numberFormat.output",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"number","sourceId":"s","select":[],"colorRules":[{"operator":"eq","value":{"nested":true},"color":"chart-blue"}]}}]}),
+                "value must be a finite number or string",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"number","sourceId":"s","select":[],"colorRules":[{"operator":"neq","value":true,"color":"chart-blue"}]}}]}),
+                "value must be a finite number or string",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[{"name":"x","x":0,"y":0,"w":1,"h":1,"config":{"displayType":"line","sourceId":"s","select":[{"aggFn":"count","aliass":"x"}]}}]}),
+                "aliass",
+            ),
+            (
+                serde_json::json!({"name":"bad","tiles":[],"savedFilterValues":[{"type":"variable","name":"v","values":[],"valuess":[]}]}),
+                "valuess",
+            ),
+        ] {
+            std::fs::write(&config_file, body.to_string()).unwrap();
+            let error = build_create_dashboard_request(config_file.to_str().unwrap()).unwrap_err();
+            assert!(error.message.contains(expected), "{error}");
         }
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -15487,3 +15487,326 @@ async fn clickstack_saved_search_oauth_reads_and_rejects_writes_before_http() {
     assert_eq!(output.status.code(), Some(4));
     assert_eq!(mock.received_requests().await.unwrap().len(), 1);
 }
+
+// ── ClickStack dashboard commands (issue #693) ─────────────────────────────
+
+#[tokio::test]
+async fn clickstack_dashboard_all_six_routes_preserve_typed_bodies_and_auth() {
+    let mock = MockServer::start().await;
+    let dashboards = "/v1/organizations/org-1/services/svc-1/clickstack/dashboards";
+    Mock::given(method("GET"))
+        .and(path(dashboards))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":[{}]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{dashboards}/dash-get")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":{}})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(dashboards))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"result":{"id":"dash-created"}})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(format!("{dashboards}/dash-update")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"result":{"id":"dash-update"}})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("{dashboards}/dash-delete")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"status":200})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("{dashboards}/validate")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result":{"valid":true,"errors":[],"normalized":{"name":"minimal"}}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let create = serde_json::json!({
+        "name":"minimal", "tiles":[], "savedQuery":null, "savedQueryLanguage":null
+    });
+    let update = serde_json::json!({
+        "name":"replacement", "tiles":[], "tags":[], "filters":[],
+        "savedFilterValues":[], "containers":[]
+    });
+    let directory = tempfile::tempdir().unwrap();
+    let create_file = directory.path().join("create.json");
+    std::fs::write(&create_file, create.to_string()).unwrap();
+    let create_path = create_file.to_str().unwrap();
+    let update_stdin = update.to_string();
+    let commands: Vec<(Vec<&str>, Option<&str>)> = vec![
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "list",
+                "svc-1",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "get",
+                "svc-1",
+                "dash-get",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "create",
+                "svc-1",
+                "--config-file",
+                create_path,
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "update",
+                "svc-1",
+                "dash-update",
+                "--config-file",
+                "-",
+                "--org-id",
+                "org-1",
+            ],
+            Some(update_stdin.as_str()),
+        ),
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "delete",
+                "svc-1",
+                "dash-delete",
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+        (
+            vec![
+                "clickstack",
+                "dashboard",
+                "validate",
+                "svc-1",
+                "--config-file",
+                create_path,
+                "--org-id",
+                "org-1",
+            ],
+            None,
+        ),
+    ];
+    for (args, stdin) in commands {
+        let output = invoke_clickstack_cli(&mock, &args, stdin, true);
+        assert_success(&output);
+        serde_json::from_slice::<Value>(&output.stdout).unwrap();
+    }
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 6);
+    for request in &requests {
+        assert!(
+            request
+                .headers
+                .get("authorization")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("Basic ")
+        );
+    }
+    let writes = requests
+        .iter()
+        .filter(|request| {
+            matches!(
+                request.method,
+                wiremock::http::Method::POST | wiremock::http::Method::PUT
+            )
+        })
+        .map(|request| {
+            (
+                request.url.path().to_owned(),
+                request.body_json::<Value>().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(writes.len(), 3);
+    assert_eq!(
+        writes[0].1,
+        serde_json::json!({"name":"minimal","tiles":[]})
+    );
+    assert_eq!(writes[1].1, update);
+    assert_eq!(
+        writes[2].1,
+        serde_json::json!({"name":"minimal","tiles":[]})
+    );
+}
+
+#[tokio::test]
+async fn clickstack_dashboard_validation_surfaces_invalid_and_sparse_results() {
+    for (result, expected) in [
+        (
+            serde_json::json!({"valid":false,"errors":[{"path":"tiles.0.config","message":"Required"}],"normalized":null}),
+            Some(false),
+        ),
+        (serde_json::json!({}), None),
+    ] {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/v1/organizations/org-1/services/svc-1/clickstack/dashboards/validate",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":result})),
+            )
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_clickstack_cli(
+            &mock,
+            &[
+                "clickstack",
+                "dashboard",
+                "validate",
+                "svc-1",
+                "--config-file",
+                "-",
+                "--org-id",
+                "org-1",
+            ],
+            Some(r#"{"name":"dashboard","tiles":[]}"#),
+            true,
+        );
+        assert_success(&output);
+        let output: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(output.get("valid").and_then(Value::as_bool), expected);
+        if expected == Some(false) {
+            assert_eq!(output["errors"][0]["path"], "tiles.0.config");
+        }
+    }
+}
+
+#[tokio::test]
+async fn clickstack_dashboard_sparse_human_list_and_errors_are_safe() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result":[{}]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "dashboard",
+            "list",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+        None,
+        false,
+    );
+    assert_success(&output);
+    assert!(String::from_utf8_lossy(&output.stdout).contains('-'));
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-sensitive/services/svc-1/clickstack/dashboards/missing",
+        ))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_json(serde_json::json!({"error":"DASHBOARD_NOT_FOUND"})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_clickstack_cli(
+        &mock,
+        &[
+            "clickstack",
+            "dashboard",
+            "get",
+            "svc-1",
+            "missing",
+            "--org-id",
+            "org-sensitive",
+        ],
+        None,
+        false,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(error.contains("DASHBOARD_NOT_FOUND"), "{error}");
+}
+
+#[tokio::test]
+async fn clickstack_dashboard_validate_fails_fast_for_oauth() {
+    let mock = MockServer::start().await;
+    let directory = tempfile::tempdir().unwrap();
+    let home = directory.path().join("home");
+    let ch_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&ch_dir).unwrap();
+    write_oauth_tokens(&ch_dir, &mock.uri());
+    let config = directory.path().join("dashboard.json");
+    std::fs::write(&config, r#"{"name":"dashboard","tiles":[]}"#).unwrap();
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "clickstack",
+            "dashboard",
+            "validate",
+            "svc-1",
+            "--config-file",
+            config.to_str().unwrap(),
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(4));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("read-only"));
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

ClickStack dashboards had typed Cloud API methods but no CLI surface. This adds `cloud clickstack dashboard list|get|create|update|delete|validate`, with JSON file/stdin input for create, update, and validation and sparse-safe human/JSON output.

Dashboard input is deserialized into the published request models and validated strictly across every nested chart, raw-SQL/builder, on-click, color-rule, and saved-filter union. Unknown fields and discriminators fail locally, and closed enum values are rejected through their typed library `Unknown` variants before organization lookup or an API request. Equality color rules accept only the specified finite-number-or-string value shape. Update is documented as a full PUT replacement. Validation is intentionally classified as API-key-only under the CLI's write-command policy because the Cloud API exposes it as POST, even though validation does not persist data.

The README includes a validate-then-create flow, a nested line-chart/filter-variable example, and the full-replacement update contract.

Closes #693

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`

Focused real-binary wiremock coverage exercises all six service/organization paths, Basic auth, file and stdin request bodies, nullable-field omission, valid/invalid/sparse validation responses, sparse dashboard lists, API errors, and OAuth fail-fast behavior.
