### PR TITLE
feat(api): expose BigQuery replication mode values

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -67,6 +67,11 @@ impl std::fmt::Display for ClickPipeBigQueryPipeSettingsReplicationmode {
     }
 }
 
+impl ClickPipeBigQueryPipeSettingsReplicationmode {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["snapshot"];
+}
+
 /// Inline enum for `ClickPipeBigQueryPipeTableMapping.tableEngine`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ClickPipeBigQueryPipeTableMappingTableengine {


### PR DESCRIPTION
BigQuery ClickPipe replication mode is a typed Cloud API enum, but it did not expose the analyzer-checked wire-value list needed by CLI validation. Add `ClickPipeBigQueryPipeSettingsReplicationmode::VALUES` with the currently supported `snapshot` value so downstream callers can reject unsupported modes before HTTP without duplicating the enum vocabulary.

This is the API prerequisite for #592.

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (91 passed)

