### PR TITLE
feat(org): expose Prometheus service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ clickhousectl cloud org update <org-id> \
   --remove-private-endpoint pe-1,cloud-provider=aws,region=us-east-1 \
   --enable-core-dumps false
 clickhousectl cloud org prometheus --filtered-metrics true
+clickhousectl cloud org prometheus discovery --filtered-metrics false
 clickhousectl cloud org usage \
   --from-date 2024-01-01 \
   --to-date 2024-01-31 \
@@ -658,6 +659,8 @@ clickhousectl cloud org usage \
 # It is auto-detected only when your credentials reach exactly one organization.
 # Organization quota and balance commands are beta and read-only, so they support OAuth.
 ```
+
+`cloud org prometheus discovery` returns the beta HTTP service-discovery target groups used by Prometheus `http_sd_configs`; `--json` preserves the complete target and label array. The command defaults discovered scrape targets to filtered metrics. The command without `discovery` still calls the deprecated organization metrics endpoint and emits raw Prometheus exposition text for compatibility.
 
 ### Services
 
@@ -1724,7 +1727,7 @@ clickhousectl cloud --json service list
 clickhousectl cloud --json service get <service-id>
 ```
 
-`clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, others, and any tool that sets the standard `AGENT` / `AI_AGENT` env vars) and emits JSON to stdout automatically without setting `--json`. Protocol-oriented commands retain their natural output: `cloud org prometheus` and `cloud service prometheus` always emit raw Prometheus exposition text and silently ignore `--json`, `cloud service query` uses a ClickHouse format such as `JSONEachRow`, and Postgres runtime configuration is JSON already.
+`clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, others, and any tool that sets the standard `AGENT` / `AI_AGENT` env vars) and emits JSON to stdout automatically without setting `--json`. Protocol-oriented commands retain their natural output: the legacy `cloud org prometheus` command and `cloud service prometheus` always emit raw Prometheus exposition text and silently ignore `--json`, `cloud service query` uses a ClickHouse format such as `JSONEachRow`, and Postgres runtime configuration is JSON already.
 
 Human-readable detail views (`cloud clickpipe get` and every other `get`-style command) never print PEM-framed material. Each well-formed PEM block in a value is replaced, where it stands, by a one-line summary of that block: `<PEM CERTIFICATE, SHA-256 fingerprint AB:CD:...>` for a certificate, certificate request or CRL, using the fingerprint `openssl x509 -fingerprint -sha256` prints for that block, and `<PEM EC PRIVATE KEY, 121 bytes>` for any other label, because a private key is reported by size and never fingerprinted. Text around the blocks, such as a bundle's header comments, is kept as it was. This affects human output only: `--json` still returns the value verbatim, and `cloud postgres certs get` deliberately still prints the raw PEM, since emitting the certificate is that command's purpose.
 

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -63,11 +63,14 @@ CONTEXT FOR AGENTS:
     /// Get organization Prometheus configuration
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Always prints raw Prometheus exposition text; --json is accepted but ignored.
-  Scrape targets and their per-service URLs: `cloud service prometheus`.")]
+  With no subcommand, prints raw metrics text from the legacy endpoint; --json is ignored.
+  Use `discovery` for Prometheus HTTP service-discovery target groups.")]
     Prometheus {
+        #[command(subcommand)]
+        command: Option<PrometheusCommands>,
+
         /// Organization ID (auto-detected only if you have one org)
-        #[arg(long)]
+        #[arg(long, global = true)]
         org_id: Option<String>,
 
         /// Organization ID (deprecated positional form; use --org-id)
@@ -75,7 +78,7 @@ CONTEXT FOR AGENTS:
         legacy_org_id: Option<String>,
 
         /// Return the reduced (filtered) metric set
-        #[arg(long)]
+        #[arg(long, global = true)]
         filtered_metrics: Option<bool>,
     },
 
@@ -119,6 +122,12 @@ impl OrgCommands {
             OrgCommands::Update { .. } => true,
         }
     }
+}
+
+#[derive(Subcommand)]
+pub enum PrometheusCommands {
+    /// List Prometheus scrape targets (Beta)
+    Discovery,
 }
 
 #[derive(Subcommand)]
@@ -276,12 +285,18 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
             org_update(client, &org_id, options, json).await
         }
         OrgCommands::Prometheus {
+            command,
             org_id,
             legacy_org_id,
             filtered_metrics,
         } => {
             let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
-            org_prometheus(client, org_id, filtered_metrics, json).await
+            match command {
+                Some(PrometheusCommands::Discovery) => {
+                    org_prometheus_discovery(client, org_id, filtered_metrics, json).await
+                }
+                None => org_prometheus(client, org_id, filtered_metrics, json).await,
+            }
         }
         OrgCommands::Usage {
             org_id,
@@ -670,6 +685,24 @@ async fn org_prometheus(
     Ok(())
 }
 
+async fn org_prometheus_discovery(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    filtered_metrics: Option<bool>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let groups = client
+        .discover_org_prometheus_targets(&org_id, filtered_metrics)
+        .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&groups)?);
+    } else {
+        print_human(&groups)?;
+    }
+    Ok(())
+}
+
 async fn org_usage(
     client: &CloudClient,
     org_id: Option<&str>,
@@ -997,6 +1030,20 @@ impl CloudClient {
         let filtered_metrics = filtered_metrics.map(|value| if value { "true" } else { "false" });
         self.api()
             .organization_prometheus_get(org_id, filtered_metrics)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))
+    }
+
+    pub async fn discover_org_prometheus_targets(
+        &self,
+        org_id: &str,
+        filtered_metrics: Option<bool>,
+    ) -> crate::cloud::client::Result<
+        Vec<clickhouse_cloud_api::models::PrometheusDiscoveryTargetGroup>,
+    > {
+        let filtered_metrics = filtered_metrics.map(|value| if value { "true" } else { "false" });
+        self.api()
+            .organization_prometheus_discovery_get(org_id, filtered_metrics)
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))
     }
@@ -1459,6 +1506,40 @@ mod tests {
     }
 
     #[test]
+    fn parses_org_prometheus_discovery_flags() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "prometheus",
+            "discovery",
+            "--org-id",
+            "org-1",
+            "--filtered-metrics",
+            "false",
+        ])
+        .unwrap();
+
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Prometheus {
+            command: Some(PrometheusCommands::Discovery),
+            org_id,
+            filtered_metrics,
+            ..
+        } = command
+        else {
+            panic!("expected prometheus discovery");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+        assert_eq!(filtered_metrics, Some(false));
+    }
+
+    #[test]
     fn parses_org_quota_commands() {
         let CloudCommands::Org { command } = parse_cloud_command(&[
             "clickhousectl",
@@ -1659,6 +1740,10 @@ mod tests {
         );
         assert_write(&["clickhousectl", "cloud", "org", "balance"], false);
         assert_write(&["clickhousectl", "cloud", "org", "prometheus"], false);
+        assert_write(
+            &["clickhousectl", "cloud", "org", "prometheus", "discovery"],
+            false,
+        );
         assert_write(
             &[
                 "clickhousectl",

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use serde_json::Value;
-use wiremock::matchers::{body_json, header, method, path, path_regex};
+use wiremock::matchers::{body_json, header, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Locate the `clickhousectl` binary. cargo populates `CARGO_BIN_EXE_<name>`
@@ -2930,6 +2930,130 @@ async fn org_prometheus_auto_detects_the_only_organization() {
         format!("/v1/organizations/{AUTO_DETECTED_ORG_ID}/prometheus")
     );
     assert_eq!(requests[1].url.query(), Some("filtered_metrics=true"));
+}
+
+#[tokio::test]
+async fn org_prometheus_discovery_preserves_groups_and_supports_oauth() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!([{
+        "targets": ["api.clickhouse.cloud:443"],
+        "labels": {
+            "__scheme__": "https",
+            "__metrics_path__": "/v1/organizations/org-1/services/svc-1/prometheus",
+            "__param_filtered_metrics": "false",
+            "clickhouse_org_id": "11111111-2222-3333-4444-555555555555",
+            "clickhouse_service_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "clickhouse_discovery_service_name": "analytics"
+        }
+    }]);
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/prometheus/discovery"))
+        .and(query_param("filtered_metrics", "false"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&result))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "org",
+            "prometheus",
+            "discovery",
+            "--org-id",
+            "org-1",
+            "--filtered-metrics",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+}
+
+#[tokio::test]
+async fn org_prometheus_discovery_renders_sparse_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/prometheus/discovery"))
+        .and(query_param("filtered_metrics", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "targets": ["api.clickhouse.cloud:443"] },
+            { "labels": { "__scheme__": "https" } }
+        ])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "org",
+            "prometheus",
+            "discovery",
+            "--org-id",
+            "org-1",
+            "--filtered-metrics",
+            "true",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "- targets: [api.clickhouse.cloud:443]\n- labels:\n    __scheme__: https\n"
+    );
+}
+
+#[tokio::test]
+async fn org_prometheus_discovery_omits_filter_query_when_unspecified() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/prometheus/discovery"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["org", "prometheus", "discovery", "--org-id", "org-1"],
+    );
+    assert_success(&output);
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "[]\n");
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].url.query(), None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #581.

The organization Prometheus command only exposed the deprecated raw metrics endpoint, while the replacement HTTP service-discovery endpoint had no CLI route. Add `cloud org prometheus discovery` as an explicit read-only command that returns the typed target-group array, supports `--filtered-metrics true|false`, organization auto-detection, OAuth, full JSON output, and sparse-safe human output. Invoking `cloud org prometheus` without the subcommand retains its existing raw exposition-text behavior.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (1061 unit tests and 304 cloud subprocess tests passed; two existing long-running tests ignored; all local and telemetry subprocess suites passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (90 passed; one sandbox-blocked temporary-git test passed on an exact unrestricted rerun)
