### PR TITLE
feat(postgres): expose Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,10 @@ clickhousectl cloud postgres logs <pg-id> \
   --severity ERROR --body-contains "connection refused" \
   --sort-order asc --limit 200 --offset 0
 
+# Raw Prometheus scrape text for one service or the whole organization
+clickhousectl cloud postgres prometheus service <pg-id>
+clickhousectl cloud postgres prometheus org
+
 # Create
 clickhousectl cloud postgres create \
   --name my-pg \
@@ -1041,6 +1045,8 @@ Use `clickhousectl cloud postgres create --help` for the complete option list. S
 `postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
 
 `postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
+
+`postgres prometheus service` and `postgres prometheus org` return the beta API's raw Prometheus exposition text for scraping. In `--json` mode, including automatic coding-agent mode, the complete text is emitted as one JSON string; it is not parsed into metric series. These endpoints have no filtered-metrics query parameter. Use `postgres metrics` when you need time-bucketed metric objects over a chosen date range.
 
 `postgres list --filter KEY=VALUE` is applied client-side to the listing and is repeatable; every filter must match. Supported keys are `state`, `region`, `name`, `provider` and `isPrimary` (the `Primary` column; `true`/`false`, or the `yes`/`no` the column shows). Keys are case-insensitive, `state` and `provider` match the wire value case-insensitively, and `region`/`name` match exactly. An unknown key, a missing `=` or an empty value is a usage error (exit 2) listing the valid keys — it never returns an unfiltered list. A field the API omitted matches no filter value, so filtering on it excludes that service. This is unrelated to `cloud service list --filter`, which sends server-side resource-tag filters (`tag:env=production`) to the API.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -214,6 +214,16 @@ CONTEXT FOR AGENTS:
         org_id: Option<String>,
     },
 
+    /// Get raw Postgres Prometheus metrics
+    #[command(
+        subcommand,
+        after_help = "\
+CONTEXT FOR AGENTS:
+  Human output is raw Prometheus exposition text.
+  --json, including automatic coding-agent mode, returns that text as a JSON string."
+    )]
+    Prometheus(PrometheusCommands),
+
     /// Restore a Postgres service to a point in time
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -385,13 +395,32 @@ CONTEXT FOR AGENTS:
     },
 }
 
+#[derive(Subcommand)]
+pub enum PrometheusCommands {
+    /// Get metrics for one Postgres service
+    Service {
+        /// Postgres service ID (from `cloud postgres list`)
+        postgres_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get metrics for all Postgres services in an organization
+    Org {
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
 impl PostgresCommands {
     pub fn is_write(&self) -> bool {
         match self {
             PostgresCommands::List { .. }
             | PostgresCommands::Get { .. }
             | PostgresCommands::Metrics { .. }
-            | PostgresCommands::Logs { .. } => false,
+            | PostgresCommands::Logs { .. }
+            | PostgresCommands::Prometheus(_) => false,
             PostgresCommands::Certs(CertsCommands::Get { .. }) => false,
             PostgresCommands::Config(ConfigCommands::Get { .. }) => false,
 
@@ -581,6 +610,13 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
                 json,
             )
             .await
+        }
+        PostgresCommands::Prometheus(PrometheusCommands::Service {
+            postgres_id,
+            org_id,
+        }) => postgres_prometheus_service(client, &postgres_id, org_id.as_deref(), json).await,
+        PostgresCommands::Prometheus(PrometheusCommands::Org { org_id }) => {
+            postgres_prometheus_org(client, org_id.as_deref(), json).await
         }
         PostgresCommands::Restore {
             postgres_id,
@@ -1856,11 +1892,62 @@ pub async fn postgres_metrics(
     Ok(())
 }
 
+fn print_prometheus(metrics: &str, json: bool) -> CloudResult<()> {
+    if json {
+        print_line(serde_json::to_string_pretty(metrics)?);
+    } else {
+        use std::io::Write;
+        std::io::stdout().lock().write_all(metrics.as_bytes())?;
+    }
+    Ok(())
+}
+
+async fn postgres_prometheus_service(
+    client: &CloudClient,
+    postgres_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let metrics = client.get_postgres_prometheus(&org_id, postgres_id).await?;
+    print_prometheus(&metrics, json)
+}
+
+async fn postgres_prometheus_org(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let metrics = client.get_postgres_org_prometheus(&org_id).await?;
+    print_prometheus(&metrics, json)
+}
+
 // ---------------------------------------------------------------------------
 // Role changes: promote / switchover (issue #604)
 // ---------------------------------------------------------------------------
 
 impl CloudClient {
+    /// Fetch raw Prometheus exposition text for a Postgres service.
+    pub async fn get_postgres_prometheus(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+    ) -> CloudResult<String> {
+        self.api()
+            .postgres_instance_prometheus_get(org_id, postgres_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))
+    }
+
+    /// Fetch raw Prometheus exposition text for all Postgres services in an organization.
+    pub async fn get_postgres_org_prometheus(&self, org_id: &str) -> CloudResult<String> {
+        self.api()
+            .postgres_org_prometheus_get(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))
+    }
+
     /// Fetch time-bucketed metrics for a Postgres service.
     pub async fn get_postgres_metrics(
         &self,
@@ -3185,6 +3272,62 @@ mod tests {
             error.to_string(),
             "invalid date range: --from-date must not be after --to-date"
         );
+    }
+
+    #[test]
+    fn parses_postgres_prometheus_service_and_org_scopes_as_reads() {
+        let service = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "prometheus",
+            "service",
+            "pg-1",
+            "--org-id",
+            "org-1",
+        ]);
+        assert!(!service.is_write());
+        let PostgresCommands::Prometheus(PrometheusCommands::Service {
+            postgres_id,
+            org_id,
+        }) = service
+        else {
+            panic!("expected service prometheus");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let org = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "prometheus",
+            "org",
+            "--org-id",
+            "org-2",
+        ]);
+        assert!(!org.is_write());
+        let PostgresCommands::Prometheus(PrometheusCommands::Org { org_id }) = org else {
+            panic!("expected organization prometheus");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-2"));
+    }
+
+    #[test]
+    fn postgres_prometheus_does_not_advertise_unsupported_filters() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "prometheus",
+            "service",
+            "pg-1",
+            "--filtered-metrics",
+            "false",
+        ])
+        .err()
+        .expect("expected parse error");
+        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1904,6 +1904,137 @@ async fn postgres_logs_reports_empty_results_and_structured_api_errors() {
     }
 }
 
+// ── Postgres Prometheus metrics (issue #584) ──────────────────────────────
+
+#[tokio::test]
+async fn postgres_prometheus_service_uses_oauth_and_returns_a_json_string() {
+    let mock = MockServer::start().await;
+    let metrics = "# HELP pg_up Whether Postgres is available.\n# TYPE pg_up gauge\npg_up 1\n";
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/prometheus"))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/plain; charset=UTF-8")
+                .set_body_string(metrics),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "postgres",
+            "prometheus",
+            "service",
+            "pg-1",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<String>(&output.stdout).unwrap(),
+        metrics
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].url.query(), None);
+}
+
+#[tokio::test]
+async fn postgres_prometheus_org_preserves_raw_text_and_agent_mode_is_json() {
+    let mock = MockServer::start().await;
+    let metrics = "# TYPE pg_connections gauge\npg_connections{service=\"pg-1\"} 4\n";
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/prometheus"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/plain; charset=UTF-8")
+                .set_body_string(metrics),
+        )
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let args = ["postgres", "prometheus", "org", "--org-id", "org-1"];
+    let human = invoke_cli_with_cloud_credentials_human(&mock, &args);
+    assert_success(&human);
+    assert_eq!(human.stdout, metrics.as_bytes());
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let agent = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("AI_AGENT", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args(["cloud", "--url", &mock.uri()])
+        .args(args)
+        .output()
+        .unwrap();
+    assert_success(&agent);
+    assert_eq!(
+        serde_json::from_slice::<String>(&agent.stdout).unwrap(),
+        metrics
+    );
+
+    for request in mock.received_requests().await.unwrap() {
+        assert_eq!(request.url.query(), None);
+    }
+}
+
+#[tokio::test]
+async fn postgres_prometheus_converts_api_errors() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/prometheus"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "status": 403,
+            "error": "Forbidden",
+            "requestId": "stub-postgres-prometheus-error"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "postgres",
+            "prometheus",
+            "service",
+            "pg-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Forbidden\n"
+    );
+}
+
 // ── Postgres deletion JSON output (issue #614) ────────────────────────────
 
 /// `postgres delete --json` must emit the Postgres resource object, not the


### PR DESCRIPTION
## Summary

Postgres Prometheus endpoints were available in the Cloud API client but unreachable from `clickhousectl`. This adds explicit `cloud postgres prometheus service <ID>` and `cloud postgres prometheus org` read commands, both compatible with OAuth.

Human output preserves the raw Prometheus exposition body byte for byte. `--json` and automatic coding-agent mode emit the complete body as a JSON string, so machine output stays valid JSON without pretending the text is a structured metric-series response. The endpoints expose no query parameters in the current schema, so the commands send none and do not accept the ClickHouse-specific `--filtered-metrics` flag.

The handlers use domain `CloudClient` wrappers with organization-aware error conversion. README documentation distinguishes scrape text from the existing time-bucketed `postgres metrics` command.

Closes #584.

## Validation

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl`

