### PR TITLE
feat(cloud): manage BYOC infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,16 @@ clickhousectl cloud org update <org-id> --name "Renamed Org"
 clickhousectl cloud org update <org-id> \
   --remove-private-endpoint pe-1,cloud-provider=aws,region=us-east-1 \
   --enable-core-dumps false
+# Create BYOC infrastructure (repeat --availability-zone-suffix as needed)
+clickhousectl cloud org byoc create --org-id <org-id> \
+  --region us-east-1 --account-id <aws-account-id> \
+  --availability-zone-suffix a --availability-zone-suffix b \
+  --vpc-cidr-range 10.0.0.0/16 --display-name production
+# Find the infrastructure ID and state in the organization's byocConfig
+clickhousectl cloud org get <org-id>
+clickhousectl cloud org byoc update <infrastructure-id> \
+  --display-name renamed --org-id <org-id>
+clickhousectl cloud org byoc delete <infrastructure-id> --org-id <org-id>
 clickhousectl cloud org prometheus --filtered-metrics true
 clickhousectl cloud org prometheus discovery --filtered-metrics false
 clickhousectl cloud org usage \
@@ -659,6 +669,10 @@ clickhousectl cloud org usage \
 # It is auto-detected only when your credentials reach exactly one organization.
 # Organization quota and balance commands are beta and read-only, so they support OAuth.
 ```
+
+BYOC create, update, and delete require API key authentication. Update requires
+`--display-name`, so it cannot send an empty/no-op patch. The API has no separate
+BYOC list command; `cloud org get` returns the organization's `byocConfig` entries.
 
 `cloud org prometheus discovery` returns the beta HTTP service-discovery target groups used by Prometheus `http_sd_configs`; `--json` preserves the complete target and label array. The command defaults discovered scrape targets to filtered metrics. The command without `discovery` still calls the deprecated organization metrics endpoint and emits raw Prometheus exposition text for compatibility.
 
@@ -674,6 +688,13 @@ clickhousectl cloud service get <service-id>
 # Discover profiles available in a region before choosing --profile
 clickhousectl cloud service profile list --region us-east-1
 clickhousectl cloud service profile list --region us-east-1 --byoc-id <infrastructure-id> --json
+
+# Create a BYOC service using the discovered profile and its exact memory size
+clickhousectl cloud service create --name my-byoc-service \
+  --provider aws --region us-east-1 --byoc-id <infrastructure-id> \
+  --profile v1-standard-byoc-4 \
+  --min-replica-memory-gb <profile-memory-gib> \
+  --max-replica-memory-gb <profile-memory-gib>
 
 # Create a service with explicit placement and network access
 # Omitting --ip-allow creates the service with an "Allow all" 0.0.0.0/0 access list

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -87,6 +87,8 @@ impl CloudArgs {
     }
 }
 
+// Resource command groups naturally differ in size; clap owns their concrete layout.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum CloudCommands {
     /// Manage user-defined functions (Beta)
@@ -108,6 +110,7 @@ pub enum CloudCommands {
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   `org list` is the source of the org IDs that other cloud commands take as --org-id.
+  BYOC infrastructure IDs and state are shown by `cloud org get <org-id>`.
   Next: `cloud service list`, `cloud member list`.")]
     Org {
         #[command(subcommand)]

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -4,9 +4,11 @@ use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
-    InvitationPostRequest, MemberPatchRequest, OrganizationPatchPrivateEndpoint,
-    OrganizationPatchPrivateEndpointCloudprovider, OrganizationPatchPrivateEndpointRegion,
-    OrganizationPatchRequest, OrganizationPrivateEndpointsPatch,
+    ByocAvailabilityZoneSuffix, ByocInfrastructurePatchRequest, ByocInfrastructurePostRequest,
+    ByocInfrastructurePostRequestRegionid, InvitationPostRequest, MemberPatchRequest,
+    OrganizationPatchPrivateEndpoint, OrganizationPatchPrivateEndpointCloudprovider,
+    OrganizationPatchPrivateEndpointRegion, OrganizationPatchRequest,
+    OrganizationPrivateEndpointsPatch,
 };
 use tabled::{Table, Tabled, settings::Style};
 
@@ -32,6 +34,12 @@ pub enum OrgCommands {
         /// Organization ID (auto-detected only if you have one org)
         #[arg(long)]
         org_id: Option<String>,
+    },
+
+    /// Manage BYOC infrastructure
+    Byoc {
+        #[command(subcommand)]
+        command: ByocCommands,
     },
 
     /// Update organization settings
@@ -117,9 +125,78 @@ impl OrgCommands {
             OrgCommands::Get { .. } => false,
             OrgCommands::Quota { .. } => false,
             OrgCommands::Balance { .. } => false,
+            OrgCommands::Byoc { command } => command.is_write(),
             OrgCommands::Prometheus { .. } => false,
             OrgCommands::Usage { .. } => false,
             OrgCommands::Update { .. } => true,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum ByocCommands {
+    /// Create BYOC infrastructure
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Wait for `cloud org get <org-id>` to show state `infra-ready` before creating a service.
+  Discover profiles with `cloud service profile list --region <region> --byoc-id <id>`.")]
+    Create {
+        /// Cloud region ID
+        #[arg(long)]
+        region: String,
+
+        /// Cloud account ID
+        #[arg(long)]
+        account_id: String,
+
+        /// Availability-zone suffix (repeatable)
+        #[arg(long, required = true)]
+        availability_zone_suffix: Vec<String>,
+
+        /// VPC CIDR range
+        #[arg(long)]
+        vpc_cidr_range: String,
+
+        /// Human-readable infrastructure name
+        #[arg(long)]
+        display_name: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Update BYOC infrastructure
+    Update {
+        /// BYOC infrastructure ID
+        byoc_id: String,
+
+        /// New human-readable infrastructure name
+        #[arg(long)]
+        display_name: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete BYOC infrastructure
+    Delete {
+        /// BYOC infrastructure ID
+        byoc_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl ByocCommands {
+    fn is_write(&self) -> bool {
+        match self {
+            ByocCommands::Create { .. } => true,
+            ByocCommands::Update { .. } => true,
+            ByocCommands::Delete { .. } => true,
         }
     }
 }
@@ -271,6 +348,7 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
         OrgCommands::Quota { command } => run_quota(client, command, json).await,
         OrgCommands::Balance { org_id } => org_balance(client, org_id.as_deref(), json).await,
+        OrgCommands::Byoc { command } => run_byoc(client, command, json).await,
         OrgCommands::Update {
             org_id,
             name,
@@ -307,6 +385,39 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         } => {
             let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
             org_usage(client, org_id, &from_date, &to_date, &filter, json).await
+        }
+    }
+}
+
+async fn run_byoc(client: &CloudClient, command: ByocCommands, json: bool) -> CloudResult<()> {
+    match command {
+        ByocCommands::Create {
+            region,
+            account_id,
+            availability_zone_suffix,
+            vpc_cidr_range,
+            display_name,
+            org_id,
+        } => {
+            let request = build_byoc_create_request(
+                &region,
+                &account_id,
+                &availability_zone_suffix,
+                &vpc_cidr_range,
+                &display_name,
+            )?;
+            byoc_create(client, request, org_id.as_deref(), json).await
+        }
+        ByocCommands::Update {
+            byoc_id,
+            display_name,
+            org_id,
+        } => {
+            let request = build_byoc_update_request(&display_name);
+            byoc_update(client, &byoc_id, request, org_id.as_deref(), json).await
+        }
+        ByocCommands::Delete { byoc_id, org_id } => {
+            byoc_delete(client, &byoc_id, org_id.as_deref(), json).await
         }
     }
 }
@@ -470,6 +581,64 @@ fn build_org_update_request(options: &OrgUpdateOptions) -> CloudResult<Organizat
         private_endpoints: parse_org_private_endpoints_patch(&options.remove_private_endpoints)?,
         enable_core_dumps: options.enable_core_dumps,
     })
+}
+
+fn parse_byoc_region(value: &str) -> CloudResult<ByocInfrastructurePostRequestRegionid> {
+    let region = serde_json::from_value::<ByocInfrastructurePostRequestRegionid>(
+        serde_json::Value::String(value.to_string()),
+    )
+    .map_err(|error| CloudError::new(format!("invalid region: {error}")))?;
+    if matches!(region, ByocInfrastructurePostRequestRegionid::Unknown(_)) {
+        return Err(CloudError::new(format!(
+            "invalid region: unsupported BYOC region '{value}'"
+        )));
+    }
+    Ok(region)
+}
+
+fn parse_byoc_availability_zone_suffix(value: &str) -> CloudResult<ByocAvailabilityZoneSuffix> {
+    let suffix = serde_json::from_value::<ByocAvailabilityZoneSuffix>(serde_json::Value::String(
+        value.to_string(),
+    ))
+    .map_err(|error| CloudError::new(format!("invalid availability zone suffix: {error}")))?;
+    if matches!(suffix, ByocAvailabilityZoneSuffix::Unknown(_)) {
+        return Err(CloudError::new(format!(
+            "invalid availability zone suffix '{value}'"
+        )));
+    }
+    Ok(suffix)
+}
+
+fn build_byoc_create_request(
+    region: &str,
+    account_id: &str,
+    availability_zone_suffixes: &[String],
+    vpc_cidr_range: &str,
+    display_name: &str,
+) -> CloudResult<ByocInfrastructurePostRequest> {
+    let availability_zone_suffixes = availability_zone_suffixes
+        .iter()
+        .map(|suffix| parse_byoc_availability_zone_suffix(suffix))
+        .collect::<CloudResult<Vec<_>>>()?;
+    if availability_zone_suffixes.is_empty() {
+        return Err(CloudError::new(
+            "at least one --availability-zone-suffix is required",
+        ));
+    }
+
+    Ok(ByocInfrastructurePostRequest {
+        account_id: account_id.to_string(),
+        availability_zone_suffixes,
+        display_name: display_name.to_string(),
+        region_id: parse_byoc_region(region)?,
+        vpc_cidr_range: vpc_cidr_range.to_string(),
+    })
+}
+
+fn build_byoc_update_request(display_name: &str) -> ByocInfrastructurePatchRequest {
+    ByocInfrastructurePatchRequest {
+        display_name: Some(display_name.to_string()),
+    }
 }
 
 fn build_member_update_request(role_ids: &[String], clear_roles: bool) -> MemberPatchRequest {
@@ -669,6 +838,59 @@ async fn org_update(
             or_absent(organization.name.as_deref()),
             or_absent(organization.id)
         );
+    }
+    Ok(())
+}
+
+async fn byoc_create(
+    client: &CloudClient,
+    request: ByocInfrastructurePostRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let infrastructure = client.create_byoc_infrastructure(&org_id, &request).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&infrastructure)?);
+    } else {
+        print_human(&infrastructure)?;
+    }
+    Ok(())
+}
+
+async fn byoc_update(
+    client: &CloudClient,
+    byoc_id: &str,
+    request: ByocInfrastructurePatchRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let infrastructure = client
+        .update_byoc_infrastructure(&org_id, byoc_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&infrastructure)?);
+    } else {
+        print_human(&infrastructure)?;
+    }
+    Ok(())
+}
+
+async fn byoc_delete(
+    client: &CloudClient,
+    byoc_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_byoc_infrastructure(&org_id, byoc_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("BYOC infrastructure {byoc_id} deleted");
     }
     Ok(())
 }
@@ -1020,6 +1242,49 @@ impl CloudClient {
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
+    }
+
+    pub async fn create_byoc_infrastructure(
+        &self,
+        org_id: &str,
+        request: &ByocInfrastructurePostRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ByocConfig> {
+        let response = self
+            .api()
+            .organization_byoc_infrastructure_create(org_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_byoc_infrastructure(
+        &self,
+        org_id: &str,
+        byoc_id: &str,
+        request: &ByocInfrastructurePatchRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ByocConfig> {
+        let response = self
+            .api()
+            .organization_byoc_infrastructure_update(org_id, byoc_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_byoc_infrastructure(
+        &self,
+        org_id: &str,
+        byoc_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .organization_byoc_infrastructure_delete(org_id, byoc_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
     }
 
     pub async fn get_org_prometheus(
@@ -1945,5 +2210,194 @@ mod tests {
                 "unexpected error for {value:?}: {error}"
             );
         }
+    }
+
+    #[test]
+    fn parses_byoc_create_update_and_delete_commands() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "byoc",
+            "create",
+            "--region",
+            "us-east-1",
+            "--account-id",
+            "123456789012",
+            "--availability-zone-suffix",
+            "a",
+            "--availability-zone-suffix",
+            "b",
+            "--vpc-cidr-range",
+            "10.0.0.0/16",
+            "--display-name",
+            "production",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Byoc {
+            command:
+                ByocCommands::Create {
+                    region,
+                    account_id,
+                    availability_zone_suffix,
+                    vpc_cidr_range,
+                    display_name,
+                    org_id,
+                },
+        } = command
+        else {
+            panic!("expected BYOC create");
+        };
+        assert_eq!(region, "us-east-1");
+        assert_eq!(account_id, "123456789012");
+        assert_eq!(availability_zone_suffix, vec!["a", "b"]);
+        assert_eq!(vpc_cidr_range, "10.0.0.0/16");
+        assert_eq!(display_name, "production");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "byoc",
+            "update",
+            "byoc-1",
+            "--display-name",
+            "renamed",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Byoc {
+            command:
+                ByocCommands::Update {
+                    byoc_id,
+                    display_name,
+                    org_id,
+                },
+        } = command
+        else {
+            panic!("expected BYOC update");
+        };
+        assert_eq!(byoc_id, "byoc-1");
+        assert_eq!(display_name, "renamed");
+        assert!(org_id.is_none());
+
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "org",
+                "byoc",
+                "delete",
+                "byoc-1",
+                "--org-id",
+                "org-1",
+            ],
+            true,
+        );
+    }
+
+    #[test]
+    fn byoc_create_requires_an_availability_zone_suffix() {
+        let result = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "byoc",
+            "create",
+            "--region",
+            "us-east-1",
+            "--account-id",
+            "123456789012",
+            "--vpc-cidr-range",
+            "10.0.0.0/16",
+            "--display-name",
+            "production",
+        ]);
+        let Err(error) = result else {
+            panic!("missing availability zone suffix must fail");
+        };
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn build_byoc_create_request_supports_minimal_and_maximal_zones() {
+        let minimal = build_byoc_create_request(
+            "us-east-1",
+            "123456789012",
+            &["a".to_string()],
+            "10.0.0.0/16",
+            "production",
+        )
+        .unwrap();
+        assert_eq!(
+            minimal.region_id,
+            ByocInfrastructurePostRequestRegionid::Us_east_1
+        );
+        assert_eq!(minimal.account_id, "123456789012");
+        assert_eq!(
+            minimal.availability_zone_suffixes,
+            vec![ByocAvailabilityZoneSuffix::A]
+        );
+        assert_eq!(minimal.vpc_cidr_range, "10.0.0.0/16");
+        assert_eq!(minimal.display_name, "production");
+
+        let maximal = build_byoc_create_request(
+            "eastus",
+            "azure-account",
+            &[
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+                "d".to_string(),
+                "e".to_string(),
+                "f".to_string(),
+            ],
+            "10.20.0.0/16",
+            "all-zones",
+        )
+        .unwrap();
+        assert_eq!(
+            maximal.region_id,
+            ByocInfrastructurePostRequestRegionid::Eastus
+        );
+        assert_eq!(maximal.availability_zone_suffixes.len(), 6);
+    }
+
+    #[test]
+    fn build_byoc_requests_validate_enums_and_update_only_the_name() {
+        assert!(
+            build_byoc_create_request(
+                "future-region",
+                "account",
+                &["a".to_string()],
+                "10.0.0.0/16",
+                "name",
+            )
+            .is_err()
+        );
+        assert!(
+            build_byoc_create_request(
+                "us-east-1",
+                "account",
+                &["z".to_string()],
+                "10.0.0.0/16",
+                "name",
+            )
+            .is_err()
+        );
+
+        let update = build_byoc_update_request("renamed");
+        assert_eq!(update.display_name.as_deref(), Some("renamed"));
+        assert_eq!(
+            serde_json::to_value(update).unwrap(),
+            serde_json::json!({"displayName": "renamed"})
+        );
     }
 }

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -191,6 +191,10 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         profile: Option<String>,
 
+        /// BYOC infrastructure ID
+        #[arg(long)]
+        byoc_id: Option<String>,
+
         /// Tag to attach to the service. Format: key or key=value (repeatable)
         #[arg(long = "tag", value_name = "KEY[=VALUE]")]
         tag: Vec<String>,
@@ -727,6 +731,7 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
             enable_tde,
             compliance_type,
             profile,
+            byoc_id,
             tag,
             enable_endpoint,
             disable_endpoint,
@@ -756,6 +761,7 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
                 enable_tde,
                 compliance_type,
                 profile,
+                byoc_id,
                 tags: tag,
                 enable_endpoints: enable_endpoint,
                 disable_endpoints: disable_endpoint,
@@ -1267,6 +1273,7 @@ struct CreateServiceOptions {
     enable_tde: bool,
     compliance_type: Option<String>,
     profile: Option<String>,
+    byoc_id: Option<String>,
     tags: Vec<String>,
     enable_endpoints: Vec<String>,
     disable_endpoints: Vec<String>,
@@ -1352,6 +1359,30 @@ fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<S
         options.max_replicas,
     )?;
 
+    if options.byoc_id.as_deref().is_some_and(str::is_empty) {
+        return Err(CloudError::new("--byoc-id cannot be empty"));
+    }
+    if options.byoc_id.is_some()
+        && (options.min_replica_memory_gb.is_none() || options.max_replica_memory_gb.is_none())
+    {
+        return Err(CloudError::new(
+            "--byoc-id requires --min-replica-memory-gb and --max-replica-memory-gb",
+        ));
+    }
+
+    let profile = options
+        .profile
+        .as_deref()
+        .map(|value| parse_create_service_profile(value, options.byoc_id.as_deref()))
+        .transpose()?;
+    if matches!(profile, Some(ServicePostRequestProfile::Unknown(_)))
+        && options.min_replica_memory_gb != options.max_replica_memory_gb
+    {
+        return Err(CloudError::new(
+            "a dynamic BYOC --profile requires equal --min-replica-memory-gb and --max-replica-memory-gb",
+        ));
+    }
+
     Ok(ServicePostRequest {
         name: options.name.clone(),
         provider: parse_serde_enum::<ServicePostRequestProvider>(
@@ -1402,14 +1433,7 @@ fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<S
             )?),
             None => None,
         },
-        profile: match options.profile.as_deref() {
-            Some(value) => Some(parse_serde_enum::<ServicePostRequestProfile>(
-                value,
-                "profile",
-                ServicePostRequestProfile::VALUES,
-            )?),
-            None => None,
-        },
+        profile,
         private_preview_terms_checked: if options.private_preview_terms_checked {
             Some(true)
         } else {
@@ -1421,7 +1445,7 @@ fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<S
         )?,
         enable_core_dumps: options.enable_core_dumps,
         autoscaling_mode: horizontal.autoscaling_mode,
-        byoc_id: None,
+        byoc_id: options.byoc_id.clone(),
         min_replicas: horizontal.min_replicas,
         max_replicas: horizontal.max_replicas,
         #[cfg(feature = "deprecated-fields")]
@@ -1433,6 +1457,29 @@ fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<S
         #[cfg(feature = "deprecated-fields")]
         tier: None,
     })
+}
+
+fn parse_create_service_profile(
+    value: &str,
+    byoc_id: Option<&str>,
+) -> CloudResult<ServicePostRequestProfile> {
+    if ServicePostRequestProfile::VALUES.contains(&value) {
+        return parse_serde_enum::<ServicePostRequestProfile>(
+            value,
+            "profile",
+            ServicePostRequestProfile::VALUES,
+        );
+    }
+    if byoc_id.is_none() {
+        return Err(CloudError::new(format!(
+            "invalid profile: unknown standard profile '{value}'; dynamic profiles require --byoc-id"
+        )));
+    }
+    if value.is_empty() {
+        return Err(CloudError::new("--profile cannot be empty"));
+    }
+    serde_json::from_value(serde_json::Value::String(value.to_string()))
+        .map_err(|error| CloudError::new(format!("invalid profile: {error}")))
 }
 
 fn build_update_service_request(
@@ -1658,6 +1705,7 @@ async fn service_create(
 ) -> CloudResult<()> {
     let request = build_create_service_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
+    validate_dynamic_byoc_profile(client, &org_id, &request).await?;
     let response = client.create_service(&org_id, &request).await?;
 
     if json {
@@ -1678,6 +1726,50 @@ async fn service_create(
             println!();
             println!("{}", hint);
         }
+    }
+    Ok(())
+}
+
+async fn validate_dynamic_byoc_profile(
+    client: &CloudClient,
+    org_id: &str,
+    request: &ServicePostRequest,
+) -> CloudResult<()> {
+    let Some(ServicePostRequestProfile::Unknown(profile_name)) = request.profile.as_ref() else {
+        return Ok(());
+    };
+    let byoc_id = request
+        .byoc_id
+        .as_deref()
+        .ok_or_else(|| CloudError::new("dynamic profiles require --byoc-id"))?;
+    let region = request.region.to_string();
+    let profiles = client
+        .list_service_profiles(org_id, &region, Some(byoc_id))
+        .await?;
+    let profile = profiles
+        .iter()
+        .find(|candidate| candidate.profile.as_deref() == Some(profile_name.as_str()))
+        .ok_or_else(|| {
+            CloudError::new(format!(
+                "profile '{profile_name}' is not available for BYOC infrastructure '{byoc_id}' in region '{region}'"
+            ))
+        })?;
+    let memory_gi = profile.memory_gi.ok_or_else(|| {
+        CloudError::new(format!(
+            "profile '{profile_name}' did not include its memory size; cannot validate service memory bounds"
+        ))
+    })?;
+    let (Some(min_memory), Some(max_memory)) =
+        (request.min_replica_memory_gb, request.max_replica_memory_gb)
+    else {
+        return Err(CloudError::new(
+            "dynamic BYOC profiles require both replica memory bounds",
+        ));
+    };
+    if min_memory != memory_gi || max_memory != memory_gi {
+        return Err(CloudError::new(format!(
+            "profile '{profile_name}' requires both replica memory bounds to equal {memory_gi} GiB"
+        )));
     }
     Ok(())
 }
@@ -3518,6 +3610,7 @@ mod tests {
             enable_tde,
             compliance_type,
             profile,
+            byoc_id,
             tag,
             enable_endpoint,
             disable_endpoint,
@@ -3550,6 +3643,7 @@ mod tests {
         assert!(!enable_tde);
         assert!(compliance_type.is_none());
         assert!(profile.is_none());
+        assert!(byoc_id.is_none());
         assert!(tag.is_empty());
         assert!(enable_endpoint.is_empty());
         assert!(disable_endpoint.is_empty());
@@ -3603,6 +3697,8 @@ mod tests {
             "pci",
             "--profile",
             "v1-highmem-xs",
+            "--byoc-id",
+            "byoc-1",
             "--tag",
             "env=prod",
             "--tag",
@@ -3637,6 +3733,7 @@ mod tests {
             enable_tde,
             compliance_type,
             profile,
+            byoc_id,
             tag,
             enable_endpoint,
             disable_endpoint,
@@ -3671,12 +3768,47 @@ mod tests {
         assert!(enable_tde);
         assert_eq!(compliance_type.as_deref(), Some("pci"));
         assert_eq!(profile.as_deref(), Some("v1-highmem-xs"));
+        assert_eq!(byoc_id.as_deref(), Some("byoc-1"));
         assert_eq!(tag, vec!["env=prod", "team=analytics"]);
         assert_eq!(enable_endpoint, vec!["mysql"]);
         assert_eq!(disable_endpoint, vec!["mysql"]);
         assert!(private_preview_terms_checked);
         assert_eq!(enable_core_dumps, Some(false));
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_service_create_dynamic_byoc_profile_flags() {
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "create",
+            "--name",
+            "byoc-service",
+            "--profile",
+            "v1-standard-byoc-4",
+            "--byoc-id",
+            "byoc-1",
+            "--min-replica-memory-gb",
+            "48",
+            "--max-replica-memory-gb",
+            "48",
+        ]);
+        let ServiceCommands::Create {
+            profile,
+            byoc_id,
+            min_replica_memory_gb,
+            max_replica_memory_gb,
+            ..
+        } = command
+        else {
+            panic!("expected service create");
+        };
+        assert_eq!(profile.as_deref(), Some("v1-standard-byoc-4"));
+        assert_eq!(byoc_id.as_deref(), Some("byoc-1"));
+        assert_eq!(min_replica_memory_gb, Some(48));
+        assert_eq!(max_replica_memory_gb, Some(48));
     }
 
     #[test]
@@ -6095,6 +6227,76 @@ mod tests {
         assert_eq!(request.private_preview_terms_checked, Some(true));
         assert_eq!(request.enable_core_dumps, Some(true));
         assert!(request.byoc_id.is_none());
+    }
+
+    #[test]
+    fn build_create_service_request_accepts_a_dynamic_byoc_profile() {
+        let request = build_create_service_request(&CreateServiceOptions {
+            min_replica_memory_gb: Some(48),
+            max_replica_memory_gb: Some(48),
+            profile: Some("v1-standard-byoc-4".to_string()),
+            byoc_id: Some("byoc-1".to_string()),
+            ..minimal_create_options()
+        })
+        .unwrap();
+
+        assert_eq!(request.byoc_id.as_deref(), Some("byoc-1"));
+        assert_eq!(
+            request.profile,
+            Some(ServicePostRequestProfile::Unknown(
+                "v1-standard-byoc-4".to_string()
+            ))
+        );
+        assert_eq!(request.min_replica_memory_gb, Some(48.0));
+        assert_eq!(request.max_replica_memory_gb, Some(48.0));
+    }
+
+    #[test]
+    fn build_create_service_request_preserves_standard_profile_validation() {
+        let standard = build_create_service_request(&CreateServiceOptions {
+            profile: Some("v1-highmem-xs".to_string()),
+            ..minimal_create_options()
+        })
+        .unwrap();
+        assert_eq!(
+            standard.profile,
+            Some(ServicePostRequestProfile::V1_highmem_xs)
+        );
+
+        let error = build_create_service_request(&CreateServiceOptions {
+            profile: Some("future-standard-profile".to_string()),
+            ..minimal_create_options()
+        })
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("dynamic profiles require --byoc-id")
+        );
+    }
+
+    #[test]
+    fn build_create_service_request_enforces_byoc_memory_constraints() {
+        for options in [
+            CreateServiceOptions {
+                byoc_id: Some("byoc-1".to_string()),
+                ..minimal_create_options()
+            },
+            CreateServiceOptions {
+                byoc_id: Some("byoc-1".to_string()),
+                min_replica_memory_gb: Some(48),
+                ..minimal_create_options()
+            },
+            CreateServiceOptions {
+                byoc_id: Some("byoc-1".to_string()),
+                min_replica_memory_gb: Some(48),
+                max_replica_memory_gb: Some(116),
+                profile: Some("v1-standard-byoc-4".to_string()),
+                ..minimal_create_options()
+            },
+        ] {
+            assert!(build_create_service_request(&options).is_err());
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -18028,3 +18028,306 @@ async fn service_profile_list_routes_auth_errors() {
         "Error: Unauthorized\n"
     );
 }
+
+// BYOC infrastructure and service placement (#578).
+
+#[tokio::test]
+async fn byoc_infrastructure_commands_send_exact_paths_and_bodies() {
+    let mock = MockServer::start().await;
+    let collection = "/v1/organizations/org-1/byocInfrastructure";
+    let item = "/v1/organizations/org-1/byocInfrastructure/byoc-1";
+
+    Mock::given(method("POST"))
+        .and(path(collection))
+        .and(body_json(serde_json::json!({
+            "regionId": "us-east-1",
+            "accountId": "123456789012",
+            "availabilityZoneSuffixes": ["a", "b"],
+            "vpcCidrRange": "10.0.0.0/16",
+            "displayName": "production"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "byoc-1", "displayName": "production"},
+            "status": 200,
+            "requestId": "stub-byoc-create"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path(item))
+        .and(body_json(serde_json::json!({"displayName": "renamed"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"id": "byoc-1", "displayName": "renamed"},
+            "status": 200,
+            "requestId": "stub-byoc-update"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(item))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "stub-byoc-delete"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let create = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "org",
+            "byoc",
+            "create",
+            "--region",
+            "us-east-1",
+            "--account-id",
+            "123456789012",
+            "--availability-zone-suffix",
+            "a",
+            "--availability-zone-suffix",
+            "b",
+            "--vpc-cidr-range",
+            "10.0.0.0/16",
+            "--display-name",
+            "production",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&create);
+    let printed: Value = serde_json::from_slice(&create.stdout).unwrap();
+    assert_eq!(
+        printed,
+        serde_json::json!({"id": "byoc-1", "displayName": "production"})
+    );
+
+    let update = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "org",
+            "byoc",
+            "update",
+            "byoc-1",
+            "--display-name",
+            "renamed",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&update);
+
+    let delete = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["org", "byoc", "delete", "byoc-1", "--org-id", "org-1"],
+    );
+    assert_success(&delete);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&delete.stdout).unwrap(),
+        serde_json::json!({"status": 200, "requestId": "stub-byoc-delete"})
+    );
+}
+
+#[tokio::test]
+async fn byoc_create_rejects_unknown_zone_before_any_request() {
+    let mock = MockServer::start().await;
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "org",
+            "byoc",
+            "create",
+            "--region",
+            "us-east-1",
+            "--account-id",
+            "123456789012",
+            "--availability-zone-suffix",
+            "z",
+            "--vpc-cidr-range",
+            "10.0.0.0/16",
+            "--display-name",
+            "production",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid availability zone suffix"));
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn byoc_api_errors_keep_auth_classification() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/v1/organizations/org-1/byocInfrastructure/byoc-forbidden",
+        ))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "status": 403,
+            "error": "Forbidden",
+            "requestId": "stub-byoc-forbidden"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "org",
+            "byoc",
+            "delete",
+            "byoc-forbidden",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Forbidden\n"
+    );
+}
+
+#[tokio::test]
+async fn byoc_update_human_output_tolerates_sparse_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path("/v1/organizations/org-1/byocInfrastructure/byoc-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"state": "infra-provisioning"},
+            "status": 200,
+            "requestId": "stub-sparse-byoc-update"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "org",
+            "byoc",
+            "update",
+            "byoc-1",
+            "--display-name",
+            "renamed",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("infra-provisioning"));
+}
+
+#[tokio::test]
+async fn service_create_discovers_and_sends_a_dynamic_byoc_profile() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .and(query_param("region_id", "us-east-1"))
+        .and(query_param("byoc_id", "byoc-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{
+                "profile": "v1-standard-byoc-4",
+                "cpuCores": 4.0,
+                "memoryGi": 48.0
+            }],
+            "status": 200,
+            "requestId": "stub-byoc-profiles"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/services"))
+        .and(body_json(serde_json::json!({
+            "name": "byoc-service",
+            "provider": "aws",
+            "region": "us-east-1",
+            "ipAccessList": [{
+                "source": "0.0.0.0/0",
+                "description": "Allow all (created by clickhousectl)"
+            }],
+            "minReplicaMemoryGb": 48.0,
+            "maxReplicaMemoryGb": 48.0,
+            "profile": "v1-standard-byoc-4",
+            "byocId": "byoc-1"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "service": {"id": "22222222-3333-4444-5555-666666666666", "name": "byoc-service"},
+                "password": "generated-password"
+            },
+            "status": 200,
+            "requestId": "stub-byoc-service-create"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "create",
+            "--name",
+            "byoc-service",
+            "--profile",
+            "v1-standard-byoc-4",
+            "--byoc-id",
+            "byoc-1",
+            "--min-replica-memory-gb",
+            "48",
+            "--max-replica-memory-gb",
+            "48",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+}
+
+#[tokio::test]
+async fn service_create_rejects_dynamic_profile_memory_mismatch_before_post() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(SERVICE_PROFILES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{"profile": "v1-standard-byoc-4", "memoryGi": 48.0}],
+            "status": 200,
+            "requestId": "stub-byoc-profiles"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "create",
+            "--name",
+            "byoc-service",
+            "--profile",
+            "v1-standard-byoc-4",
+            "--byoc-id",
+            "byoc-1",
+            "--min-replica-memory-gb",
+            "16",
+            "--max-replica-memory-gb",
+            "16",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("requires both replica memory bounds to equal 48 GiB")
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, wiremock::http::Method::GET);
+}


### PR DESCRIPTION
`clickhousectl` could provision ordinary services but could neither manage an organization's BYOC infrastructure nor place a new service into it. This adds `cloud org byoc create|update|delete`, forwards `service create --byoc-id`, and accepts dynamic BYOC profile names after verifying the selected profile and exact memory size through service-profile discovery.

For example, users can create infrastructure with the required region, account, availability-zone suffixes, VPC CIDR, and display name; inspect its ID and readiness through `cloud org get`; discover its profiles with `cloud service profile list --region ... --byoc-id ...`; then create a service with matching minimum and maximum replica memory. Standard profile names retain the library-backed allowlist, BYOC zone and region values use typed library enums, update sends only `displayName`, and every new operation is classified as an API-key-only write.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (clean full rerun: 1093 unit tests, 339 cloud request-shape tests with 1 ignored, and all local/telemetry binaries passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (91 passed; run with commit signing disabled for temporary test repositories)

The first full CLI run had one unrelated failure in `version_port_and_startup_failures_have_typed_safe_shapes` because a fixture returned exit 0 instead of 1. Its exact rerun passed, and the following full rerun passed cleanly.

Closes #578.
