### PR TITLE
feat(service): discover available profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,10 @@ clickhousectl cloud service list
 # Get service details
 clickhousectl cloud service get <service-id>
 
+# Discover profiles available in a region before choosing --profile
+clickhousectl cloud service profile list --region us-east-1
+clickhousectl cloud service profile list --region us-east-1 --byoc-id <infrastructure-id> --json
+
 # Create a service with explicit placement and network access
 # Omitting --ip-allow creates the service with an "Allow all" 0.0.0.0/0 access list
 clickhousectl cloud service create --name my-service \

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -20,9 +20,9 @@ use clickhouse_cloud_api::models::{
     ServiceEndpointChangeProtocol, ServiceEndpointProtocol, ServicePasswordPatchRequest,
     ServicePatchRequest, ServicePatchRequestReleasechannel, ServicePostRequest,
     ServicePostRequestCompliancetype, ServicePostRequestProfile, ServicePostRequestProvider,
-    ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceQueryAPIEndpoint,
-    ServiceReplicaScalingPatchRequest, ServiceState, ServiceStatePatchRequest,
-    ServiceStatePatchRequestCommand,
+    ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceProfile,
+    ServiceQueryAPIEndpoint, ServiceReplicaScalingPatchRequest, ServiceState,
+    ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
 };
 #[cfg(test)]
 use clickhouse_cloud_api::models::{IpAccessListEntryResponse, ResourceTagsV1Response};
@@ -69,6 +69,12 @@ pub enum ServiceCommands {
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
         org_id: Option<String>,
+    },
+
+    /// Discover available service profiles
+    Profile {
+        #[command(subcommand)]
+        command: ServiceProfileCommands,
     },
 
     /// Create a service
@@ -624,11 +630,38 @@ pub enum PrivateEndpointCommands {
     },
 }
 
+#[derive(Subcommand)]
+pub enum ServiceProfileCommands {
+    /// List available service profiles
+    List {
+        /// Region ID, e.g. us-east-1, eu-west-1, us-central1
+        #[arg(long)]
+        region: String,
+
+        /// BYOC infrastructure ID
+        #[arg(long)]
+        byoc_id: Option<String>,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl ServiceProfileCommands {
+    fn is_write(&self) -> bool {
+        match self {
+            ServiceProfileCommands::List { .. } => false,
+        }
+    }
+}
+
 impl ServiceCommands {
     pub fn is_write(&self) -> bool {
         match self {
             ServiceCommands::List { .. } => false,
             ServiceCommands::Get { .. } => false,
+            ServiceCommands::Profile { command } => command.is_write(),
             ServiceCommands::Prometheus { .. } => false,
             ServiceCommands::Query { .. } => false,
             ServiceCommands::RepairQueryKey { .. } => true,
@@ -662,6 +695,16 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
         ServiceCommands::Get { service_id, org_id } => {
             service_get(client, &service_id, org_id.as_deref(), json).await
         }
+        ServiceCommands::Profile { command } => match command {
+            ServiceProfileCommands::List {
+                region,
+                byoc_id,
+                org_id,
+            } => {
+                service_profile_list(client, &region, byoc_id.as_deref(), org_id.as_deref(), json)
+                    .await
+            }
+        },
         ServiceCommands::Create {
             name,
             provider,
@@ -1156,6 +1199,47 @@ async fn service_get(
         println!("{}", serde_json::to_string_pretty(&service)?);
     } else {
         print_human(&service)?;
+    }
+    Ok(())
+}
+
+async fn service_profile_list(
+    client: &CloudClient,
+    region_id: &str,
+    byoc_id: Option<&str>,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let profiles = client
+        .list_service_profiles(&org_id, region_id, byoc_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&profiles)?);
+    } else {
+        if profiles.is_empty() {
+            println!("No service profiles found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Profile")]
+            profile: String,
+            #[tabled(rename = "CPU cores")]
+            cpu_cores: String,
+            #[tabled(rename = "Memory GiB")]
+            memory_gi: String,
+        }
+        let rows: Vec<Row> = profiles
+            .into_iter()
+            .map(|profile| Row {
+                profile: or_absent(profile.profile),
+                cpu_cores: or_absent(profile.cpu_cores),
+                memory_gi: or_absent(profile.memory_gi),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
     }
     Ok(())
 }
@@ -3078,6 +3162,20 @@ async fn service_prometheus(
 }
 
 impl CloudClient {
+    pub async fn list_service_profiles(
+        &self,
+        org_id: &str,
+        region_id: &str,
+        byoc_id: Option<&str>,
+    ) -> crate::cloud::client::Result<Vec<ServiceProfile>> {
+        let response = self
+            .api()
+            .service_profiles_list(org_id, region_id, byoc_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
     pub async fn list_services(&self, org_id: &str) -> crate::cloud::client::Result<Vec<Service>> {
         let response = self
             .api()
@@ -3607,6 +3705,45 @@ mod tests {
         };
         assert_eq!(org_id.as_deref(), Some("org-1"));
         assert_eq!(filter, vec!["tag:env=prod", "tag:team=analytics"]);
+    }
+
+    #[test]
+    fn parses_service_profile_list_flags_and_requires_region() {
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "profile",
+            "list",
+            "--region",
+            "eu-west-1",
+            "--byoc-id",
+            "byoc-1",
+            "--org-id",
+            "org-1",
+        ]);
+        let ServiceCommands::Profile {
+            command:
+                ServiceProfileCommands::List {
+                    region,
+                    byoc_id,
+                    org_id,
+                },
+        } = command
+        else {
+            panic!("expected service profile list");
+        };
+        assert_eq!(region, "eu-west-1");
+        assert_eq!(byoc_id.as_deref(), Some("byoc-1"));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let error = Cli::try_parse_from(["clickhousectl", "cloud", "service", "profile", "list"])
+            .err()
+            .expect("missing --region should fail");
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]
@@ -4847,6 +4984,18 @@ mod tests {
         assert_write(&["clickhousectl", "cloud", "service", "list"], false);
         assert_write(
             &["clickhousectl", "cloud", "service", "get", "svc-1"],
+            false,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "profile",
+                "list",
+                "--region",
+                "us-east-1",
+            ],
             false,
         );
         assert_write(

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -22,6 +22,8 @@ use serde_json::Value;
 use wiremock::matchers::{body_json, header, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+const SERVICE_PROFILES_PATH: &str = "/v1/organizations/org-1/serviceProfiles";
+
 /// Locate the `clickhousectl` binary. cargo populates `CARGO_BIN_EXE_<name>`
 /// for integration tests in the same package — so this is just the absolute
 /// path to the build output, no `cargo build` shellout needed.
@@ -17405,4 +17407,197 @@ async fn clickstack_alert_and_webhook_writes_fail_fast_for_oauth() {
         assert!(String::from_utf8_lossy(&output.stderr).contains("read-only"));
     }
     assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn service_profile_list_sends_exact_queries_and_preserves_json() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!([
+        { "profile": "v1-standard-byoc-4", "cpuCores": 4.0, "memoryGi": 16.0 },
+        { "profile": "future-profile", "cpuCores": 12.5, "memoryGi": 48.5 }
+    ]);
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .and(query_param("region_id", "us-east-1"))
+        .and(query_param("byoc_id", "byoc-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-service-profiles"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "profile",
+            "list",
+            "--region",
+            "us-east-1",
+            "--byoc-id",
+            "byoc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let query: Vec<_> = requests[0].url.query_pairs().collect();
+    assert_eq!(query.len(), 2);
+    assert!(
+        query
+            .iter()
+            .any(|(key, value)| key == "region_id" && value == "us-east-1")
+    );
+    assert!(
+        query
+            .iter()
+            .any(|(key, value)| key == "byoc_id" && value == "byoc-1")
+    );
+    assert!(
+        requests[0]
+            .headers
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("Basic ")
+    );
+}
+
+#[tokio::test]
+async fn service_profile_list_omits_byoc_and_accepts_empty_oauth_result() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .and(query_param("region_id", "eu-west-1"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [],
+            "status": 200,
+            "requestId": "stub-empty-service-profiles"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "service",
+            "profile",
+            "list",
+            "--region",
+            "eu-west-1",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!([])
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let query: Vec<_> = requests[0].url.query_pairs().collect();
+    assert_eq!(query, vec![("region_id".into(), "eu-west-1".into())]);
+}
+
+#[tokio::test]
+async fn service_profile_list_renders_sparse_unknown_profiles() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [
+                { "profile": "future-profile", "memoryGi": 48.5 },
+                { "cpuCores": 8.0, "memoryGi": null }
+            ],
+            "status": 200,
+            "requestId": "stub-sparse-service-profiles"
+        })))
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "service",
+            "profile",
+            "list",
+            "--region",
+            "us-east-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("| Profile        | CPU cores | Memory GiB |"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("| future-profile | -         | 48.5       |"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("| -              | 8         | -          |"),
+        "{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn service_profile_list_routes_auth_errors() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "status": 401,
+            "error": "Unauthorized",
+            "requestId": "stub-profile-auth"
+        })))
+        .mount(&mock)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "profile",
+            "list",
+            "--region",
+            "us-east-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Unauthorized\n"
+    );
 }


### PR DESCRIPTION
## Title

feat(service): discover available service profiles

## Body

`cloud service create --profile` requires a profile name, but the CLI could not discover the profiles available to an organization in a specific region. Add `cloud service profile list --region <region>` with optional `--byoc-id`, organization auto-resolution, API key and OAuth support, complete JSON output, and a sparse-safe human table showing profile, CPU cores, and memory GiB.

The request sends `region_id` and omits `byoc_id` unless supplied. Returned profile names remain open strings so new and BYOC-specific names are preserved. Service creation changes remain scoped to #578.

Validation:

- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl` (all suites passed except the known local broken-pipe telemetry flake; its exact isolated rerun passed)
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- focused profile clap and wiremock tests

Closes #696
