### PR TITLE
fix(service): normalize IP removal warning matches

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1537,9 +1537,14 @@ fn unmatched<'a>(requested: &'a [String], current: &HashSet<&str>) -> Vec<&'a st
         .collect()
 }
 
-/// Human-readable warnings for every `--remove-*` value on `options` that
-/// does not match anything in `current`.
-fn unmatched_removal_warnings(options: &ServiceUpdateOptions, current: &Service) -> Vec<String> {
+/// Human-readable warnings for every `--remove-*` value that does not match
+/// anything in `current`. IP entries come from the validated request so the
+/// comparison uses the same parsed source that the API receives.
+fn unmatched_removal_warnings(
+    options: &ServiceUpdateOptions,
+    validated_request: &ServicePatchRequest,
+    current: &Service,
+) -> Vec<String> {
     let mut warnings = Vec::new();
 
     let current_ip_allow: HashSet<&str> = current
@@ -1548,7 +1553,16 @@ fn unmatched_removal_warnings(options: &ServiceUpdateOptions, current: &Service)
         .flatten()
         .filter_map(|entry| entry.source.as_deref())
         .collect();
-    for value in unmatched(&options.remove_ip_allow, &current_ip_allow) {
+    let remove_ip_allow = validated_request
+        .ip_access_list
+        .as_ref()
+        .map(|patch| patch.remove.as_slice())
+        .unwrap_or_default();
+    for entry in remove_ip_allow {
+        if current_ip_allow.contains(entry.source.as_str()) {
+            continue;
+        }
+        let value = &entry.source;
         warnings.push(format!(
             "--remove-ip-allow {value} did not match any entry in the service's current IP allow list; no entry was removed"
         ));
@@ -1967,7 +1981,7 @@ async fn service_update(
 
     if has_removals(&options) {
         let current = client.get_service(&org_id, service_id).await?;
-        for warning in unmatched_removal_warnings(&options, &current) {
+        for warning in unmatched_removal_warnings(&options, &request, &current) {
             eprint_line(format!("Warning: {warning}"));
         }
     }
@@ -6476,24 +6490,53 @@ mod tests {
     fn unmatched_removal_warnings_is_empty_when_everything_matches() {
         let current = service_with_ip_allow_endpoints_and_tags();
         let options = ServiceUpdateOptions {
-            remove_ip_allow: vec!["10.0.0.0/8".to_string()],
+            remove_ip_allow: vec![" 10.0.0.0/8 =retired office".to_string()],
             remove_private_endpoint_ids: vec!["pe-1".to_string()],
             remove_tags: vec!["env".to_string()],
             ..Default::default()
         };
-        assert!(unmatched_removal_warnings(&options, &current).is_empty());
+        let request = build_update_service_request(&options).unwrap();
+        assert!(unmatched_removal_warnings(&options, &request, &current).is_empty());
+    }
+
+    #[test]
+    fn unmatched_removal_warnings_match_parsed_ipv4_and_ipv6_sources() {
+        let current = Service {
+            ip_access_list: Some(vec![
+                IpAccessListEntryResponse {
+                    source: Some("192.0.2.0/24".to_string()),
+                    description: None,
+                },
+                IpAccessListEntryResponse {
+                    source: Some("2001:db8::/32".to_string()),
+                    description: None,
+                },
+            ]),
+            ..Default::default()
+        };
+        let options = ServiceUpdateOptions {
+            remove_ip_allow: vec![
+                " 192.0.2.0/24 =old office".to_string(),
+                " 2001:db8::/32 =old ipv6 range".to_string(),
+            ],
+            ..Default::default()
+        };
+        let request = build_update_service_request(&options).unwrap();
+
+        assert!(unmatched_removal_warnings(&options, &request, &current).is_empty());
     }
 
     #[test]
     fn unmatched_removal_warnings_names_every_unmatched_entry() {
         let current = service_with_ip_allow_endpoints_and_tags();
         let options = ServiceUpdateOptions {
-            remove_ip_allow: vec!["10.99.99.99/32".to_string()],
+            remove_ip_allow: vec![" 10.99.99.99/32 =old office".to_string()],
             remove_private_endpoint_ids: vec!["pe-missing".to_string()],
             remove_tags: vec!["missing=value".to_string()],
             ..Default::default()
         };
-        let warnings = unmatched_removal_warnings(&options, &current);
+        let request = build_update_service_request(&options).unwrap();
+        let warnings = unmatched_removal_warnings(&options, &request, &current);
         assert_eq!(warnings.len(), 3);
         assert!(
             warnings[0].contains("--remove-ip-allow 10.99.99.99/32")
@@ -6516,7 +6559,8 @@ mod tests {
             remove_tags: vec!["env=staging".to_string()],
             ..Default::default()
         };
-        assert!(unmatched_removal_warnings(&options, &current).is_empty());
+        let request = build_update_service_request(&options).unwrap();
+        assert!(unmatched_removal_warnings(&options, &request, &current).is_empty());
     }
 
     #[test]
@@ -6525,7 +6569,8 @@ mod tests {
             remove_ip_allow: vec!["10.0.0.0/8".to_string()],
             ..Default::default()
         };
-        let warnings = unmatched_removal_warnings(&options, &Service::default());
+        let request = build_update_service_request(&options).unwrap();
+        let warnings = unmatched_removal_warnings(&options, &request, &Service::default());
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("--remove-ip-allow 10.0.0.0/8"));
     }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -13853,7 +13853,10 @@ async fn service_update_does_not_warn_when_remove_ip_allow_matches() {
         serde_json::json!({
             "id": "22222222-3333-4444-5555-666666666666",
             "name": "demo",
-            "ipAccessList": [{ "source": "10.0.0.0/8" }],
+            "ipAccessList": [
+                { "source": "10.0.0.0/8" },
+                { "source": "2001:db8::/32" },
+            ],
         }),
     )
     .await;
@@ -13867,7 +13870,9 @@ async fn service_update_does_not_warn_when_remove_ip_allow_matches() {
             "--org-id",
             "org-1",
             "--remove-ip-allow",
-            "10.0.0.0/8",
+            " 10.0.0.0/8 =retired office",
+            "--remove-ip-allow",
+            " 2001:db8::/32 =retired ipv6 range",
         ],
     );
 
@@ -13876,6 +13881,20 @@ async fn service_update_does_not_warn_when_remove_ip_allow_matches() {
         output.stderr.is_empty(),
         "unexpected stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    let patch = requests
+        .iter()
+        .find(|request| request.method.as_str() == "PATCH")
+        .unwrap();
+    let body: Value = serde_json::from_slice(&patch.body).unwrap();
+    assert_eq!(
+        body["ipAccessList"]["remove"],
+        serde_json::json!([
+            { "source": "10.0.0.0/8", "description": "retired office" },
+            { "source": "2001:db8::/32", "description": "retired ipv6 range" },
+        ])
     );
 }
 
@@ -15970,6 +15989,15 @@ async fn invalid_allowlist_sources_fail_before_service_or_key_requests() {
             "key-1",
             "--ip-allow",
             "not-an-ip=invalid",
+            "--org-id",
+            "org-1",
+        ],
+        vec![
+            "service",
+            "update",
+            "svc-1",
+            "--remove-ip-allow",
+            "2001:db8::/129=invalid",
             "--org-id",
             "org-1",
         ],


### PR DESCRIPTION
`cloud service update --remove-ip-allow` validated and normalized `SOURCE[=DESCRIPTION]` values for the PATCH request, but warning detection compared the original CLI text with the current service sources. A described or padded removal therefore succeeded while incorrectly reporting that no entry was removed.

Warning detection now consumes the already-validated request entries and compares their parsed `source` fields. Descriptions and surrounding source whitespace no longer cause false warnings, invalid entries still fail before any API request, and unmatched removals continue to warn through the existing output channel.

Tests cover described and padded IPv4/IPv6 matches, normalized unmatched warnings, the real CLI PATCH body and stderr behavior, and pre-network invalid-input rejection.

Validation: formatting, default clippy, no-default check and all-target clippy passed; five focused unit tests and both relevant real-binary mock tests passed.

References #589.
Follow-up correction for PR #721.
