### PR TITLE
feat(postgres): expose service metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,12 @@ clickhousectl cloud postgres list --filter state=running
 clickhousectl cloud postgres list --filter region=us-east-1 --filter isPrimary=true
 clickhousectl cloud postgres get <pg-id>
 
+# Time-bucketed metrics (omit --bucket-size-seconds to let the API choose)
+clickhousectl cloud postgres metrics <pg-id> \
+  --from-date 2026-04-16T12:00:00Z \
+  --to-date 2026-04-16T13:00:00Z \
+  --bucket-size-seconds 60
+
 # Create
 clickhousectl cloud postgres create \
   --name my-pg \
@@ -1017,6 +1023,8 @@ PgBouncer parameter names are open-ended; values must be quoted strings, includi
 `pgConfig` uses the closed set of GUC names supported by the Cloud API. Unknown names and `null` values are rejected locally on `--set` and every PgConfig file path, and the enum-valued settings accept only `default_transaction_isolation` (`read committed`, `repeatable read`, `serializable`), `ssl_min_protocol_version` (`TLSv1` through `TLSv1.3`), and `wal_compression` (`off`, `on`, `lz4`, `zstd`). Files for `config patch` and `config replace` must contain both `pgConfig` and `pgBouncerConfig`; use an explicit `{}` when a section is intentionally empty rather than omitting it.
 
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
+
+`postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
 
 `postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,16 +1,17 @@
 use crate::cloud::client::{
     CloudClient, CloudError, ResourceKind, ResourceLookup, Result as CloudResult,
 };
-use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_line};
+use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_human, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
     ApiResponse, PgBouncerConfig, PgConfig, PgConfigDefaultTransactionIsolation,
     PgConfigSslMinProtocolVersion, PgConfigWalCompression, PgHaType, PgIdProperty, PgProvider,
-    PgSize, PgVersion, PostgresInstanceConfig, PostgresService, PostgresServiceListItem,
-    PostgresServicePatchRequest, PostgresServicePostRequest, PostgresServiceReadReplicaRequest,
-    PostgresServiceRestoreRequest, PostgresServiceSetPassword, PostgresServiceSetState,
-    PostgresServiceSetStateCommand, ResourceTagsV1, ResourceTagsV1Response,
+    PgSize, PgVersion, PostgresInstanceConfig, PostgresMetrics, PostgresService,
+    PostgresServiceListItem, PostgresServicePatchRequest, PostgresServicePostRequest,
+    PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest, PostgresServiceSetPassword,
+    PostgresServiceSetState, PostgresServiceSetStateCommand, ResourceTagsV1,
+    ResourceTagsV1Response,
 };
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
@@ -160,6 +161,24 @@ CONTEXT FOR AGENTS:
     /// Manage Postgres read replicas
     #[command(name = "read-replica", subcommand)]
     ReadReplica(ReadReplicaCommands),
+
+    /// Get Postgres service metrics
+    Metrics {
+        /// Postgres service ID (from `cloud postgres list`)
+        postgres_id: String,
+        /// Start time (ISO 8601 / RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        from_date: String,
+        /// End time (ISO 8601 / RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        to_date: String,
+        /// Time bucket size in seconds
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..))]
+        bucket_size_seconds: Option<i64>,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
 
     /// Restore a Postgres service to a point in time
     #[command(after_help = "\
@@ -335,7 +354,9 @@ CONTEXT FOR AGENTS:
 impl PostgresCommands {
     pub fn is_write(&self) -> bool {
         match self {
-            PostgresCommands::List { .. } | PostgresCommands::Get { .. } => false,
+            PostgresCommands::List { .. }
+            | PostgresCommands::Get { .. }
+            | PostgresCommands::Metrics { .. } => false,
             PostgresCommands::Certs(CertsCommands::Get { .. }) => false,
             PostgresCommands::Config(ConfigCommands::Get { .. }) => false,
 
@@ -485,6 +506,24 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
                 org_id: org_id.as_deref(),
             };
             postgres_read_replica_create(client, &postgres_id, opts, json).await
+        }
+        PostgresCommands::Metrics {
+            postgres_id,
+            from_date,
+            to_date,
+            bucket_size_seconds,
+            org_id,
+        } => {
+            postgres_metrics(
+                client,
+                &postgres_id,
+                &from_date,
+                &to_date,
+                bucket_size_seconds,
+                org_id.as_deref(),
+                json,
+            )
+            .await
         }
         PostgresCommands::Restore {
             postgres_id,
@@ -1622,11 +1661,76 @@ pub async fn postgres_state_change(
     Ok(())
 }
 
+fn validate_metrics_date_range(from_date: &str, to_date: &str) -> CloudResult<()> {
+    let from = chrono::DateTime::parse_from_rfc3339(from_date)
+        .map_err(|_| CloudError::new("invalid --from-date: expected ISO 8601 / RFC 3339"))?;
+    let to = chrono::DateTime::parse_from_rfc3339(to_date)
+        .map_err(|_| CloudError::new("invalid --to-date: expected ISO 8601 / RFC 3339"))?;
+    if from > to {
+        return Err(CloudError::new(
+            "invalid date range: --from-date must not be after --to-date",
+        ));
+    }
+    Ok(())
+}
+
+pub async fn postgres_metrics(
+    client: &CloudClient,
+    postgres_id: &str,
+    from_date: &str,
+    to_date: &str,
+    bucket_size_seconds: Option<i64>,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    validate_metrics_date_range(from_date, to_date)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let metrics = client
+        .get_postgres_metrics(
+            &org_id,
+            postgres_id,
+            from_date,
+            to_date,
+            bucket_size_seconds,
+        )
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&metrics)?);
+    } else {
+        print_human(&metrics)?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Role changes: promote / switchover (issue #604)
 // ---------------------------------------------------------------------------
 
 impl CloudClient {
+    /// Fetch time-bucketed metrics for a Postgres service.
+    pub async fn get_postgres_metrics(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+        from_date: &str,
+        to_date: &str,
+        bucket_size_seconds: Option<i64>,
+    ) -> CloudResult<PostgresMetrics> {
+        let response = self
+            .api()
+            .postgres_instance_metrics_get(
+                org_id,
+                postgres_id,
+                from_date,
+                to_date,
+                bucket_size_seconds,
+            )
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
     /// Fetch a single Postgres service.
     pub async fn get_postgres_service(
         &self,
@@ -2575,6 +2679,125 @@ mod tests {
         .err()
         .expect("expected parse error");
         assert!(err.to_string().contains("invalid datetime"));
+    }
+
+    #[test]
+    fn parses_postgres_metrics_with_all_query_inputs() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "metrics",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00+01:00",
+            "--to-date",
+            "2026-04-16T13:00:00+01:00",
+            "--bucket-size-seconds",
+            "60",
+            "--org-id",
+            "org-1",
+        ]);
+        assert!(!cmd.is_write());
+        let PostgresCommands::Metrics {
+            postgres_id,
+            from_date,
+            to_date,
+            bucket_size_seconds,
+            org_id,
+        } = cmd
+        else {
+            panic!("expected metrics");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(from_date, "2026-04-16T12:00:00+01:00");
+        assert_eq!(to_date, "2026-04-16T13:00:00+01:00");
+        assert_eq!(bucket_size_seconds, Some(60));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn postgres_metrics_requires_dates_without_defaulting_bucket_size() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "metrics",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00Z",
+            "--to-date",
+            "2026-04-16T13:00:00Z",
+        ]);
+        let PostgresCommands::Metrics {
+            bucket_size_seconds,
+            ..
+        } = cmd
+        else {
+            panic!("expected metrics");
+        };
+        assert_eq!(bucket_size_seconds, None);
+
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "metrics",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00Z",
+        ])
+        .err()
+        .expect("expected parse error");
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn postgres_metrics_rejects_invalid_dates_and_bucket_sizes() {
+        for (flag, value) in [
+            ("--from-date", "yesterday"),
+            ("--to-date", "tomorrow"),
+            ("--bucket-size-seconds", "0"),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "metrics",
+                "pg-1",
+                "--from-date",
+                "2026-04-16T12:00:00Z",
+                "--to-date",
+                "2026-04-16T13:00:00Z",
+            ];
+            let position = args.iter().position(|arg| *arg == flag);
+            if let Some(position) = position {
+                args[position + 1] = value;
+            } else {
+                args.extend([flag, value]);
+            }
+            let error = Cli::try_parse_from(args)
+                .err()
+                .expect("expected parse error");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+    }
+
+    #[test]
+    fn postgres_metrics_validates_chronological_range() {
+        assert!(
+            validate_metrics_date_range("2026-04-16T12:00:00+01:00", "2026-04-16T11:00:00Z")
+                .is_ok()
+        );
+        let error = validate_metrics_date_range("2026-04-16T12:00:01Z", "2026-04-16T12:00:00Z")
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid date range: --from-date must not be after --to-date"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1489,6 +1489,210 @@ async fn service_delete_running_conflict_suggests_force() {
     );
 }
 
+// ── Postgres metrics (issue #583) ─────────────────────────────────────────
+
+#[tokio::test]
+async fn postgres_metrics_sends_exact_query_supports_oauth_and_preserves_json() {
+    let mock = MockServer::start().await;
+    let postgres_id = "11111111-2222-3333-4444-555555555555";
+    let result = serde_json::json!({
+        "metrics": [{
+            "key": "cpu",
+            "name": "CPU usage",
+            "description": "Average CPU usage",
+            "unit": "percent",
+            "series": [{
+                "label": "primary",
+                "dataPoints": [
+                    { "timestamp": 1776337200, "value": 12.5 },
+                    { "timestamp": 1776337260, "value": 13.25 }
+                ]
+            }]
+        }, {
+            "key": "replication-lag",
+            "series": []
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/postgres/{postgres_id}/metrics"
+        )))
+        .and(query_param("from_date", "2026-04-16T12:00:00+01:00"))
+        .and(query_param("to_date", "2026-04-16T13:00:00+01:00"))
+        .and(query_param("bucket_size_seconds", "60"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-postgres-metrics"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "postgres",
+            "metrics",
+            postgres_id,
+            "--from-date",
+            "2026-04-16T12:00:00+01:00",
+            "--to-date",
+            "2026-04-16T13:00:00+01:00",
+            "--bucket-size-seconds",
+            "60",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let query: Vec<_> = requests[0]
+        .url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    assert_eq!(
+        query,
+        [
+            (
+                "from_date".to_string(),
+                "2026-04-16T12:00:00+01:00".to_string()
+            ),
+            (
+                "to_date".to_string(),
+                "2026-04-16T13:00:00+01:00".to_string()
+            ),
+            ("bucket_size_seconds".to_string(), "60".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn postgres_metrics_omits_bucket_and_renders_sparse_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/metrics"))
+        .and(query_param("from_date", "2026-04-16T12:00:00Z"))
+        .and(query_param("to_date", "2026-04-16T13:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "metrics": [{
+                    "key": "connections",
+                    "series": [{ "dataPoints": [{ "timestamp": 1776337200 }] }]
+                }]
+            },
+            "status": 200
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "postgres",
+            "metrics",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00Z",
+            "--to-date",
+            "2026-04-16T13:00:00Z",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for text in [
+        "metrics:",
+        "key: connections",
+        "dataPoints:",
+        "timestamp: 1776337200",
+    ] {
+        assert!(stdout.contains(text), "missing {text:?} from:\n{stdout}");
+    }
+    let requests = mock.received_requests().await.unwrap();
+    let query: Vec<_> = requests[0].url.query_pairs().collect();
+    assert_eq!(query.len(), 2, "unexpected query parameters: {query:?}");
+    assert!(
+        query.iter().all(|(key, _)| key != "bucket_size_seconds"),
+        "bucket size must be omitted when the flag is absent: {query:?}"
+    );
+}
+
+#[tokio::test]
+async fn postgres_metrics_rejects_reverse_range_before_request_and_surfaces_api_errors() {
+    let mock = MockServer::start().await;
+    let base_args = [
+        "postgres",
+        "metrics",
+        "pg-1",
+        "--from-date",
+        "2026-04-16T13:00:00Z",
+        "--to-date",
+        "2026-04-16T12:00:00Z",
+        "--org-id",
+        "org-1",
+    ];
+    let output = invoke_cli_with_cloud_credentials(&mock, &base_args);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from-date must not be after --to-date")
+    );
+    assert!(mock.received_requests().await.unwrap().is_empty());
+
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/metrics"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "status": 429,
+            "error": "RATE_LIMIT_EXCEEDED: try later",
+            "requestId": "stub-postgres-metrics-error"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let valid_args = [
+        "postgres",
+        "metrics",
+        "pg-1",
+        "--from-date",
+        "2026-04-16T12:00:00Z",
+        "--to-date",
+        "2026-04-16T13:00:00Z",
+        "--org-id",
+        "org-1",
+    ];
+    let output = invoke_cli_with_cloud_credentials(&mock, &valid_args);
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("RATE_LIMIT_EXCEEDED: try later"),
+        "{stderr}"
+    );
+}
+
 // ── Postgres deletion JSON output (issue #614) ────────────────────────────
 
 /// `postgres delete --json` must emit the Postgres resource object, not the


### PR DESCRIPTION
Closes #583.

Managed Postgres metrics were available in the typed Cloud API client but had no CLI surface. This adds `cloud postgres metrics <POSTGRES_ID>` with required RFC 3339 `--from-date` and `--to-date` inputs plus an optional positive `--bucket-size-seconds`. The command validates chronological ranges before HTTP, supports OAuth reads, preserves the complete nested response in JSON, and renders sparse human output through the shared printer.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
