### PR TITLE
feat(cloud): support IP allowlist descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,8 +688,8 @@ clickhousectl cloud service create --name my-service \
 clickhousectl cloud service create --name my-service \
   --provider aws \
   --region us-east-1 \
-  --ip-allow <trusted-egress-cidr> \
-  --ip-allow <another-trusted-egress-cidr>
+  --ip-allow '<trusted-egress-cidr>=office' \
+  --ip-allow '<another-trusted-egress-cidr>=CI runners'
 
 # Create from backup
 clickhousectl cloud service create --name restored-service \
@@ -745,7 +745,7 @@ clickhousectl cloud service repair-query-key <service-id> --org-id <org-id>
 # Update service metadata and patches
 clickhousectl cloud service update <service-id> \
   --name my-renamed-service \
-  --add-ip-allow <trusted-egress-cidr> \
+  --add-ip-allow '<trusted-egress-cidr>=office' \
   --remove-ip-allow 0.0.0.0/0 \
   --add-private-endpoint-id pe-1 \
   --release-channel fast \
@@ -820,6 +820,9 @@ clickhousectl cloud service delete <service-id>
 # Force delete: stops a running service then deletes
 clickhousectl cloud service delete <service-id> --force
 ```
+
+IP allowlist flags accept `IP_OR_CIDR` or `IP_OR_CIDR=DESCRIPTION`. The `=`
+delimiter is safe with IPv6; quote entries whose descriptions contain spaces.
 
 `query-endpoint create` adds and deduplicates API keys while preserving existing browser origins. `--role` is required and replaces the endpoint-wide roles for **all** authorized keys; roles are not assigned per key.
 Pass `--allowed-origins` on first creation or to change browser access (`'*'` explicitly allows every origin). Use `--replace-open-api-keys` with `--open-api-key` to deliberately replace the entire authorized-key list.
@@ -1688,7 +1691,7 @@ clickhousectl cloud key get <key-id>
 clickhousectl cloud key create --name ci-key \
   --role-id <role-id> \
   --expires-at <future-RFC3339-time> \
-  --ip-allow <trusted-egress-ip>/32 \
+  --ip-allow '<trusted-egress-ip>/32=CI runners' \
   --state disabled   # create the key already disabled
 # --hash-key-id/--hash-key-id-suffix/--hash-key-secret submit a pre-hashed key; no secret is returned
 clickhousectl cloud key update <key-id> \

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -1,13 +1,14 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
 use crate::cloud::output::{eprint_line, or_absent, print_human};
-use crate::cloud::shared::{parse_datetime, resolve_org_id};
+use crate::cloud::shared::{parse_datetime, parse_ip_access_entries, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::FailureStage;
 use clap::Subcommand;
+#[cfg(test)]
+use clickhouse_cloud_api::models::IpAccessListEntry;
 use clickhouse_cloud_api::models::{
     ApiKeyPatchRequest, ApiKeyPatchRequestState, ApiKeyPostRequest, ApiKeyPostRequestState,
-    IpAccessListEntry,
 };
 use tabled::{Table, Tabled, settings::Style};
 
@@ -38,8 +39,8 @@ pub enum KeyCommands {
         #[arg(long)]
         state: Option<String>,
 
-        /// IP or CIDR allowed to use the key (repeatable)
-        #[arg(long = "ip-allow")]
+        /// Allowed IP/CIDR, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
+        #[arg(long = "ip-allow", value_name = "IP_OR_CIDR[=DESCRIPTION]")]
         ip_allow: Vec<String>,
 
         /// Pre-hashed key ID digest; needs --hash-key-id-suffix and --hash-key-secret
@@ -98,8 +99,12 @@ pub enum KeyCommands {
         #[arg(long)]
         state: Option<String>,
 
-        /// IP or CIDR to allow (repeatable; conflicts with --clear-ip-allow)
-        #[arg(long = "ip-allow", conflicts_with = "clear_ip_allow")]
+        /// Allowed IP/CIDR, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
+        #[arg(
+            long = "ip-allow",
+            value_name = "IP_OR_CIDR[=DESCRIPTION]",
+            conflicts_with = "clear_ip_allow"
+        )]
         ip_allow: Vec<String>,
 
         /// Clear the IP allowlist; conflicts with --ip-allow
@@ -241,18 +246,6 @@ fn parse_api_key_hash_data(
     }
 }
 
-fn parse_ip_access_entries(values: &[String]) -> Option<Vec<IpAccessListEntry>> {
-    (!values.is_empty()).then(|| {
-        values
-            .iter()
-            .map(|value| IpAccessListEntry {
-                source: value.clone(),
-                description: None,
-            })
-            .collect()
-    })
-}
-
 fn parse_uuid_list(values: &[String], field: &str) -> CloudResult<Vec<uuid::Uuid>> {
     values
         .iter()
@@ -310,7 +303,7 @@ fn build_api_key_create_request(options: &KeyCreateOptions) -> CloudResult<ApiKe
             None => ApiKeyPostRequestState::default(),
         },
         assigned_role_ids: parse_uuid_list(&options.role_ids, "role_id")?,
-        ip_access_list: parse_ip_access_entries(&options.ip_allow).unwrap_or_default(),
+        ip_access_list: parse_ip_access_entries(&options.ip_allow)?.unwrap_or_default(),
         hash_data: parse_api_key_hash_data(
             options.hash_key_id.as_deref(),
             options.hash_key_id_suffix.as_deref(),
@@ -354,7 +347,7 @@ fn build_api_key_update_request(options: &KeyUpdateOptions) -> CloudResult<ApiKe
         ip_access_list: if options.clear_ip_allow {
             Some(Vec::new())
         } else {
-            parse_ip_access_entries(&options.ip_allow)
+            parse_ip_access_entries(&options.ip_allow)?
         },
         #[cfg(feature = "deprecated-fields")]
         roles: None,
@@ -805,9 +798,9 @@ mod tests {
             "--role-id",
             "role-2",
             "--ip-allow",
-            "10.0.0.0/8",
+            "10.0.0.0/8=office",
             "--ip-allow",
-            "192.0.2.0/24",
+            "2001:db8::/32=\u{6771}\u{4eac}",
             "--hash-key-id",
             "id-hash",
             "--hash-key-id-suffix",
@@ -840,7 +833,10 @@ mod tests {
         assert_eq!(role_id, vec!["role-1", "role-2"]);
         assert_eq!(expires_at.as_deref(), Some("2025-12-31T23:59:59Z"));
         assert_eq!(state.as_deref(), Some("disabled"));
-        assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert_eq!(
+            ip_allow,
+            vec!["10.0.0.0/8=office", "2001:db8::/32=\u{6771}\u{4eac}"]
+        );
         assert_eq!(hash_key_id.as_deref(), Some("id-hash"));
         assert_eq!(hash_key_id_suffix.as_deref(), Some("abcd"));
         assert_eq!(hash_key_secret.as_deref(), Some("secret-hash"));
@@ -866,9 +862,9 @@ mod tests {
             "--state",
             "enabled",
             "--ip-allow",
-            "10.0.0.0/8",
+            "10.0.0.0/8=office",
             "--ip-allow",
-            "192.0.2.0/24",
+            "2001:db8::/32=\u{6771}\u{4eac}",
             "--org-id",
             "org-1",
         ]);
@@ -895,7 +891,10 @@ mod tests {
         assert_eq!(expires_at.as_deref(), Some("2025-01-01T00:00:00Z"));
         assert!(!clear_expiry);
         assert_eq!(state.as_deref(), Some("enabled"));
-        assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert_eq!(
+            ip_allow,
+            vec!["10.0.0.0/8=office", "2001:db8::/32=\u{6771}\u{4eac}"]
+        );
         assert!(!clear_ip_allow);
         assert_eq!(org_id.as_deref(), Some("org-1"));
     }
@@ -1167,7 +1166,7 @@ mod tests {
             role_ids: vec![role_id.to_string()],
             expires_at: Some("2025-12-31T23:59:59Z".to_string()),
             state: Some("disabled".to_string()),
-            ip_allow: vec!["10.0.0.0/8".to_string()],
+            ip_allow: vec!["10.0.0.0/8=office".to_string()],
             hash_key_id: Some("id-hash".to_string()),
             hash_key_id_suffix: Some("abcd".to_string()),
             hash_key_secret: Some("secret-hash".to_string()),
@@ -1185,7 +1184,10 @@ mod tests {
         assert_eq!(create.state, ApiKeyPostRequestState::Disabled);
         assert_eq!(create.ip_access_list.len(), 1);
         assert_eq!(create.ip_access_list[0].source, "10.0.0.0/8");
-        assert!(create.ip_access_list[0].description.is_none());
+        assert_eq!(
+            create.ip_access_list[0].description.as_deref(),
+            Some("office")
+        );
         let hash_data = create.hash_data.as_ref().expect("maximal hash data");
         assert_eq!(hash_data.key_id_hash, "id-hash");
         assert_eq!(hash_data.key_id_suffix, "abcd");
@@ -1200,7 +1202,7 @@ mod tests {
             expires_at: Some("2025-01-01T00:00:00Z".to_string()),
             clear_expiry: false,
             state: Some("disabled".to_string()),
-            ip_allow: vec!["0.0.0.0/0".to_string()],
+            ip_allow: vec!["2001:db8::/32=\u{6771}\u{4eac}".to_string()],
             clear_ip_allow: false,
             org_id: None,
         })
@@ -1215,8 +1217,11 @@ mod tests {
         assert_eq!(update.state, Some(ApiKeyPatchRequestState::Disabled));
         let ip_access_list = update.ip_access_list.as_ref().unwrap();
         assert_eq!(ip_access_list.len(), 1);
-        assert_eq!(ip_access_list[0].source, "0.0.0.0/0");
-        assert!(ip_access_list[0].description.is_none());
+        assert_eq!(ip_access_list[0].source, "2001:db8::/32");
+        assert_eq!(
+            ip_access_list[0].description.as_deref(),
+            Some("\u{6771}\u{4eac}")
+        );
         #[cfg(feature = "deprecated-fields")]
         assert!(update.roles.is_none());
     }

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -8,7 +8,7 @@ use crate::cloud::output::{
     ABSENT, CloudErrorCode, CloudErrorDetail, eprint_line, or_absent, print_human, print_line,
 };
 use crate::cloud::service_query::{RepairVerification, existing_open_api_keys};
-use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
+use crate::cloud::shared::{parse_ip_access_entries, parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::{self, ApiFailure, FailureKind, FailureStage, ProvisioningState};
 use clap::builder::PossibleValuesParser;
@@ -145,8 +145,8 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         idle_timeout_minutes: Option<u32>,
 
-        /// IP/CIDR entry to allow, e.g. "10.0.0.0/8" (repeatable)
-        #[arg(long = "ip-allow")]
+        /// Allowed IP/CIDR, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
+        #[arg(long = "ip-allow", value_name = "IP_OR_CIDR[=DESCRIPTION]")]
         ip_allow: Vec<String>,
 
         /// Backup ID to restore from
@@ -287,12 +287,12 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         name: Option<String>,
 
-        /// IP/CIDR entry to add to the service allow list (repeatable)
-        #[arg(long = "add-ip-allow")]
+        /// IP/CIDR to add, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
+        #[arg(long = "add-ip-allow", value_name = "IP_OR_CIDR[=DESCRIPTION]")]
         add_ip_allow: Vec<String>,
 
-        /// IP/CIDR entry to remove from the service allow list (repeatable)
-        #[arg(long = "remove-ip-allow")]
+        /// IP or CIDR to remove from the service allow list (repeatable)
+        #[arg(long = "remove-ip-allow", value_name = "IP_OR_CIDR")]
         remove_ip_allow: Vec<String>,
 
         /// Private endpoint ID to add; format-checked before the request (repeatable)
@@ -947,25 +947,16 @@ async fn resolve_service(
     }
 }
 
-fn parse_ip_access_entries(values: &[String]) -> Option<Vec<IpAccessListEntry>> {
-    (!values.is_empty()).then(|| {
-        values
-            .iter()
-            .map(|value| IpAccessListEntry {
-                source: value.clone(),
-                description: None,
-            })
-            .collect()
-    })
-}
-
-fn parse_ip_access_list_patch(add: &[String], remove: &[String]) -> Option<IpAccessListPatch> {
+fn parse_ip_access_list_patch(
+    add: &[String],
+    remove: &[String],
+) -> CloudResult<Option<IpAccessListPatch>> {
     let patch = IpAccessListPatch {
-        add: parse_ip_access_entries(add).unwrap_or_default(),
-        remove: parse_ip_access_entries(remove).unwrap_or_default(),
+        add: parse_ip_access_entries(add)?.unwrap_or_default(),
+        remove: parse_ip_access_entries(remove)?.unwrap_or_default(),
     };
 
-    (!patch.add.is_empty() || !patch.remove.is_empty()).then_some(patch)
+    Ok((!patch.add.is_empty() || !patch.remove.is_empty()).then_some(patch))
 }
 
 /// Prefix of an AWS PrivateLink VPC endpoint ID.
@@ -1268,7 +1259,7 @@ fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<S
             description: Some("Allow all (created by clickhousectl)".to_string()),
         }]
     } else {
-        parse_ip_access_entries(&options.ip_allow).unwrap_or_default()
+        parse_ip_access_entries(&options.ip_allow)?.unwrap_or_default()
     };
 
     let horizontal = resolve_horizontal_autoscaling(
@@ -1365,7 +1356,10 @@ fn build_update_service_request(
 ) -> CloudResult<ServicePatchRequest> {
     Ok(ServicePatchRequest {
         name: options.name.clone(),
-        ip_access_list: parse_ip_access_list_patch(&options.add_ip_allow, &options.remove_ip_allow),
+        ip_access_list: parse_ip_access_list_patch(
+            &options.add_ip_allow,
+            &options.remove_ip_allow,
+        )?,
         private_endpoint_ids: parse_private_endpoint_ids_patch(
             &options.add_private_endpoint_ids,
             &options.remove_private_endpoint_ids,
@@ -3492,9 +3486,9 @@ mod tests {
             "--idle-timeout-minutes",
             "10",
             "--ip-allow",
-            "10.0.0.0/8",
+            "10.0.0.0/8=office",
             "--ip-allow",
-            "192.0.2.0/24",
+            "2001:db8::/32=\u{6771}\u{4eac}",
             "--backup-id",
             "backup-1",
             "--release-channel",
@@ -3566,7 +3560,10 @@ mod tests {
         assert_eq!(autoscaling_mode.as_deref(), Some("vertical"));
         assert_eq!(idle_scaling, Some(false));
         assert_eq!(idle_timeout_minutes, Some(10));
-        assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert_eq!(
+            ip_allow,
+            vec!["10.0.0.0/8=office", "2001:db8::/32=\u{6771}\u{4eac}"]
+        );
         assert_eq!(backup_id.as_deref(), Some("backup-1"));
         assert_eq!(release_channel.as_deref(), Some("fast"));
         assert_eq!(data_warehouse_id.as_deref(), Some("dw-1"));
@@ -3860,7 +3857,7 @@ mod tests {
             "update",
             "svc-1",
             "--add-ip-allow",
-            "10.0.0.0/8",
+            "2001:db8::/32=office",
             "--remove-ip-allow",
             "0.0.0.0/0",
             "--add-private-endpoint-id",
@@ -3892,7 +3889,7 @@ mod tests {
             panic!("expected service update");
         };
         assert_eq!(service_id, "svc-1");
-        assert_eq!(add_ip_allow, vec!["10.0.0.0/8"]);
+        assert_eq!(add_ip_allow, vec!["2001:db8::/32=office"]);
         assert_eq!(remove_ip_allow, vec!["0.0.0.0/0"]);
         assert_eq!(add_private_endpoint_id, vec!["pe-1"]);
         assert_eq!(remove_private_endpoint_id, vec!["pe-2"]);
@@ -3913,9 +3910,9 @@ mod tests {
             "--name",
             "renamed",
             "--add-ip-allow",
-            "10.0.0.0/8",
+            "10.0.0.0/8=office",
             "--add-ip-allow",
-            "192.0.2.0/24",
+            "2001:db8::/32=\u{6771}\u{4eac}",
             "--remove-ip-allow",
             "0.0.0.0/0",
             "--add-private-endpoint-id",
@@ -3965,7 +3962,10 @@ mod tests {
 
         assert_eq!(service_id, "svc-1");
         assert_eq!(name.as_deref(), Some("renamed"));
-        assert_eq!(add_ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert_eq!(
+            add_ip_allow,
+            vec!["10.0.0.0/8=office", "2001:db8::/32=\u{6771}\u{4eac}"]
+        );
         assert_eq!(remove_ip_allow, vec!["0.0.0.0/0"]);
         assert_eq!(add_private_endpoint_id, vec!["pe-1", "pe-2"]);
         assert_eq!(remove_private_endpoint_id, vec!["pe-3"]);
@@ -5876,7 +5876,7 @@ mod tests {
             autoscaling_mode: Some("vertical".to_string()),
             idle_scaling: Some(true),
             idle_timeout_minutes: Some(10),
-            ip_allow: vec!["10.0.0.0/8".to_string()],
+            ip_allow: vec!["2001:db8::/32=office".to_string()],
             backup_id: Some("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6".to_string()),
             release_channel: Some("fast".to_string()),
             data_warehouse_id: Some("dw-1".to_string()),
@@ -5907,8 +5907,11 @@ mod tests {
         assert_eq!(request.idle_scaling, Some(true));
         assert_eq!(request.idle_timeout_minutes, Some(10.0));
         assert_eq!(request.ip_access_list.len(), 1);
-        assert_eq!(request.ip_access_list[0].source, "10.0.0.0/8");
-        assert!(request.ip_access_list[0].description.is_none());
+        assert_eq!(request.ip_access_list[0].source, "2001:db8::/32");
+        assert_eq!(
+            request.ip_access_list[0].description.as_deref(),
+            Some("office")
+        );
         assert_eq!(
             request.backup_id,
             Some(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap())
@@ -5988,7 +5991,7 @@ mod tests {
     fn build_update_service_request_supports_maximal_fields() {
         let options = ServiceUpdateOptions {
             name: Some("updated".to_string()),
-            add_ip_allow: vec!["10.0.0.0/8".to_string()],
+            add_ip_allow: vec!["10.0.0.0/8=office".to_string()],
             remove_ip_allow: vec!["0.0.0.0/0".to_string()],
             add_private_endpoint_ids: vec!["pe-1".to_string()],
             remove_private_endpoint_ids: vec!["pe-2".to_string()],
@@ -6007,7 +6010,7 @@ mod tests {
         let ip_access_list = request.ip_access_list.as_ref().unwrap();
         assert_eq!(ip_access_list.add.len(), 1);
         assert_eq!(ip_access_list.add[0].source, "10.0.0.0/8");
-        assert!(ip_access_list.add[0].description.is_none());
+        assert_eq!(ip_access_list.add[0].description.as_deref(), Some("office"));
         assert_eq!(ip_access_list.remove.len(), 1);
         assert_eq!(ip_access_list.remove[0].source, "0.0.0.0/0");
         assert!(ip_access_list.remove[0].description.is_none());

--- a/crates/clickhousectl/src/cloud/shared.rs
+++ b/crates/clickhousectl/src/cloud/shared.rs
@@ -1,6 +1,7 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use chrono::{DateTime, FixedOffset, NaiveDate};
-use clickhouse_cloud_api::models::ResourceTagsV1;
+use clickhouse_cloud_api::models::{IpAccessListEntry, ResourceTagsV1};
+use std::net::IpAddr;
 
 /// Resolve an organization ID from an explicit argument or auto-detection.
 pub(super) async fn resolve_org_id(
@@ -77,6 +78,63 @@ pub(super) fn parse_tags(values: &[String]) -> CloudResult<Option<Vec<ResourceTa
     }
 }
 
+/// Parse an IP allowlist argument in `SOURCE[=DESCRIPTION]` form.
+///
+/// `=` keeps the description delimiter unambiguous for IPv6 sources. The
+/// description is kept byte-for-byte, including an explicitly empty value.
+fn parse_ip_access_entry(value: &str) -> CloudResult<IpAccessListEntry> {
+    let (source, description) = value
+        .split_once('=')
+        .map_or((value, None), |(source, description)| {
+            (source, Some(description.to_string()))
+        });
+    let source = source.trim();
+
+    let (address, prefix) = match source.split_once('/') {
+        Some((address, prefix)) if !prefix.contains('/') => (address, Some(prefix)),
+        Some(_) => return Err(invalid_ip_access_entry(value)),
+        None => (source, None),
+    };
+    let address = address
+        .parse::<IpAddr>()
+        .map_err(|_| invalid_ip_access_entry(value))?;
+    if let Some(prefix) = prefix {
+        let prefix = prefix
+            .parse::<u8>()
+            .map_err(|_| invalid_ip_access_entry(value))?;
+        let max_prefix = if address.is_ipv4() { 32 } else { 128 };
+        if prefix > max_prefix {
+            return Err(invalid_ip_access_entry(value));
+        }
+    }
+
+    Ok(IpAccessListEntry {
+        source: source.to_string(),
+        description,
+    })
+}
+
+fn invalid_ip_access_entry(value: &str) -> CloudError {
+    CloudError::new(format!(
+        "invalid IP allowlist entry '{}': expected IP_OR_CIDR[=DESCRIPTION]",
+        value
+    ))
+}
+
+pub(super) fn parse_ip_access_entries(
+    values: &[String],
+) -> CloudResult<Option<Vec<IpAccessListEntry>>> {
+    if values.is_empty() {
+        Ok(None)
+    } else {
+        values
+            .iter()
+            .map(|value| parse_ip_access_entry(value))
+            .collect::<CloudResult<Vec<_>>>()
+            .map(Some)
+    }
+}
+
 pub(super) fn parse_date_only(value: &str) -> Result<String, String> {
     if NaiveDate::parse_from_str(value, "%Y-%m-%d").is_err() {
         return Err(format!("invalid date '{}': expected YYYY-MM-DD", value));
@@ -113,5 +171,44 @@ mod tests {
             err.to_string(),
             "invalid tag '   ': tag key cannot be empty"
         );
+    }
+
+    #[test]
+    fn parse_ip_access_entries_supports_bare_ipv4_ipv6_and_descriptions() {
+        let values = vec![
+            "192.0.2.7".to_string(),
+            "10.0.0.0/8=office".to_string(),
+            "2001:db8::/32=\u{6771}\u{4eac} \u{1f5fc}".to_string(),
+            "2001:db8::1=".to_string(),
+        ];
+        let entries = parse_ip_access_entries(&values).unwrap().unwrap();
+
+        assert_eq!(entries[0].source, "192.0.2.7");
+        assert!(entries[0].description.is_none());
+        assert_eq!(entries[1].source, "10.0.0.0/8");
+        assert_eq!(entries[1].description.as_deref(), Some("office"));
+        assert_eq!(entries[2].source, "2001:db8::/32");
+        assert_eq!(
+            entries[2].description.as_deref(),
+            Some("\u{6771}\u{4eac} \u{1f5fc}")
+        );
+        assert_eq!(entries[3].source, "2001:db8::1");
+        assert_eq!(entries[3].description.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn parse_ip_access_entries_rejects_invalid_sources() {
+        for value in [
+            "",
+            "=office",
+            "not-an-ip",
+            "10.0.0.0/nope",
+            "10.0.0.0/33",
+            "2001:db8::/129",
+            "10.0.0.0/8/9",
+        ] {
+            let error = parse_ip_access_entries(&[value.to_string()]).unwrap_err();
+            assert!(error.to_string().contains(value), "{error}");
+        }
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -13304,6 +13304,189 @@ async fn pgbouncer_config_get_json_preserves_values_and_tolerates_absent_section
     }
 }
 
+// IP allowlist descriptions (#589).
+
+#[tokio::test]
+async fn service_allowlist_descriptions_reach_create_and_additive_update_requests() {
+    let create = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/services"))
+        .and(body_json(serde_json::json!({
+            "name": "described-service",
+            "provider": "aws",
+            "region": "us-east-1",
+            "ipAccessList": [
+                {"source": "192.0.2.0/24"},
+                {"source": "2001:db8::/32", "description": "\u{6771}\u{4eac} \u{1f5fc}"},
+            ],
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "service": {"id": "22222222-3333-4444-5555-666666666666", "name": "described-service"},
+                "password": "generated-password"
+            },
+            "status": 200,
+            "requestId": "stub-service-create"
+        })))
+        .expect(1)
+        .mount(&create)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &create,
+        &[
+            "service",
+            "create",
+            "--name",
+            "described-service",
+            "--ip-allow",
+            "192.0.2.0/24",
+            "--ip-allow",
+            "2001:db8::/32=\u{6771}\u{4eac} \u{1f5fc}",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+
+    let update = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/services/svc-1"))
+        .and(body_json(serde_json::json!({
+            "ipAccessList": {
+                "add": [{"source": "2001:db8:1::/48", "description": "branch office"}],
+                "remove": []
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "22222222-3333-4444-5555-666666666666", "name": "described-service"},
+            "status": 200,
+            "requestId": "stub-service-update"
+        })))
+        .expect(1)
+        .mount(&update)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &update,
+        &[
+            "service",
+            "update",
+            "svc-1",
+            "--add-ip-allow",
+            "2001:db8:1::/48=branch office",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+}
+
+#[tokio::test]
+async fn api_key_allowlist_descriptions_reach_create_and_update_requests() {
+    let create = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .and(body_json(serde_json::json!({
+            "name": "described-key",
+            "state": "enabled",
+            "assignedRoleIds": [],
+            "ipAccessList": [
+                {"source": "198.51.100.4"},
+                {"source": "2001:db8::/32", "description": "production"},
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "key": {"id": "11111111-2222-3333-4444-555555555555", "name": "described-key"},
+                "keyId": "generated-key-id",
+                "keySecret": "generated-key-secret"
+            },
+            "status": 200,
+            "requestId": "stub-key-create"
+        })))
+        .expect(1)
+        .mount(&create)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &create,
+        &[
+            "key",
+            "create",
+            "--name",
+            "described-key",
+            "--ip-allow",
+            "198.51.100.4",
+            "--ip-allow",
+            "2001:db8::/32=production",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+
+    let update = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/keys/key-1"))
+        .and(body_json(serde_json::json!({
+            "ipAccessList": [{"source": "203.0.113.0/24", "description": ""}]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "11111111-2222-3333-4444-555555555555", "name": "described-key"},
+            "status": 200,
+            "requestId": "stub-key-update"
+        })))
+        .expect(1)
+        .mount(&update)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &update,
+        &[
+            "key",
+            "update",
+            "key-1",
+            "--ip-allow",
+            "203.0.113.0/24=",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+}
+
+#[tokio::test]
+async fn invalid_allowlist_sources_fail_before_service_or_key_requests() {
+    for args in [
+        vec![
+            "service",
+            "create",
+            "--name",
+            "invalid-service",
+            "--ip-allow",
+            "2001:db8::/129=invalid",
+            "--org-id",
+            "org-1",
+        ],
+        vec![
+            "key",
+            "update",
+            "key-1",
+            "--ip-allow",
+            "not-an-ip=invalid",
+            "--org-id",
+            "org-1",
+        ],
+    ] {
+        let server = MockServer::start().await;
+        let output = invoke_cli_with_cloud_credentials(&server, &args);
+        assert_eq!(output.status.code(), Some(1), "{args:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("invalid IP allowlist entry"),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+}
+
 // API key nullable expiry (#698) and explicit list clearing (#597).
 async fn invoke_key_update(server: &MockServer, flags: &[&str]) -> std::process::Output {
     let project = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #589.

Accept `IP_OR_CIDR=DESCRIPTION` on service and API-key allowlist flags while preserving bare IP/CIDR inputs. A shared parser validates IPv4 and IPv6 sources, keeps Unicode and explicitly blank descriptions, and carries descriptions through service create/additive update and API-key create/update request bodies.

The existing service removal diff and API-key clear behavior remain unchanged. README and help text document the IPv6-safe `=` syntax.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
