### PR TITLE
feat(api): expose slow query sort values

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/models/postgres.rs
@@ -139,6 +139,24 @@ impl std::fmt::Display for SlowQueryPatternsGetListSortby {
     }
 }
 
+impl SlowQueryPatternsGetListSortby {
+    pub const VALUES: &'static [&'static str] = &[
+        "total_duration",
+        "avg_duration",
+        "call_count",
+        "total_blks_read",
+        "total_cpu_time",
+        "error_count",
+        "max_duration",
+        "p50_duration",
+        "p95_duration",
+        "p99_duration",
+        "total_rows",
+        "total_shared_blks_hit",
+        "total_wal_bytes",
+    ];
+}
+
 /// Inline enum for `slowQueryPatternsGetList.sort_order`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum SlowQueryPatternsGetListSortorder {
@@ -160,6 +178,10 @@ impl std::fmt::Display for SlowQueryPatternsGetListSortorder {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl SlowQueryPatternsGetListSortorder {
+    pub const VALUES: &'static [&'static str] = &["asc", "desc"];
 }
 
 /// `pgSize` enum from the ClickHouse Cloud API.

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -713,6 +713,28 @@ fn postgres_config_enum_values_roundtrip_and_match_values() {
 }
 
 #[test]
+fn postgres_slow_query_sort_values_roundtrip_as_known_variants() {
+    for value in SlowQueryPatternsGetListSortby::VALUES {
+        let parsed: SlowQueryPatternsGetListSortby =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, SlowQueryPatternsGetListSortby::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+    }
+    for value in SlowQueryPatternsGetListSortorder::VALUES {
+        let parsed: SlowQueryPatternsGetListSortorder =
+            serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+        assert!(
+            !matches!(parsed, SlowQueryPatternsGetListSortorder::Unknown(_)),
+            "{value} fell through to the catch-all"
+        );
+        assert_eq!(parsed.to_string(), *value);
+    }
+}
+
+#[test]
 fn postgres_gcp_sizes_roundtrip_as_known_variants() {
     let sizes = [
         "c4a-highmem-4",


### PR DESCRIPTION
The slow-query sorting enums had no analyzer-checked value lists for CLI parsing. This publishes `VALUES` for `SlowQueryPatternsGetListSortby` and `SlowQueryPatternsGetListSortorder`, with serialization coverage; the existing analyzer checks keep those lists aligned with the schema.

This is the API prerequisite for #585. CLI commands follow in a separate PR.

Validation: both library/analyzer crates passed all-target clippy and their complete tests; all 91 Python script tests passed; formatting is clean.
