### PR TITLE
feat(postgres): expose server logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,16 @@ clickhousectl cloud postgres metrics <pg-id> \
   --to-date 2026-04-16T13:00:00Z \
   --bucket-size-seconds 60
 
+# Server logs (RFC 3339 range, at most 30 days)
+clickhousectl cloud postgres logs <pg-id> \
+  --from-date 2026-08-01T00:00:00Z \
+  --to-date 2026-08-02T00:00:00Z
+clickhousectl cloud postgres logs <pg-id> \
+  --from-date 2026-08-01T00:00:00Z \
+  --to-date 2026-08-02T00:00:00Z \
+  --severity ERROR --body-contains "connection refused" \
+  --sort-order asc --limit 200 --offset 0
+
 # Create
 clickhousectl cloud postgres create \
   --name my-pg \
@@ -1025,6 +1035,8 @@ PgBouncer parameter names are open-ended; values must be quoted strings, includi
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
 
 `postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
+
+`postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
 
 `postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -7,11 +7,11 @@ use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
     ApiResponse, PgBouncerConfig, PgConfig, PgConfigDefaultTransactionIsolation,
     PgConfigSslMinProtocolVersion, PgConfigWalCompression, PgHaType, PgIdProperty, PgProvider,
-    PgSize, PgVersion, PostgresInstanceConfig, PostgresMetrics, PostgresService,
-    PostgresServiceListItem, PostgresServicePatchRequest, PostgresServicePostRequest,
-    PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest, PostgresServiceSetPassword,
-    PostgresServiceSetState, PostgresServiceSetStateCommand, ResourceTagsV1,
-    ResourceTagsV1Response,
+    PgSize, PgVersion, PostgresInstanceConfig, PostgresLogEntry, PostgresLogsGetListSortorder,
+    PostgresMetrics, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
+    PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
+    PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
+    ResourceTagsV1, ResourceTagsV1Response,
 };
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
@@ -37,6 +37,40 @@ pub enum PostgresCommands {
     Get {
         /// Postgres service ID (from `cloud postgres list`)
         postgres_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// List Postgres server logs
+    Logs {
+        /// Postgres service ID (from `cloud postgres list`)
+        postgres_id: String,
+        /// Inclusive start of the time window (RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        from_date: String,
+        /// Inclusive end of the time window (RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        to_date: String,
+        /// Case-sensitive substring the log body must contain
+        #[arg(long)]
+        body_contains: Option<String>,
+        /// PostgreSQL severity, such as ERROR, WARNING, or LOG
+        #[arg(long)]
+        severity: Option<String>,
+        /// Sort order
+        #[arg(long, value_parser = parse_postgres_logs_sort_order)]
+        sort_order: Option<PostgresLogsGetListSortorder>,
+        /// Maximum number of log entries
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=2000))]
+        limit: Option<i64>,
+        /// Number of log entries to skip
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            value_parser = clap::value_parser!(i64).range(0..)
+        )]
+        offset: Option<i64>,
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
         org_id: Option<String>,
@@ -356,7 +390,8 @@ impl PostgresCommands {
         match self {
             PostgresCommands::List { .. }
             | PostgresCommands::Get { .. }
-            | PostgresCommands::Metrics { .. } => false,
+            | PostgresCommands::Metrics { .. }
+            | PostgresCommands::Logs { .. } => false,
             PostgresCommands::Certs(CertsCommands::Get { .. }) => false,
             PostgresCommands::Config(ConfigCommands::Get { .. }) => false,
 
@@ -384,6 +419,28 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
             postgres_id,
             org_id,
         } => postgres_get(client, &postgres_id, org_id.as_deref(), json).await,
+        PostgresCommands::Logs {
+            postgres_id,
+            from_date,
+            to_date,
+            body_contains,
+            severity,
+            sort_order,
+            limit,
+            offset,
+            org_id,
+        } => {
+            let query = build_postgres_logs_query(
+                &from_date,
+                &to_date,
+                body_contains.as_deref(),
+                severity.as_deref(),
+                sort_order.as_ref(),
+                limit,
+                offset,
+            )?;
+            postgres_logs(client, &postgres_id, &query, org_id.as_deref(), json).await
+        }
         PostgresCommands::Create {
             name,
             region,
@@ -1059,6 +1116,80 @@ pub struct PostgresRestoreOptions<'a> {
     pub org_id: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct PostgresLogsQuery {
+    from_date: String,
+    to_date: String,
+    body_contains: Option<String>,
+    severity: Option<String>,
+    sort_order: Option<PostgresLogsGetListSortorder>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_postgres_logs_query(
+    from_date: &str,
+    to_date: &str,
+    body_contains: Option<&str>,
+    severity: Option<&str>,
+    sort_order: Option<&PostgresLogsGetListSortorder>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+) -> CloudResult<PostgresLogsQuery> {
+    let from = chrono::DateTime::parse_from_rfc3339(from_date)
+        .map_err(|error| CloudError::new(format!("invalid from-date: {error}")))?;
+    let to = chrono::DateTime::parse_from_rfc3339(to_date)
+        .map_err(|error| CloudError::new(format!("invalid to-date: {error}")))?;
+    if to <= from {
+        return Err(CloudError::new("to-date must be after from-date"));
+    }
+    if to.signed_duration_since(from) > chrono::Duration::days(30) {
+        return Err(CloudError::new(
+            "the Postgres log time window must not exceed 30 days",
+        ));
+    }
+    if !matches!(limit, None | Some(1..=2000)) {
+        return Err(CloudError::new("limit must be between 1 and 2000"));
+    }
+    if offset.is_some_and(|value| value < 0) {
+        return Err(CloudError::new("offset must be at least 0"));
+    }
+
+    let sort_order = sort_order
+        .cloned()
+        .map(validate_postgres_logs_sort_order)
+        .transpose()
+        .map_err(CloudError::new)?;
+
+    Ok(PostgresLogsQuery {
+        from_date: from_date.to_string(),
+        to_date: to_date.to_string(),
+        body_contains: body_contains.map(str::to_string),
+        severity: severity.map(str::to_string),
+        sort_order,
+        limit,
+        offset,
+    })
+}
+
+fn parse_postgres_logs_sort_order(value: &str) -> Result<PostgresLogsGetListSortorder, String> {
+    let parsed = serde_json::from_value(serde_json::Value::String(value.to_string()))
+        .map_err(|error| format!("invalid sort order '{value}': {error}"))?;
+    validate_postgres_logs_sort_order(parsed)
+}
+
+fn validate_postgres_logs_sort_order(
+    value: PostgresLogsGetListSortorder,
+) -> Result<PostgresLogsGetListSortorder, String> {
+    match value {
+        PostgresLogsGetListSortorder::Unknown(value) => Err(format!(
+            "invalid sort order '{value}': expected a value supported by the Cloud API"
+        )),
+        known => Ok(known),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -1149,6 +1280,28 @@ pub async fn postgres_get(
         // credentials on July 31, 2026 — they are only available from
         // `postgres create` and `postgres reset-password`.
         render_postgres_service(&svc);
+    }
+    Ok(())
+}
+
+async fn postgres_logs(
+    client: &CloudClient,
+    postgres_id: &str,
+    query: &PostgresLogsQuery,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let logs = client
+        .list_postgres_logs(&org_id, postgres_id, query)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&logs)?);
+    } else if logs.is_empty() {
+        println!("No Postgres logs found");
+    } else {
+        print_human(&logs)?;
     }
     Ok(())
 }
@@ -1752,6 +1905,31 @@ impl CloudClient {
         Self::unwrap_response(response)
     }
 
+    /// Fetch Postgres server logs for a validated time window.
+    async fn list_postgres_logs(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+        query: &PostgresLogsQuery,
+    ) -> CloudResult<Vec<PostgresLogEntry>> {
+        let response = self
+            .api()
+            .postgres_logs_get_list(
+                org_id,
+                postgres_id,
+                &query.from_date,
+                &query.to_date,
+                query.body_contains.as_deref(),
+                query.severity.as_deref(),
+                query.sort_order.as_ref(),
+                query.limit,
+                query.offset,
+            )
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
     /// Issue a `restart`/`promote`/`switchover` command against a Postgres service.
     pub async fn set_postgres_service_state(
         &self,
@@ -2153,6 +2331,215 @@ mod tests {
             panic!("expected get");
         };
         assert_eq!(postgres_id, "pg-1");
+    }
+
+    #[test]
+    fn parses_postgres_logs_minimal() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "logs",
+            "pg-1",
+            "--from-date",
+            "2026-08-01T00:00:00Z",
+            "--to-date",
+            "2026-08-02T00:00:00Z",
+        ]);
+        let PostgresCommands::Logs {
+            postgres_id,
+            from_date,
+            to_date,
+            body_contains,
+            severity,
+            sort_order,
+            limit,
+            offset,
+            ..
+        } = &cmd
+        else {
+            panic!("expected logs");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(from_date, "2026-08-01T00:00:00Z");
+        assert_eq!(to_date, "2026-08-02T00:00:00Z");
+        assert_eq!(body_contains, &None);
+        assert_eq!(severity, &None);
+        assert_eq!(sort_order, &None);
+        assert_eq!(limit, &None);
+        assert_eq!(offset, &None);
+        assert!(!cmd.is_write());
+    }
+
+    #[test]
+    fn parses_postgres_logs_maximal() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "logs",
+            "pg-1",
+            "--from-date",
+            "2026-08-01T00:00:00+01:00",
+            "--to-date",
+            "2026-08-02T00:00:00+01:00",
+            "--body-contains",
+            "checkpoint complete",
+            "--severity",
+            "LOG",
+            "--sort-order",
+            "asc",
+            "--limit",
+            "2000",
+            "--offset",
+            "0",
+            "--org-id",
+            "org-1",
+        ]);
+        let PostgresCommands::Logs {
+            body_contains,
+            severity,
+            sort_order,
+            limit,
+            offset,
+            org_id,
+            ..
+        } = cmd
+        else {
+            panic!("expected logs");
+        };
+        assert_eq!(body_contains.as_deref(), Some("checkpoint complete"));
+        assert_eq!(severity.as_deref(), Some("LOG"));
+        assert_eq!(sort_order, Some(PostgresLogsGetListSortorder::Asc));
+        assert_eq!(limit, Some(2000));
+        assert_eq!(offset, Some(0));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn rejects_invalid_postgres_logs_flag_values() {
+        let invalid_datetime = PostgresCli::try_parse_from([
+            "clickhousectl",
+            "logs",
+            "pg-1",
+            "--from-date",
+            "yesterday",
+            "--to-date",
+            "2026-08-02T00:00:00Z",
+        ])
+        .err()
+        .expect("expected invalid datetime");
+        assert_eq!(
+            invalid_datetime.kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+
+        for (flag, value, expected_kind) in [
+            (
+                "--sort-order",
+                "newest",
+                clap::error::ErrorKind::ValueValidation,
+            ),
+            ("--limit", "0", clap::error::ErrorKind::ValueValidation),
+            ("--limit", "2001", clap::error::ErrorKind::ValueValidation),
+            ("--offset", "-1", clap::error::ErrorKind::ValueValidation),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "logs",
+                "pg-1",
+                "--from-date",
+                "2026-08-01T00:00:00Z",
+                "--to-date",
+                "2026-08-02T00:00:00Z",
+            ];
+            args.extend([flag, value]);
+            let error = PostgresCli::try_parse_from(args)
+                .err()
+                .expect("expected invalid logs option");
+            assert_eq!(error.kind(), expected_kind);
+        }
+    }
+
+    #[test]
+    fn builds_minimal_postgres_logs_query() {
+        let query = build_postgres_logs_query(
+            "2026-08-01T00:00:00Z",
+            "2026-08-02T00:00:00Z",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(query.from_date, "2026-08-01T00:00:00Z");
+        assert_eq!(query.to_date, "2026-08-02T00:00:00Z");
+        assert_eq!(query.body_contains, None);
+        assert_eq!(query.severity, None);
+        assert_eq!(query.sort_order, None);
+        assert_eq!(query.limit, None);
+        assert_eq!(query.offset, None);
+    }
+
+    #[test]
+    fn builds_maximal_postgres_logs_query() {
+        let query = build_postgres_logs_query(
+            "2026-08-01T00:00:00Z",
+            "2026-08-31T00:00:00Z",
+            Some("checkpoint"),
+            Some("LOG"),
+            Some(&PostgresLogsGetListSortorder::Asc),
+            Some(2000),
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(query.body_contains.as_deref(), Some("checkpoint"));
+        assert_eq!(query.severity.as_deref(), Some("LOG"));
+        assert_eq!(query.sort_order, Some(PostgresLogsGetListSortorder::Asc));
+        assert_eq!(query.limit, Some(2000));
+        assert_eq!(query.offset, Some(0));
+    }
+
+    #[test]
+    fn rejects_invalid_postgres_logs_time_windows() {
+        for (from, to, message) in [
+            (
+                "2026-08-02T00:00:00Z",
+                "2026-08-01T00:00:00Z",
+                "to-date must be after from-date",
+            ),
+            (
+                "2026-08-01T00:00:00Z",
+                "2026-08-01T00:00:00Z",
+                "to-date must be after from-date",
+            ),
+            (
+                "2026-08-01T00:00:00Z",
+                "2026-09-01T00:00:01Z",
+                "must not exceed 30 days",
+            ),
+        ] {
+            let error =
+                build_postgres_logs_query(from, to, None, None, None, None, None).unwrap_err();
+            assert!(error.to_string().contains(message), "{error}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_typed_postgres_logs_sort_order() {
+        let unknown = PostgresLogsGetListSortorder::Unknown("future".to_string());
+        let error = build_postgres_logs_query(
+            "2026-08-01T00:00:00Z",
+            "2026-08-02T00:00:00Z",
+            None,
+            None,
+            Some(&unknown),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("invalid sort order 'future'"));
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1693,6 +1693,215 @@ async fn postgres_metrics_rejects_reverse_range_before_request_and_surfaces_api_
     );
 }
 
+// ── Postgres logs (issue #582) ────────────────────────────────────────────
+
+fn invoke_postgres_logs(
+    mock: &MockServer,
+    home: &Path,
+    json: bool,
+    args: &[&str],
+) -> std::process::Output {
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(home)
+        .args(["cloud", "--url", &mock.uri()]);
+    if json {
+        command.arg("--json");
+    }
+    command.args(["postgres", "logs", "pg-1"]).args(args);
+    command.output().expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn postgres_logs_routes_all_query_parameters_and_preserves_json_with_oauth() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!([
+        {
+            "timestamp": "2026-08-01T12:00:00Z",
+            "severity": "LOG",
+            "body": "checkpoint complete"
+        },
+        { "severity": "WARNING" }
+    ]);
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/logs"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-postgres-logs"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = invoke_postgres_logs(
+        &mock,
+        &home,
+        true,
+        &[
+            "--from-date",
+            "2026-08-01T00:00:00+01:00",
+            "--to-date",
+            "2026-08-02T00:00:00+01:00",
+            "--body-contains",
+            "checkpoint complete",
+            "--severity",
+            "LOG",
+            "--sort-order",
+            "asc",
+            "--limit",
+            "2000",
+            "--offset",
+            "0",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].body.is_empty(), "GET must not carry a body");
+    let query: std::collections::BTreeMap<_, _> = requests[0]
+        .url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    assert_eq!(
+        query,
+        std::collections::BTreeMap::from([
+            (
+                "body_contains".to_string(),
+                "checkpoint complete".to_string()
+            ),
+            (
+                "from_date".to_string(),
+                "2026-08-01T00:00:00+01:00".to_string()
+            ),
+            ("limit".to_string(), "2000".to_string()),
+            ("offset".to_string(), "0".to_string()),
+            ("severity".to_string(), "LOG".to_string()),
+            ("sort_order".to_string(), "asc".to_string()),
+            (
+                "to_date".to_string(),
+                "2026-08-02T00:00:00+01:00".to_string()
+            ),
+        ])
+    );
+}
+
+#[tokio::test]
+async fn postgres_logs_minimal_query_and_sparse_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{ "severity": "WARNING" }, { "body": "recovery complete" }],
+            "status": 200
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let home = tempfile::tempdir().unwrap();
+    let output = invoke_postgres_logs(
+        &mock,
+        home.path(),
+        false,
+        &[
+            "--from-date",
+            "2026-08-01T00:00:00Z",
+            "--to-date",
+            "2026-08-02T00:00:00Z",
+            "--org-id",
+            "org-1",
+            "--api-key",
+            "logs-key",
+            "--api-secret",
+            "logs-secret",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("severity: WARNING"), "{stdout}");
+    assert!(stdout.contains("body: recovery complete"), "{stdout}");
+    assert!(!stdout.contains("timestamp:"), "{stdout}");
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].url.query(),
+        Some("from_date=2026-08-01T00%3A00%3A00Z&to_date=2026-08-02T00%3A00%3A00Z")
+    );
+}
+
+#[tokio::test]
+async fn postgres_logs_reports_empty_results_and_structured_api_errors() {
+    for (response, expected_status, expected_text) in [
+        (
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": [], "status": 200
+            })),
+            0,
+            "No Postgres logs found",
+        ),
+        (
+            ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "status": 400,
+                "error": "BAD_REQUEST: invalid log window",
+                "requestId": "stub-invalid-window"
+            })),
+            1,
+            "invalid log window",
+        ),
+    ] {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/organizations/org-1/postgres/pg-1/logs"))
+            .respond_with(response)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let home = tempfile::tempdir().unwrap();
+        let output = invoke_postgres_logs(
+            &mock,
+            home.path(),
+            false,
+            &[
+                "--from-date",
+                "2026-08-01T00:00:00Z",
+                "--to-date",
+                "2026-08-02T00:00:00Z",
+                "--org-id",
+                "org-1",
+                "--api-key",
+                "logs-key",
+                "--api-secret",
+                "logs-secret",
+            ],
+        );
+        assert_eq!(output.status.code(), Some(expected_status));
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(combined.contains(expected_text), "{combined}");
+    }
+}
+
 // ── Postgres deletion JSON output (issue #614) ────────────────────────────
 
 /// `postgres delete --json` must emit the Postgres resource object, not the


### PR DESCRIPTION
Title: feat(postgres): expose server logs

Adds `cloud postgres logs <POSTGRES_ID>` for retrieving server logs over a required RFC 3339 time window. The command exposes body and severity filters, typed ascending/descending sort order, and optional limit/offset pagination while rejecting reversed or over-30-day ranges and schema-invalid bounds before making a request.

The read-only command supports OAuth, sends every input as an exact GET query parameter through a `CloudClient` wrapper with organization-aware errors, preserves the complete log array in JSON, and renders sparse human results safely.

Validation:
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl` (all passed except known local-process flake `a_refused_stdout_write_is_an_io_failure_of_the_response_stream`; exact rerun passed)
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- focused Postgres logs unit tests: 7 passed
- focused Postgres logs wiremock tests: 3 passed

Closes #582.
