### PR TITLE
feat(postgres): expose slow query patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,14 @@ clickhousectl cloud postgres logs <pg-id> \
   --severity ERROR --body-contains "connection refused" \
   --sort-order asc --limit 200 --offset 0
 
+# Find costly normalized queries, then inspect one pattern and recent executions
+clickhousectl cloud postgres slow-queries list <pg-id> \
+  --from-date 2026-04-16T12:00:00Z \
+  --to-date 2026-04-16T13:00:00Z \
+  --sort-by total_cpu_time --limit 20
+clickhousectl cloud postgres slow-queries get <pg-id> <query-id> \
+  --db-name app --db-user reporter --db-operation SELECT
+
 # Raw Prometheus scrape text for one service or the whole organization
 clickhousectl cloud postgres prometheus service <pg-id>
 clickhousectl cloud postgres prometheus org
@@ -1066,6 +1074,8 @@ Use `clickhousectl cloud postgres create --help` for the complete option list. S
 `postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
 
 `postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
+
+`postgres slow-queries list` requires an RFC 3339 start and end time and supports database, user, operation and application filters, sorting, limits and offsets. Copy `queryId`, `dbName`, `dbUser` and `dbOperation` from a list result into `slow-queries get`; add `--app` when the list result has one, and optionally select a recent execution with `--timestamp`. JSON and human output preserve every aggregate and execution field the API returns, including sparse beta responses.
 
 `postgres prometheus service` and `postgres prometheus org` return the beta API's raw Prometheus exposition text for scraping. In `--json` mode, including automatic coding-agent mode, the complete text is emitted as one JSON string; it is not parsed into metric series. These endpoints have no filtered-metrics query parameter. Use `postgres metrics` when you need time-bucketed metric objects over a chosen date range.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -11,7 +11,8 @@ use clickhouse_cloud_api::models::{
     PostgresMetrics, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
     PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
     PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
-    ResourceTagsV1, ResourceTagsV1Response,
+    PostgresSlowQueryPattern, PostgresSlowQueryPatternDetail, ResourceTagsV1,
+    ResourceTagsV1Response, SlowQueryPatternsGetListSortby, SlowQueryPatternsGetListSortorder,
 };
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
@@ -214,6 +215,10 @@ CONTEXT FOR AGENTS:
         org_id: Option<String>,
     },
 
+    /// Inspect Postgres slow query patterns
+    #[command(name = "slow-queries", subcommand)]
+    SlowQueries(SlowQueryCommands),
+
     /// Get raw Postgres Prometheus metrics
     #[command(
         subcommand,
@@ -413,6 +418,83 @@ pub enum PrometheusCommands {
     },
 }
 
+#[derive(Subcommand)]
+pub enum SlowQueryCommands {
+    /// List slow query patterns
+    List {
+        /// Postgres service ID (from `cloud postgres list`)
+        postgres_id: String,
+        /// Inclusive start time (ISO 8601 / RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        from_date: String,
+        /// Exclusive end time (ISO 8601 / RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        to_date: String,
+        /// Filter by database name
+        #[arg(long)]
+        db_name: Option<String>,
+        /// Filter by database user
+        #[arg(long)]
+        db_user: Option<String>,
+        /// Filter by database operation
+        #[arg(long)]
+        db_operation: Option<String>,
+        /// Filter by application name
+        #[arg(long)]
+        app: Option<String>,
+        /// Field used to sort results
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new(
+                SlowQueryPatternsGetListSortby::VALUES
+            )
+        )]
+        sort_by: Option<String>,
+        /// Sort order
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new(
+                SlowQueryPatternsGetListSortorder::VALUES
+            )
+        )]
+        sort_order: Option<String>,
+        /// Maximum number of patterns to return
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
+        limit: Option<i64>,
+        /// Number of patterns to skip
+        #[arg(long, value_parser = clap::value_parser!(i64).range(0..))]
+        offset: Option<i64>,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+    /// Get a slow query pattern with recent executions
+    Get {
+        /// Postgres service ID (from `cloud postgres list`)
+        postgres_id: String,
+        /// Stable query pattern ID (from `slow-queries list`)
+        query_id: String,
+        /// Database name from the list result
+        #[arg(long)]
+        db_name: String,
+        /// Database user from the list result
+        #[arg(long)]
+        db_user: String,
+        /// Database operation from the list result
+        #[arg(long)]
+        db_operation: String,
+        /// Application name from the list result
+        #[arg(long)]
+        app: Option<String>,
+        /// Timestamp of a specific execution (ISO 8601 / RFC 3339)
+        #[arg(long, value_parser = parse_datetime)]
+        timestamp: Option<String>,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
 impl PostgresCommands {
     pub fn is_write(&self) -> bool {
         match self {
@@ -420,6 +502,7 @@ impl PostgresCommands {
             | PostgresCommands::Get { .. }
             | PostgresCommands::Metrics { .. }
             | PostgresCommands::Logs { .. }
+            | PostgresCommands::SlowQueries(_)
             | PostgresCommands::Prometheus(_) => false,
             PostgresCommands::Certs(CertsCommands::Get { .. }) => false,
             PostgresCommands::Config(ConfigCommands::Get { .. }) => false,
@@ -606,6 +689,61 @@ pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) ->
                 &from_date,
                 &to_date,
                 bucket_size_seconds,
+                org_id.as_deref(),
+                json,
+            )
+            .await
+        }
+        PostgresCommands::SlowQueries(SlowQueryCommands::List {
+            postgres_id,
+            from_date,
+            to_date,
+            db_name,
+            db_user,
+            db_operation,
+            app,
+            sort_by,
+            sort_order,
+            limit,
+            offset,
+            org_id,
+        }) => {
+            let input = SlowQueryListInput {
+                from_date: &from_date,
+                to_date: &to_date,
+                db_name: db_name.as_deref(),
+                db_user: db_user.as_deref(),
+                db_operation: db_operation.as_deref(),
+                app: app.as_deref(),
+                sort_by: sort_by.as_deref(),
+                sort_order: sort_order.as_deref(),
+                limit,
+                offset,
+            };
+            postgres_slow_queries_list(client, &postgres_id, input, org_id.as_deref(), json).await
+        }
+        PostgresCommands::SlowQueries(SlowQueryCommands::Get {
+            postgres_id,
+            query_id,
+            db_name,
+            db_user,
+            db_operation,
+            app,
+            timestamp,
+            org_id,
+        }) => {
+            let input = SlowQueryDetailInput {
+                db_name: &db_name,
+                db_user: &db_user,
+                db_operation: &db_operation,
+                app: app.as_deref(),
+                timestamp: timestamp.as_deref(),
+            };
+            postgres_slow_query_get(
+                client,
+                &postgres_id,
+                &query_id,
+                input,
                 org_id.as_deref(),
                 json,
             )
@@ -1850,7 +1988,7 @@ pub async fn postgres_state_change(
     Ok(())
 }
 
-fn validate_metrics_date_range(from_date: &str, to_date: &str) -> CloudResult<()> {
+fn validate_datetime_range(from_date: &str, to_date: &str) -> CloudResult<()> {
     let from = chrono::DateTime::parse_from_rfc3339(from_date)
         .map_err(|_| CloudError::new("invalid --from-date: expected ISO 8601 / RFC 3339"))?;
     let to = chrono::DateTime::parse_from_rfc3339(to_date)
@@ -1872,7 +2010,7 @@ pub async fn postgres_metrics(
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
-    validate_metrics_date_range(from_date, to_date)?;
+    validate_datetime_range(from_date, to_date)?;
     let org_id = resolve_org_id(client, org_id).await?;
     let metrics = client
         .get_postgres_metrics(
@@ -1888,6 +2026,150 @@ pub async fn postgres_metrics(
         println!("{}", serde_json::to_string_pretty(&metrics)?);
     } else {
         print_human(&metrics)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SlowQueryListInput<'a> {
+    from_date: &'a str,
+    to_date: &'a str,
+    db_name: Option<&'a str>,
+    db_user: Option<&'a str>,
+    db_operation: Option<&'a str>,
+    app: Option<&'a str>,
+    sort_by: Option<&'a str>,
+    sort_order: Option<&'a str>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SlowQueryListQuery<'a> {
+    from_date: &'a str,
+    to_date: &'a str,
+    db_name: Option<&'a str>,
+    db_user: Option<&'a str>,
+    db_operation: Option<&'a str>,
+    app: Option<&'a str>,
+    sort_by: Option<SlowQueryPatternsGetListSortby>,
+    sort_order: Option<SlowQueryPatternsGetListSortorder>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+fn build_slow_query_list_query(
+    input: SlowQueryListInput<'_>,
+) -> CloudResult<SlowQueryListQuery<'_>> {
+    validate_datetime_range(input.from_date, input.to_date)?;
+    if input.limit.is_some_and(|limit| !(1..=500).contains(&limit)) {
+        return Err(CloudError::new(
+            "invalid --limit: expected a value from 1 to 500",
+        ));
+    }
+    if input.offset.is_some_and(|offset| offset < 0) {
+        return Err(CloudError::new(
+            "invalid --offset: expected a non-negative value",
+        ));
+    }
+
+    Ok(SlowQueryListQuery {
+        from_date: input.from_date,
+        to_date: input.to_date,
+        db_name: input.db_name,
+        db_user: input.db_user,
+        db_operation: input.db_operation,
+        app: input.app,
+        sort_by: input
+            .sort_by
+            .map(|value| parse_serde_enum(value, "sort_by", SlowQueryPatternsGetListSortby::VALUES))
+            .transpose()?,
+        sort_order: input
+            .sort_order
+            .map(|value| {
+                parse_serde_enum(
+                    value,
+                    "sort_order",
+                    SlowQueryPatternsGetListSortorder::VALUES,
+                )
+            })
+            .transpose()?,
+        limit: input.limit,
+        offset: input.offset,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SlowQueryDetailInput<'a> {
+    db_name: &'a str,
+    db_user: &'a str,
+    db_operation: &'a str,
+    app: Option<&'a str>,
+    timestamp: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SlowQueryDetailQuery<'a> {
+    db_name: &'a str,
+    db_user: &'a str,
+    db_operation: &'a str,
+    app: Option<&'a str>,
+    timestamp: Option<&'a str>,
+}
+
+fn build_slow_query_detail_query(
+    input: SlowQueryDetailInput<'_>,
+) -> CloudResult<SlowQueryDetailQuery<'_>> {
+    if let Some(timestamp) = input.timestamp {
+        chrono::DateTime::parse_from_rfc3339(timestamp)
+            .map_err(|_| CloudError::new("invalid --timestamp: expected ISO 8601 / RFC 3339"))?;
+    }
+    Ok(SlowQueryDetailQuery {
+        db_name: input.db_name,
+        db_user: input.db_user,
+        db_operation: input.db_operation,
+        app: input.app,
+        timestamp: input.timestamp,
+    })
+}
+
+async fn postgres_slow_queries_list(
+    client: &CloudClient,
+    postgres_id: &str,
+    input: SlowQueryListInput<'_>,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let query = build_slow_query_list_query(input)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let patterns = client
+        .list_postgres_slow_query_patterns(&org_id, postgres_id, &query)
+        .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&patterns)?);
+    } else {
+        print_human(&patterns)?;
+    }
+    Ok(())
+}
+
+async fn postgres_slow_query_get(
+    client: &CloudClient,
+    postgres_id: &str,
+    query_id: &str,
+    input: SlowQueryDetailInput<'_>,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let query = build_slow_query_detail_query(input)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let pattern = client
+        .get_postgres_slow_query_pattern(&org_id, postgres_id, query_id, &query)
+        .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&pattern)?);
+    } else {
+        print_human(&pattern)?;
     }
     Ok(())
 }
@@ -1965,6 +2247,59 @@ impl CloudClient {
                 from_date,
                 to_date,
                 bucket_size_seconds,
+            )
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    /// Fetch aggregate slow query patterns for a Postgres service.
+    pub async fn list_postgres_slow_query_patterns(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+        query: &SlowQueryListQuery<'_>,
+    ) -> CloudResult<Vec<PostgresSlowQueryPattern>> {
+        let response = self
+            .api()
+            .slow_query_patterns_get_list(
+                org_id,
+                postgres_id,
+                query.from_date,
+                query.to_date,
+                query.db_name,
+                query.db_user,
+                query.db_operation,
+                query.app,
+                query.sort_by.as_ref(),
+                query.sort_order.as_ref(),
+                query.limit,
+                query.offset,
+            )
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    /// Fetch one slow query pattern and its recent executions.
+    pub async fn get_postgres_slow_query_pattern(
+        &self,
+        org_id: &str,
+        postgres_id: &str,
+        query_id: &str,
+        query: &SlowQueryDetailQuery<'_>,
+    ) -> CloudResult<PostgresSlowQueryPatternDetail> {
+        let response = self
+            .api()
+            .slow_query_pattern_get(
+                org_id,
+                postgres_id,
+                query_id,
+                query.db_name,
+                query.db_user,
+                query.db_operation,
+                query.app,
+                query.timestamp,
             )
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
@@ -3263,14 +3598,378 @@ mod tests {
     #[test]
     fn postgres_metrics_validates_chronological_range() {
         assert!(
-            validate_metrics_date_range("2026-04-16T12:00:00+01:00", "2026-04-16T11:00:00Z")
-                .is_ok()
+            validate_datetime_range("2026-04-16T12:00:00+01:00", "2026-04-16T11:00:00Z").is_ok()
         );
-        let error = validate_metrics_date_range("2026-04-16T12:00:01Z", "2026-04-16T12:00:00Z")
-            .unwrap_err();
+        let error =
+            validate_datetime_range("2026-04-16T12:00:01Z", "2026-04-16T12:00:00Z").unwrap_err();
         assert_eq!(
             error.to_string(),
             "invalid date range: --from-date must not be after --to-date"
+        );
+    }
+
+    #[test]
+    fn parses_slow_query_list_with_all_query_inputs_as_read() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "slow-queries",
+            "list",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00+01:00",
+            "--to-date",
+            "2026-04-16T13:00:00+01:00",
+            "--db-name",
+            "app db",
+            "--db-user",
+            "reader+worker",
+            "--db-operation",
+            "SELECT",
+            "--app",
+            "reporting/api",
+            "--sort-by",
+            "p95_duration",
+            "--sort-order",
+            "asc",
+            "--limit",
+            "500",
+            "--offset",
+            "0",
+            "--org-id",
+            "org-1",
+        ]);
+        assert!(!cmd.is_write());
+        let PostgresCommands::SlowQueries(SlowQueryCommands::List {
+            postgres_id,
+            from_date,
+            to_date,
+            db_name,
+            db_user,
+            db_operation,
+            app,
+            sort_by,
+            sort_order,
+            limit,
+            offset,
+            org_id,
+        }) = cmd
+        else {
+            panic!("expected slow-query list");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(from_date, "2026-04-16T12:00:00+01:00");
+        assert_eq!(to_date, "2026-04-16T13:00:00+01:00");
+        assert_eq!(db_name.as_deref(), Some("app db"));
+        assert_eq!(db_user.as_deref(), Some("reader+worker"));
+        assert_eq!(db_operation.as_deref(), Some("SELECT"));
+        assert_eq!(app.as_deref(), Some("reporting/api"));
+        assert_eq!(sort_by.as_deref(), Some("p95_duration"));
+        assert_eq!(sort_order.as_deref(), Some("asc"));
+        assert_eq!(limit, Some(500));
+        assert_eq!(offset, Some(0));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn slow_query_list_requires_dates_and_validates_schema_bounds() {
+        let missing_date = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "slow-queries",
+            "list",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00Z",
+        ])
+        .err()
+        .expect("expected parse error");
+        assert_eq!(
+            missing_date.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        for (flag, value, expected_kind) in [
+            (
+                "--from-date",
+                "yesterday",
+                clap::error::ErrorKind::ValueValidation,
+            ),
+            (
+                "--to-date",
+                "tomorrow",
+                clap::error::ErrorKind::ValueValidation,
+            ),
+            (
+                "--sort-by",
+                "duration",
+                clap::error::ErrorKind::InvalidValue,
+            ),
+            (
+                "--sort-order",
+                "sideways",
+                clap::error::ErrorKind::InvalidValue,
+            ),
+            ("--limit", "0", clap::error::ErrorKind::ValueValidation),
+            ("--limit", "501", clap::error::ErrorKind::ValueValidation),
+            ("--offset", "-1", clap::error::ErrorKind::UnknownArgument),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "slow-queries",
+                "list",
+                "pg-1",
+                "--from-date",
+                "2026-04-16T12:00:00Z",
+                "--to-date",
+                "2026-04-16T13:00:00Z",
+            ];
+            let position = args.iter().position(|arg| *arg == flag);
+            if let Some(position) = position {
+                args[position + 1] = value;
+            } else {
+                args.extend([flag, value]);
+            }
+            let error = Cli::try_parse_from(args)
+                .err()
+                .expect("expected parse error");
+            assert_eq!(error.kind(), expected_kind);
+        }
+    }
+
+    #[test]
+    fn slow_query_list_builder_uses_every_library_sort_value() {
+        for &sort_by in SlowQueryPatternsGetListSortby::VALUES {
+            let query = build_slow_query_list_query(SlowQueryListInput {
+                from_date: "2026-04-16T12:00:00Z",
+                to_date: "2026-04-16T13:00:00Z",
+                db_name: None,
+                db_user: None,
+                db_operation: None,
+                app: None,
+                sort_by: Some(sort_by),
+                sort_order: Some("desc"),
+                limit: Some(1),
+                offset: Some(0),
+            })
+            .unwrap();
+            assert_eq!(query.sort_by.as_ref().unwrap().to_string(), sort_by);
+            assert_eq!(
+                query.sort_order,
+                Some(SlowQueryPatternsGetListSortorder::Desc)
+            );
+        }
+        for &sort_order in SlowQueryPatternsGetListSortorder::VALUES {
+            let query = build_slow_query_list_query(SlowQueryListInput {
+                from_date: "2026-04-16T12:00:00Z",
+                to_date: "2026-04-16T13:00:00Z",
+                db_name: None,
+                db_user: None,
+                db_operation: None,
+                app: None,
+                sort_by: None,
+                sort_order: Some(sort_order),
+                limit: None,
+                offset: None,
+            })
+            .unwrap();
+            assert_eq!(query.sort_order.as_ref().unwrap().to_string(), sort_order);
+        }
+    }
+
+    #[test]
+    fn slow_query_list_builder_rejects_invalid_ranges_and_typed_values() {
+        let input = SlowQueryListInput {
+            from_date: "2026-04-16T13:00:00Z",
+            to_date: "2026-04-16T12:00:00Z",
+            db_name: None,
+            db_user: None,
+            db_operation: None,
+            app: None,
+            sort_by: None,
+            sort_order: None,
+            limit: None,
+            offset: None,
+        };
+        assert!(
+            build_slow_query_list_query(input)
+                .unwrap_err()
+                .to_string()
+                .contains("--from-date must not be after --to-date")
+        );
+        assert!(
+            build_slow_query_list_query(SlowQueryListInput {
+                from_date: "2026-04-16T12:00:00Z",
+                to_date: "2026-04-16T13:00:00Z",
+                sort_by: Some("future_sort"),
+                ..input
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("invalid sort_by")
+        );
+        assert!(
+            build_slow_query_list_query(SlowQueryListInput {
+                from_date: "2026-04-16T12:00:00Z",
+                to_date: "2026-04-16T13:00:00Z",
+                limit: Some(501),
+                ..input
+            })
+            .is_err()
+        );
+        assert!(
+            build_slow_query_list_query(SlowQueryListInput {
+                from_date: "2026-04-16T12:00:00Z",
+                to_date: "2026-04-16T13:00:00Z",
+                offset: Some(-1),
+                ..input
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn slow_query_builders_preserve_minimal_and_maximal_queries() {
+        let minimal = build_slow_query_list_query(SlowQueryListInput {
+            from_date: "2026-04-16T12:00:00Z",
+            to_date: "2026-04-16T13:00:00Z",
+            db_name: None,
+            db_user: None,
+            db_operation: None,
+            app: None,
+            sort_by: None,
+            sort_order: None,
+            limit: None,
+            offset: None,
+        })
+        .unwrap();
+        assert_eq!(minimal.from_date, "2026-04-16T12:00:00Z");
+        assert_eq!(minimal.to_date, "2026-04-16T13:00:00Z");
+        assert_eq!(minimal.db_name, None);
+        assert_eq!(minimal.sort_by, None);
+        assert_eq!(minimal.limit, None);
+        assert_eq!(minimal.offset, None);
+
+        let detail = build_slow_query_detail_query(SlowQueryDetailInput {
+            db_name: "app db",
+            db_user: "reader",
+            db_operation: "SELECT",
+            app: Some("reporter"),
+            timestamp: Some("2026-04-16T12:30:00+01:00"),
+        })
+        .unwrap();
+        assert_eq!(detail.db_name, "app db");
+        assert_eq!(detail.db_user, "reader");
+        assert_eq!(detail.db_operation, "SELECT");
+        assert_eq!(detail.app, Some("reporter"));
+        assert_eq!(detail.timestamp, Some("2026-04-16T12:30:00+01:00"));
+
+        assert!(
+            build_slow_query_detail_query(SlowQueryDetailInput {
+                db_name: "app",
+                db_user: "reader",
+                db_operation: "SELECT",
+                app: None,
+                timestamp: Some("now"),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parses_slow_query_detail_with_its_distinct_inputs_as_read() {
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app",
+            "--db-user",
+            "reader",
+            "--db-operation",
+            "SELECT",
+            "--app",
+            "reporter",
+            "--timestamp",
+            "2026-04-16T12:30:00Z",
+            "--org-id",
+            "org-1",
+        ]);
+        assert!(!cmd.is_write());
+        let PostgresCommands::SlowQueries(SlowQueryCommands::Get {
+            postgres_id,
+            query_id,
+            db_name,
+            db_user,
+            db_operation,
+            app,
+            timestamp,
+            org_id,
+        }) = cmd
+        else {
+            panic!("expected slow-query detail");
+        };
+        assert_eq!(postgres_id, "pg-1");
+        assert_eq!(query_id, "query-1");
+        assert_eq!(db_name, "app");
+        assert_eq!(db_user, "reader");
+        assert_eq!(db_operation, "SELECT");
+        assert_eq!(app.as_deref(), Some("reporter"));
+        assert_eq!(timestamp.as_deref(), Some("2026-04-16T12:30:00Z"));
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn slow_query_detail_requires_identity_filters_and_validates_timestamp() {
+        let missing_operation = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app",
+            "--db-user",
+            "reader",
+        ])
+        .err()
+        .expect("expected parse error");
+        assert_eq!(
+            missing_operation.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        let invalid_timestamp = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app",
+            "--db-user",
+            "reader",
+            "--db-operation",
+            "SELECT",
+            "--timestamp",
+            "now",
+        ])
+        .err()
+        .expect("expected parse error");
+        assert_eq!(
+            invalid_timestamp.kind(),
+            clap::error::ErrorKind::ValueValidation
         );
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1945,6 +1945,368 @@ async fn postgres_logs_reports_empty_results_and_structured_api_errors() {
     }
 }
 
+// ── Postgres slow query patterns (issue #585) ─────────────────────────────
+
+#[tokio::test]
+async fn postgres_slow_query_list_sends_exact_query_supports_oauth_and_preserves_json() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!([{
+        "queryId": "query-1",
+        "queryText": "SELECT * FROM events WHERE id = $1",
+        "dbName": "app db",
+        "dbUser": "reader+worker",
+        "dbOperation": "SELECT",
+        "app": "reporting/api",
+        "callCount": 42,
+        "errorCount": 1,
+        "totalDurationUs": 950000,
+        "avgDurationUs": 22619,
+        "maxDurationUs": 81000,
+        "p50DurationUs": 18000,
+        "p95DurationUs": 70000,
+        "p99DurationUs": 80000,
+        "totalRows": 420,
+        "totalSharedBlksRead": 12,
+        "totalSharedBlksHit": 900,
+        "totalCpuTimeUs": 700000,
+        "totalWalBytes": 128
+    }]);
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns",
+        ))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-slow-query-list"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "postgres",
+            "slow-queries",
+            "list",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00+01:00",
+            "--to-date",
+            "2026-04-16T13:00:00+01:00",
+            "--db-name",
+            "app db",
+            "--db-user",
+            "reader+worker",
+            "--db-operation",
+            "SELECT & EXPLAIN",
+            "--app",
+            "reporting/api",
+            "--sort-by",
+            "total_cpu_time",
+            "--sort-order",
+            "asc",
+            "--limit",
+            "500",
+            "--offset",
+            "0",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let query: Vec<_> = requests[0]
+        .url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    assert_eq!(
+        query,
+        [
+            (
+                "from_date".to_string(),
+                "2026-04-16T12:00:00+01:00".to_string()
+            ),
+            (
+                "to_date".to_string(),
+                "2026-04-16T13:00:00+01:00".to_string()
+            ),
+            ("db_name".to_string(), "app db".to_string()),
+            ("db_user".to_string(), "reader+worker".to_string()),
+            ("db_operation".to_string(), "SELECT & EXPLAIN".to_string()),
+            ("app".to_string(), "reporting/api".to_string()),
+            ("sort_by".to_string(), "total_cpu_time".to_string()),
+            ("sort_order".to_string(), "asc".to_string()),
+            ("limit".to_string(), "500".to_string()),
+            ("offset".to_string(), "0".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn postgres_slow_query_list_omits_filters_and_renders_sparse_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [{ "queryId": "query-1", "callCount": 2 }],
+            "status": 200
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "postgres",
+            "slow-queries",
+            "list",
+            "pg-1",
+            "--from-date",
+            "2026-04-16T12:00:00Z",
+            "--to-date",
+            "2026-04-16T13:00:00Z",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("queryId: query-1"), "{stdout}");
+    assert!(stdout.contains("callCount: 2"), "{stdout}");
+    let requests = mock.received_requests().await.unwrap();
+    let query: Vec<_> = requests[0].url.query_pairs().collect();
+    assert_eq!(query.len(), 2, "unexpected query parameters: {query:?}");
+}
+
+#[tokio::test]
+async fn postgres_slow_query_list_rejects_reverse_range_and_surfaces_api_errors() {
+    let mock = MockServer::start().await;
+    let reverse_args = [
+        "postgres",
+        "slow-queries",
+        "list",
+        "pg-1",
+        "--from-date",
+        "2026-04-16T13:00:00Z",
+        "--to-date",
+        "2026-04-16T12:00:00Z",
+        "--org-id",
+        "org-1",
+    ];
+    let output = invoke_cli_with_cloud_credentials(&mock, &reverse_args);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--from-date must not be after --to-date")
+    );
+    assert!(mock.received_requests().await.unwrap().is_empty());
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns",
+        ))
+        .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+            "status": 429,
+            "error": "RATE_LIMIT_EXCEEDED: try later",
+            "requestId": "stub-slow-query-error"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let valid_args = [
+        "postgres",
+        "slow-queries",
+        "list",
+        "pg-1",
+        "--from-date",
+        "2026-04-16T12:00:00Z",
+        "--to-date",
+        "2026-04-16T13:00:00Z",
+        "--org-id",
+        "org-1",
+    ];
+    let output = invoke_cli_with_cloud_credentials(&mock, &valid_args);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("RATE_LIMIT_EXCEEDED: try later"));
+}
+
+#[tokio::test]
+async fn postgres_slow_query_get_has_distinct_query_and_preserves_recent_executions() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!({
+        "aggregate": {
+            "queryId": "query-1",
+            "queryText": "SELECT $1",
+            "dbName": "app db",
+            "dbUser": "reader+worker",
+            "dbOperation": "SELECT & EXPLAIN",
+            "app": "reporting/api",
+            "callCount": 2
+        },
+        "recentExecutions": [{
+            "queryId": "query-1",
+            "queryText": "SELECT 42",
+            "timestamp": "2026-04-16T12:30:00Z",
+            "durationUs": 1234,
+            "rows": 1,
+            "errMessage": "optional detail"
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns/query-1",
+        ))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-slow-query-detail"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app db",
+            "--db-user",
+            "reader+worker",
+            "--db-operation",
+            "SELECT & EXPLAIN",
+            "--app",
+            "reporting/api",
+            "--timestamp",
+            "2026-04-16T12:30:00+01:00",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        result
+    );
+    let requests = mock.received_requests().await.unwrap();
+    let query: Vec<_> = requests[0]
+        .url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    assert_eq!(
+        query,
+        [
+            ("db_name".to_string(), "app db".to_string()),
+            ("db_user".to_string(), "reader+worker".to_string()),
+            ("db_operation".to_string(), "SELECT & EXPLAIN".to_string()),
+            ("app".to_string(), "reporting/api".to_string()),
+            (
+                "timestamp".to_string(),
+                "2026-04-16T12:30:00+01:00".to_string()
+            ),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn postgres_slow_query_get_omits_optional_query_and_renders_sparse_detail() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns/query-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "aggregate": { "queryId": "query-1" },
+                "recentExecutions": [{ "timestamp": "2026-04-16T12:30:00Z" }]
+            },
+            "status": 200
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app",
+            "--db-user",
+            "reader",
+            "--db-operation",
+            "SELECT",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for text in [
+        "aggregate:",
+        "queryId: query-1",
+        "recentExecutions:",
+        "timestamp: 2026-04-16T12:30:00Z",
+    ] {
+        assert!(stdout.contains(text), "missing {text:?} from:\n{stdout}");
+    }
+    let requests = mock.received_requests().await.unwrap();
+    let query: Vec<_> = requests[0].url.query_pairs().collect();
+    assert_eq!(query.len(), 3, "unexpected query parameters: {query:?}");
+    assert!(
+        query
+            .iter()
+            .all(|(key, _)| key != "app" && key != "timestamp"),
+        "optional detail filters must be omitted: {query:?}"
+    );
+}
+
 // ── Postgres Prometheus metrics (issue #584) ──────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
`cloud postgres slow-queries list` now discovers aggregate slow-query patterns over a required RFC 3339 window, with the API's database, user, operation, application, sorting, limit, and offset filters. `cloud postgres slow-queries get` uses the selected pattern's query ID and required database identity fields to return its aggregate and recent executions, with optional application and timestamp selection.

Both commands are read-only under OAuth, validate dates, chronology, enum values, and numeric bounds before sending a request, and preserve complete sparse API responses in JSON and shared human output. CLI validation uses the sorting enum `VALUES` published by the preceding API prerequisite. The README documents a list-to-detail investigation flow.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`

Closes #585.
