### PR TITLE
feat(clickpipes): expose service CDC scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,11 @@ clickhousectl cloud clickpipe delete <service-id> <clickpipe-id>
 clickhousectl cloud clickpipe scale <service-id> <clickpipe-id> \
   --replicas 2 --cpu-millicores 250 --memory-gb 1
 
+# Inspect and update service-wide scaling for database CDC ClickPipes
+clickhousectl cloud clickpipe cdc-scaling get <service-id>
+clickhousectl cloud clickpipe cdc-scaling update <service-id> \
+  --cpu-millicores 2000 --memory-gb 8
+
 # Get/update settings
 clickhousectl cloud clickpipe settings get <service-id> <clickpipe-id>
 clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
@@ -1144,6 +1149,11 @@ clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
 # Manage reverse private endpoints for private source connectivity
 clickhousectl cloud clickpipe reverse-private-endpoint list <service-id>
 ```
+
+CDC scaling CPU accepts 1000-32000 millicores in increments of 1000, and
+memory accepts 4-128 GiB in increments of 4. Memory must be four times the CPU
+core count when both are changed together; omitted update flags preserve their
+current values.
 
 `settings get` and `settings update` apply to streaming (Kafka, Kinesis) and
 object-storage pipes only; Pub/Sub counts as streaming and is accepted too,

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -64,6 +64,26 @@ const PUBSUB_FILTER_MAX_LENGTH: usize = 256;
 /// `maxLength` of the base64-encoded Kafka `protobufSchema` field.
 const PROTOBUF_SCHEMA_MAX_ENCODED_LENGTH: usize = 1_048_576;
 
+fn parse_cdc_cpu_millicores(value: &str) -> Result<u32, String> {
+    let value = value
+        .parse::<u32>()
+        .map_err(|_| "must be an integer from 1000 to 32000".to_string())?;
+    if !(1000..=32000).contains(&value) || value % 1000 != 0 {
+        return Err("must be from 1000 to 32000 in increments of 1000".to_string());
+    }
+    Ok(value)
+}
+
+fn parse_cdc_memory_gb(value: &str) -> Result<f64, String> {
+    let value = value
+        .parse::<f64>()
+        .map_err(|_| "must be a number from 4 to 128".to_string())?;
+    if !value.is_finite() || !(4.0..=128.0).contains(&value) || (value / 4.0).fract() != 0.0 {
+        return Err("must be from 4 to 128 in increments of 4".to_string());
+    }
+    Ok(value)
+}
+
 fn parse_kafka_authentication(value: &str) -> CloudResult<ClickPipePostKafkaSourceAuthentication> {
     let authentication = parse_serde_enum(
         value,
@@ -283,6 +303,17 @@ pub enum ClickPipeCommands {
         org_id: Option<String>,
     },
 
+    /// Manage service-wide CDC scaling
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  The allocation applies to database CDC ClickPipes on the service.
+  Omitted update values keep their current settings.
+  Typical flow: `get` -> `update` -> `get`.")]
+    CdcScaling {
+        #[command(subcommand)]
+        command: ClickPipeCdcScalingCommands,
+    },
+
     /// Manage ingestion settings (streaming, object-storage pipes)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -362,6 +393,7 @@ impl ClickPipeCommands {
             ClickPipeCommands::Stop { .. } => true,
             ClickPipeCommands::Resync { .. } => true,
             ClickPipeCommands::Scale { .. } => true,
+            ClickPipeCommands::CdcScaling { command } => command.is_write(),
             // Side-effect-free, but the API gateway rejects OAuth/JWT on
             // POST /clickpipes/schemaDiscovery ("This endpoint is not
             // available for JWT authentication"), so classify it as a
@@ -423,6 +455,49 @@ pub enum ClickPipeContextCommands {
         #[arg(long)]
         org_id: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+pub enum ClickPipeCdcScalingCommands {
+    /// Get CDC scaling
+    Get {
+        /// Service ID
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Update CDC scaling
+    #[command(
+        group(ArgGroup::new("cdc_scale_target").required(true).multiple(true).args(["cpu_millicores", "memory_gb"]))
+    )]
+    Update {
+        /// Service ID
+        service_id: String,
+
+        /// CPU millicores per replica (1000-32000, in increments of 1000)
+        #[arg(long, value_parser = parse_cdc_cpu_millicores)]
+        cpu_millicores: Option<u32>,
+
+        /// Memory GiB per replica (4-128, in increments of 4)
+        #[arg(long, value_parser = parse_cdc_memory_gb)]
+        memory_gb: Option<f64>,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl ClickPipeCdcScalingCommands {
+    fn is_write(&self) -> bool {
+        match self {
+            Self::Get { .. } => false,
+            Self::Update { .. } => true,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -1669,6 +1744,24 @@ pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -
             )
             .await
         }
+        ClickPipeCommands::CdcScaling { command } => match command {
+            ClickPipeCdcScalingCommands::Get { service_id, org_id } => {
+                clickpipe_cdc_scaling_get(client, &service_id, org_id.as_deref(), json).await
+            }
+            ClickPipeCdcScalingCommands::Update {
+                service_id,
+                cpu_millicores,
+                memory_gb,
+                org_id,
+            } => {
+                let values = CdcScalingValues {
+                    cpu_millicores,
+                    memory_gb,
+                };
+                clickpipe_cdc_scaling_update(client, &service_id, &values, org_id.as_deref(), json)
+                    .await
+            }
+        },
         ClickPipeCommands::Settings { command } => match command {
             ClickPipeSettingsCommands::Get {
                 service_id,
@@ -2897,6 +2990,72 @@ async fn clickpipe_scale(
         println!("  Replicas: {}", or_absent(scaling.replicas));
         println!("  CPU: {}m", or_absent(scaling.replica_cpu_millicores));
         println!("  Memory: {} GB", or_absent(scaling.replica_memory_gb));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct CdcScalingValues {
+    cpu_millicores: Option<u32>,
+    memory_gb: Option<f64>,
+}
+
+fn build_cdc_scaling_request(
+    values: &CdcScalingValues,
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipesCdcScalingPatchRequest> {
+    if let (Some(cpu_millicores), Some(memory_gb)) = (values.cpu_millicores, values.memory_gb) {
+        let required_memory_gb = f64::from(cpu_millicores) / 250.0;
+        if memory_gb != required_memory_gb {
+            return Err(CloudError::new(format!(
+                "--memory-gb must be {required_memory_gb} when --cpu-millicores is {cpu_millicores}"
+            )));
+        }
+    }
+
+    Ok(
+        clickhouse_cloud_api::models::ClickPipesCdcScalingPatchRequest {
+            replica_cpu_millicores: values.cpu_millicores.map(i64::from),
+            replica_memory_gb: values.memory_gb,
+        },
+    )
+}
+
+async fn clickpipe_cdc_scaling_get(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let scaling = client
+        .get_clickpipe_cdc_scaling(&org_id, service_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&scaling)?);
+    } else {
+        print_human(&scaling)?;
+    }
+    Ok(())
+}
+
+async fn clickpipe_cdc_scaling_update(
+    client: &CloudClient,
+    service_id: &str,
+    values: &CdcScalingValues,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let request = build_cdc_scaling_request(values)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let scaling = client
+        .update_clickpipe_cdc_scaling(&org_id, service_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&scaling)?);
+    } else {
+        print_human(&scaling)?;
     }
     Ok(())
 }
@@ -4341,6 +4500,33 @@ impl CloudClient {
         Self::unwrap_response(response)
     }
 
+    pub async fn get_clickpipe_cdc_scaling(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ClickPipesCdcScaling> {
+        let response = self
+            .api()
+            .click_pipe_cdc_scaling_get(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_clickpipe_cdc_scaling(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &clickhouse_cloud_api::models::ClickPipesCdcScalingPatchRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ClickPipesCdcScaling> {
+        let response = self
+            .api()
+            .click_pipe_cdc_scaling_update(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
     pub async fn get_clickpipe_settings(
         &self,
         org_id: &str,
@@ -4989,6 +5175,91 @@ mod tests {
         assert_eq!(replicas, Some(4));
         assert_eq!(cpu_millicores, None);
         assert_eq!(memory_gb, Some(1.5));
+    }
+
+    #[test]
+    fn parses_cdc_scaling_get_and_update_flags() {
+        let ClickPipeCommands::CdcScaling {
+            command: ClickPipeCdcScalingCommands::Get { service_id, org_id },
+        } = parse_clickpipe(&["cdc-scaling", "get", "svc-get", "--org-id", "org-get"])
+        else {
+            panic!("expected CDC scaling get");
+        };
+        assert_eq!(service_id, "svc-get");
+        assert_eq!(org_id.as_deref(), Some("org-get"));
+
+        let ClickPipeCommands::CdcScaling {
+            command:
+                ClickPipeCdcScalingCommands::Update {
+                    service_id,
+                    cpu_millicores,
+                    memory_gb,
+                    org_id,
+                },
+        } = parse_clickpipe(&[
+            "cdc-scaling",
+            "update",
+            "svc-update",
+            "--cpu-millicores",
+            "32000",
+            "--memory-gb",
+            "128",
+            "--org-id",
+            "org-update",
+        ])
+        else {
+            panic!("expected CDC scaling update");
+        };
+        assert_eq!(service_id, "svc-update");
+        assert_eq!(cpu_millicores, Some(32000));
+        assert_eq!(memory_gb, Some(128.0));
+        assert_eq!(org_id.as_deref(), Some("org-update"));
+    }
+
+    #[test]
+    fn cdc_scaling_update_requires_a_target_and_enforces_schema_ranges() {
+        assert_rejected(&["cdc-scaling", "update", "svc-1"]);
+        for value in ["999", "1500", "33000"] {
+            assert_rejected(&["cdc-scaling", "update", "svc-1", "--cpu-millicores", value]);
+        }
+        for value in ["3", "6", "132", "NaN"] {
+            assert_rejected(&["cdc-scaling", "update", "svc-1", "--memory-gb", value]);
+        }
+    }
+
+    #[test]
+    fn build_cdc_scaling_request_preserves_omission() {
+        let request = build_cdc_scaling_request(&CdcScalingValues {
+            cpu_millicores: Some(1000),
+            memory_gb: None,
+        })
+        .unwrap();
+        assert_eq!(request.replica_cpu_millicores, Some(1000));
+        assert_eq!(request.replica_memory_gb, None);
+    }
+
+    #[test]
+    fn build_cdc_scaling_request_accepts_maximum_balanced_allocation() {
+        let request = build_cdc_scaling_request(&CdcScalingValues {
+            cpu_millicores: Some(32000),
+            memory_gb: Some(128.0),
+        })
+        .unwrap();
+        assert_eq!(request.replica_cpu_millicores, Some(32000));
+        assert_eq!(request.replica_memory_gb, Some(128.0));
+    }
+
+    #[test]
+    fn build_cdc_scaling_request_rejects_unbalanced_allocation() {
+        let error = build_cdc_scaling_request(&CdcScalingValues {
+            cpu_millicores: Some(2000),
+            memory_gb: Some(4.0),
+        })
+        .unwrap_err();
+        assert_eq!(
+            error.message,
+            "--memory-gb must be 8 when --cpu-millicores is 2000"
+        );
     }
 
     #[test]
@@ -7823,6 +8094,11 @@ mod tests {
         assert_write(&["stop", "svc-1", "pipe-1"], true);
         assert_write(&["resync", "svc-1", "pipe-1"], true);
         assert_write(&["scale", "svc-1", "pipe-1", "--replicas", "4"], true);
+        assert_write(&["cdc-scaling", "get", "svc-1"], false);
+        assert_write(
+            &["cdc-scaling", "update", "svc-1", "--cpu-millicores", "1000"],
+            true,
+        );
         assert_write(&["settings", "get", "svc-1", "pipe-1"], false);
         assert_write(
             &[

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -13918,6 +13918,246 @@ async fn clickpipe_scale_with_a_single_flag_sends_the_request() {
     assert_eq!(body["replicas"], 4);
 }
 
+// ── service-wide ClickPipes CDC scaling (issue #586) ───────────────────────
+
+const CDC_SCALING_PATH: &str = "/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling";
+
+fn cdc_scaling_envelope(result: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "result": result,
+        "status": 200,
+        "requestId": "stub-cdc-scaling",
+    }))
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_get_supports_oauth_and_preserves_sparse_json() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(CDC_SCALING_PATH))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(cdc_scaling_envelope(serde_json::json!({
+            "replicaCpuMillicores": 2000,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "clickpipe",
+            "cdc-scaling",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .expect("failed to run CDC scaling get with OAuth");
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({ "replicaCpuMillicores": 2000 })
+    );
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_get_prints_sparse_human_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(CDC_SCALING_PATH))
+        .respond_with(cdc_scaling_envelope(serde_json::json!({
+            "replicaMemoryGb": 8,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "clickpipe",
+            "cdc-scaling",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("replicaMemoryGb: 8"), "{stdout}");
+    assert!(!stdout.contains("replicaCpuMillicores"), "{stdout}");
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_update_preserves_omitted_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path(CDC_SCALING_PATH))
+        .and(body_json(serde_json::json!({
+            "replicaCpuMillicores": 1000,
+        })))
+        .respond_with(cdc_scaling_envelope(serde_json::json!({
+            "replicaCpuMillicores": 1000,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "cdc-scaling",
+            "update",
+            "svc-1",
+            "--cpu-millicores",
+            "1000",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({ "replicaCpuMillicores": 1000 })
+    );
+    let requests = mock.received_requests().await.unwrap();
+    let authorization = requests[0]
+        .headers
+        .get("authorization")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(authorization.starts_with("Basic "), "{authorization}");
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_update_sends_maximum_allocation() {
+    let mock = MockServer::start().await;
+    let scaling = serde_json::json!({
+        "replicaCpuMillicores": 32000,
+        "replicaMemoryGb": 128.0,
+    });
+    Mock::given(method("PATCH"))
+        .and(path(CDC_SCALING_PATH))
+        .and(body_json(scaling.clone()))
+        .respond_with(cdc_scaling_envelope(scaling.clone()))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "cdc-scaling",
+            "update",
+            "svc-1",
+            "--cpu-millicores",
+            "32000",
+            "--memory-gb",
+            "128",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        scaling
+    );
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_update_rejects_oauth_before_http() {
+    let mock = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "clickpipe",
+            "cdc-scaling",
+            "update",
+            "svc-1",
+            "--memory-gb",
+            "4",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .expect("failed to run CDC scaling update with OAuth");
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn clickpipe_cdc_scaling_get_scopes_not_found_errors_to_the_organization() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(CDC_SCALING_PATH))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "status": 404,
+            "error": "NOT_FOUND",
+            "requestId": "stub-cdc-scaling-error",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "cdc-scaling",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: NOT_FOUND: request scoped to organization org-1\n"
+    );
+}
+
 // ── the Query API gateway timeout (issue #644) ─────────────────────────────
 //
 // The gateway stops waiting after roughly 30 seconds and answers HTTP 500


### PR DESCRIPTION
Expose service-scoped CDC scaling through `cloud clickpipe cdc-scaling get|update SERVICE_ID`. Reads support OAuth, updates require API-key authentication, and update flags preserve omitted fields while validating the Cloud API's CPU, memory, increment, and CPU-to-memory ratio constraints.

The commands use the existing typed Cloud API methods, organization-aware error conversion, JSON and human detail output, and include real-binary coverage for sparse responses, both authentication paths, exact PATCH bodies, and errors.

Validation:
- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (1109 unit tests; 350 request-shape tests with 1 ignored; all local and telemetry test binaries passed)

Closes #586
