### PR TITLE
feat(org): expose organization quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,8 @@ Reading a service, Postgres service or organization â€” or deleting a service â€
 ```bash
 clickhousectl cloud org list              # List organizations
 clickhousectl cloud org get <org-id>      # Get organization details
+clickhousectl cloud org quota list --org-id <org-id>
+clickhousectl cloud org quota get services-per-organization --org-id <org-id>
 clickhousectl cloud org update <org-id> --name "Renamed Org"
 clickhousectl cloud org update <org-id> \
   --remove-private-endpoint pe-1,cloud-provider=aws,region=us-east-1 \
@@ -650,8 +652,10 @@ clickhousectl cloud org usage \
   --from-date 2024-01-01 \
   --to-date 2024-01-31 \
   --filter tag:Environment=Production   # max 31-day window (to-date inclusive), costs in CHC
-# Of the org commands, --org-id applies to prometheus/usage only; list takes none and get/update take a positional <org-id>.
+# Org quota, prometheus, and usage commands auto-detect the org when --org-id is omitted.
+# Org list takes no ID; org get/update take a positional <org-id>.
 # It is auto-detected only when your credentials reach exactly one organization.
+# Organization quota commands are beta and read-only, so they support OAuth.
 ```
 
 ### Services

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -21,6 +21,12 @@ pub enum OrgCommands {
         org_id: String,
     },
 
+    /// View organization quotas (Beta)
+    Quota {
+        #[command(subcommand)]
+        command: QuotaCommands,
+    },
+
     /// Update organization settings
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -99,11 +105,32 @@ impl OrgCommands {
         match self {
             OrgCommands::List => false,
             OrgCommands::Get { .. } => false,
+            OrgCommands::Quota { .. } => false,
             OrgCommands::Prometheus { .. } => false,
             OrgCommands::Usage { .. } => false,
             OrgCommands::Update { .. } => true,
         }
     }
+}
+
+#[derive(Subcommand)]
+pub enum QuotaCommands {
+    /// List organization quotas
+    List {
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Get organization quota details
+    Get {
+        /// Quota code
+        quota_code: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -225,6 +252,7 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
     match command {
         OrgCommands::List => org_list(client, json).await,
         OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
+        OrgCommands::Quota { command } => run_quota(client, command, json).await,
         OrgCommands::Update {
             org_id,
             name,
@@ -255,6 +283,15 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         } => {
             let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
             org_usage(client, org_id, &from_date, &to_date, &filter, json).await
+        }
+    }
+}
+
+async fn run_quota(client: &CloudClient, command: QuotaCommands, json: bool) -> CloudResult<()> {
+    match command {
+        QuotaCommands::List { org_id } => quota_list(client, org_id.as_deref(), json).await,
+        QuotaCommands::Get { quota_code, org_id } => {
+            quota_get(client, &quota_code, org_id.as_deref(), json).await
         }
     }
 }
@@ -477,6 +514,65 @@ async fn org_get(client: &CloudClient, org_id: &str, json: bool) -> CloudResult<
         println!("{}", serde_json::to_string_pretty(&organization)?);
     } else {
         print_human(&organization)?;
+    }
+    Ok(())
+}
+
+async fn quota_list(client: &CloudClient, org_id: Option<&str>, json: bool) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let quotas = client.list_organization_quotas(&org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&quotas)?);
+    } else {
+        if quotas.is_empty() {
+            println!("No organization quotas found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Name")]
+            name: String,
+            #[tabled(rename = "Code")]
+            code: String,
+            #[tabled(rename = "Scope")]
+            scope: String,
+            #[tabled(rename = "Usage")]
+            usage: String,
+            #[tabled(rename = "Limit")]
+            limit: String,
+            #[tabled(rename = "Adjustable")]
+            adjustable: String,
+        }
+        let rows: Vec<Row> = quotas
+            .into_iter()
+            .map(|quota| Row {
+                name: or_absent(quota.name.as_deref()),
+                code: or_absent(quota.quota_code.as_ref()),
+                scope: or_absent(quota.scope.as_ref()),
+                usage: or_absent(quota.usage),
+                limit: or_absent(quota.value),
+                adjustable: or_absent(quota.adjustable),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn quota_get(
+    client: &CloudClient,
+    quota_code: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let quota = client.get_organization_quota(&org_id, quota_code).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&quota)?);
+    } else {
+        print_human(&quota)?;
     }
     Ok(())
 }
@@ -780,6 +876,31 @@ impl CloudClient {
             // missing organization, not a bad request (#666).
             self.convert_error_for_lookup(error, ResourceLookup::organization(org_id))
         })?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn list_organization_quotas(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::OrganizationQuota>> {
+        let response = self
+            .api()
+            .organization_quotas_get_list(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_organization_quota(
+        &self,
+        org_id: &str,
+        quota_code: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::OrganizationQuota> {
+        let response = self
+            .api()
+            .organization_quota_get(org_id, quota_code)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1266,6 +1387,47 @@ mod tests {
     }
 
     #[test]
+    fn parses_org_quota_commands() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "quota",
+            "list",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Quota {
+            command: QuotaCommands::List { org_id },
+        } = command
+        else {
+            panic!("expected quota list command");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "quota",
+            "get",
+            "replicas-per-warehouse",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Quota {
+            command: QuotaCommands::Get { quota_code, org_id },
+        } = command
+        else {
+            panic!("expected quota get command");
+        };
+        assert_eq!(quota_code, "replicas-per-warehouse");
+        assert!(org_id.is_none());
+    }
+
+    #[test]
     fn parses_legacy_org_id_positionals() {
         let prometheus =
             Cli::try_parse_from(["clickhousectl", "cloud", "org", "prometheus", "org-1"]).unwrap();
@@ -1393,6 +1555,18 @@ mod tests {
     fn top_level_write_classification_covers_every_organization_access_command() {
         assert_write(&["clickhousectl", "cloud", "org", "list"], false);
         assert_write(&["clickhousectl", "cloud", "org", "get", "org-1"], false);
+        assert_write(&["clickhousectl", "cloud", "org", "quota", "list"], false);
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "org",
+                "quota",
+                "get",
+                "services-per-organization",
+            ],
+            false,
+        );
         assert_write(&["clickhousectl", "cloud", "org", "prometheus"], false);
         assert_write(
             &[

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -198,6 +198,171 @@ fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> st
         .expect("failed to spawn clickhousectl")
 }
 
+#[tokio::test]
+async fn org_quota_list_preserves_sparse_json_and_supports_oauth() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{ "id": AUTO_DETECTED_ORG_ID, "name": "Only org" }],
+            "status": 200,
+            "requestId": "stub-org-list"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let result = serde_json::json!([
+        {
+            "quotaCode": "services-per-organization",
+            "name": "Services per organization",
+            "description": "Limits services.",
+            "scope": "organization",
+            "value": 20,
+            "usage": 3,
+            "adjustable": true
+        },
+        { "quotaCode": "future-quota" }
+    ]);
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/{AUTO_DETECTED_ORG_ID}/quotas"
+        )))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-quota-list"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "org",
+            "quota",
+            "list",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_quota_get_uses_lookup_key_and_human_detail_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/quotas/replicas-per-warehouse",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "quotaCode": "replicas-per-warehouse",
+                "name": "Replicas per warehouse",
+                "scope": "warehouse",
+                "value": 20,
+                "adjustable": true
+            },
+            "status": 200,
+            "requestId": "stub-quota-get"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "org",
+            "quota",
+            "get",
+            "replicas-per-warehouse",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "adjustable: true\nname: Replicas per warehouse\nquotaCode: replicas-per-warehouse\nscope: warehouse\nvalue: 20\n"
+    );
+}
+
+#[tokio::test]
+async fn org_quota_list_human_output_handles_missing_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/quotas"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{ "quotaCode": "future-quota" }],
+            "status": 200,
+            "requestId": "stub-sparse-quota-list"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "org",
+            "quota",
+            "list",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("| Name | Code         | Scope | Usage | Limit | Adjustable |"));
+    assert!(stdout.contains("| -    | future-quota | -     | -     | -     | -          |"));
+}
+
 fn invoke_cli_without_cloud_credentials(
     mock: &MockServer,
     cli_args: &[String],


### PR DESCRIPTION
Expose the Cloud API's organization quota reads through `cloud org quota list|get`. The commands auto-detect a sole organization or accept `--org-id`, work with OAuth, preserve full JSON responses, and render sparse-safe human list and detail output.

Examples:

```bash
clickhousectl cloud org quota list --org-id <org-id>
clickhousectl cloud org quota get services-per-organization --org-id <org-id>
```

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- focused organization unit tests: 21 passed
- focused quota subprocess/wiremock tests: 3 passed
- `cargo test -p clickhousectl`: all quota and related tests passed; the aggregate stopped on one unchanged local subprocess test (`foreground_child_exit_is_not_wrapped_as_a_local_error`, exit 1 instead of fixture exit 7), whose single exact rerun passed

Closes #579.
