### PR TITLE
feat(org): expose credit balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ clickhousectl cloud org list              # List organizations
 clickhousectl cloud org get <org-id>      # Get organization details
 clickhousectl cloud org quota list --org-id <org-id>
 clickhousectl cloud org quota get services-per-organization --org-id <org-id>
+clickhousectl cloud org balance --org-id <org-id>  # Active trial and prepaid credits
 clickhousectl cloud org update <org-id> --name "Renamed Org"
 clickhousectl cloud org update <org-id> \
   --remove-private-endpoint pe-1,cloud-provider=aws,region=us-east-1 \
@@ -652,10 +653,10 @@ clickhousectl cloud org usage \
   --from-date 2024-01-01 \
   --to-date 2024-01-31 \
   --filter tag:Environment=Production   # max 31-day window (to-date inclusive), costs in CHC
-# Org quota, prometheus, and usage commands auto-detect the org when --org-id is omitted.
+# Org quota, balance, prometheus, and usage commands auto-detect the org when --org-id is omitted.
 # Org list takes no ID; org get/update take a positional <org-id>.
 # It is auto-detected only when your credentials reach exactly one organization.
-# Organization quota commands are beta and read-only, so they support OAuth.
+# Organization quota and balance commands are beta and read-only, so they support OAuth.
 ```
 
 ### Services

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -27,6 +27,13 @@ pub enum OrgCommands {
         command: QuotaCommands,
     },
 
+    /// View active credit balances (Beta)
+    Balance {
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
     /// Update organization settings
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -106,6 +113,7 @@ impl OrgCommands {
             OrgCommands::List => false,
             OrgCommands::Get { .. } => false,
             OrgCommands::Quota { .. } => false,
+            OrgCommands::Balance { .. } => false,
             OrgCommands::Prometheus { .. } => false,
             OrgCommands::Usage { .. } => false,
             OrgCommands::Update { .. } => true,
@@ -253,6 +261,7 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         OrgCommands::List => org_list(client, json).await,
         OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
         OrgCommands::Quota { command } => run_quota(client, command, json).await,
+        OrgCommands::Balance { org_id } => org_balance(client, org_id.as_deref(), json).await,
         OrgCommands::Update {
             org_id,
             name,
@@ -577,6 +586,57 @@ async fn quota_get(
     Ok(())
 }
 
+async fn org_balance(client: &CloudClient, org_id: Option<&str>, json: bool) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let credit_balances = client.get_credit_balances(&org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&credit_balances)?);
+    } else {
+        println!(
+            "Total remaining credits: {} CHC",
+            or_absent(credit_balances.total_remaining_credits)
+        );
+        let balances = credit_balances.balances.unwrap_or_default();
+        if balances.is_empty() {
+            println!("No active credit balances found");
+            return Ok(());
+        }
+
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "ID")]
+            id: String,
+            #[tabled(rename = "Type")]
+            balance_type: String,
+            #[tabled(rename = "Remaining (CHC)")]
+            remaining: String,
+            #[tabled(rename = "Total (CHC)")]
+            total: String,
+            #[tabled(rename = "Spent (CHC)")]
+            spent: String,
+            #[tabled(rename = "Start")]
+            start: String,
+            #[tabled(rename = "Expires")]
+            expires: String,
+        }
+        let rows: Vec<Row> = balances
+            .into_iter()
+            .map(|balance| Row {
+                id: or_absent(balance.id),
+                balance_type: or_absent(balance.r#type.as_ref()),
+                remaining: or_absent(balance.remaining_credits),
+                total: or_absent(balance.total_amount),
+                spent: or_absent(balance.amount_spent),
+                start: or_absent(balance.start_date),
+                expires: or_absent(balance.expiration_date),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
 async fn org_update(
     client: &CloudClient,
     org_id: &str,
@@ -886,6 +946,18 @@ impl CloudClient {
         let response = self
             .api()
             .organization_quotas_get_list(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_credit_balances(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::CreditBalances> {
+        let response = self
+            .api()
+            .credit_balances_get(org_id)
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
@@ -1428,6 +1500,24 @@ mod tests {
     }
 
     #[test]
+    fn parses_org_balance_command() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "balance",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Balance { org_id } = command else {
+            panic!("expected org balance command");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
     fn parses_legacy_org_id_positionals() {
         let prometheus =
             Cli::try_parse_from(["clickhousectl", "cloud", "org", "prometheus", "org-1"]).unwrap();
@@ -1567,6 +1657,7 @@ mod tests {
             ],
             false,
         );
+        assert_write(&["clickhousectl", "cloud", "org", "balance"], false);
         assert_write(&["clickhousectl", "cloud", "org", "prometheus"], false);
         assert_write(
             &[

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -198,6 +198,158 @@ fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> st
         .expect("failed to spawn clickhousectl")
 }
 
+fn invoke_cli_with_cloud_credentials_human(
+    mock: &MockServer,
+    cli_args: &[&str],
+) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = mock.uri();
+    let mut args = vec!["cloud", "--url", &url];
+    args.extend(cli_args);
+    Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args(args)
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn org_balance_preserves_json_and_supports_oauth() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{ "id": AUTO_DETECTED_ORG_ID, "name": "Only org" }],
+            "status": 200,
+            "requestId": "stub-org-list"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let result = serde_json::json!({
+        "totalRemainingCredits": 12.5,
+        "balances": [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "type": "trial",
+                "remainingCredits": 2.5,
+                "totalAmount": 5.0,
+                "amountSpent": 2.5,
+                "startDate": "2026-01-01T00:00:00Z",
+                "expirationDate": "2026-02-01T00:00:00Z"
+            },
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "type": "prepaid",
+                "remainingCredits": 10.0,
+                "totalAmount": 20.0,
+                "amountSpent": 10.0,
+                "startDate": "2026-02-01T00:00:00Z",
+                "expirationDate": "2027-02-01T00:00:00Z"
+            }
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/{AUTO_DETECTED_ORG_ID}/creditBalances"
+        )))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-credit-balances"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args(["cloud", "--url", &mock.uri(), "--json", "org", "balance"])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+    let requests = mock.received_requests().await.unwrap();
+    let balance_request = requests
+        .iter()
+        .find(|request| request.url.path().ends_with("/creditBalances"))
+        .unwrap();
+    assert!(balance_request.url.query().is_none());
+}
+
+#[tokio::test]
+async fn org_balance_human_output_handles_sparse_and_future_balances() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/creditBalances"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "balances": [{ "type": "promotional", "remainingCredits": 3.25 }]
+            },
+            "status": 200,
+            "requestId": "stub-sparse-credit-balances"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output =
+        invoke_cli_with_cloud_credentials_human(&mock, &["org", "balance", "--org-id", "org-1"]);
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Total remaining credits: - CHC"));
+    assert!(stdout.contains(
+        "| ID | Type        | Remaining (CHC) | Total (CHC) | Spent (CHC) | Start | Expires |"
+    ));
+    assert!(stdout.contains("| -  | promotional | 3.25"));
+}
+
+#[tokio::test]
+async fn org_balance_human_output_handles_empty_balances() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/creditBalances"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "totalRemainingCredits": 0.0, "balances": [] },
+            "status": 200,
+            "requestId": "stub-empty-credit-balances"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output =
+        invoke_cli_with_cloud_credentials_human(&mock, &["org", "balance", "--org-id", "org-1"]);
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Total remaining credits: 0 CHC\nNo active credit balances found\n"
+    );
+}
+
 #[tokio::test]
 async fn org_quota_list_preserves_sparse_json_and_supports_oauth() {
     let mock = MockServer::start().await;


### PR DESCRIPTION
## Summary

Expose active organization credit balances through `clickhousectl cloud org balance`. The command calls the replacement, unpaginated `creditBalances` endpoint, supports organization auto-detection and OAuth reads, renders total and per-balance credit details for humans, and preserves the complete response with `--json`.

Closes #580.

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
