### PR TITLE
feat(api): expose CDC table mapping engine values

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -84,6 +84,11 @@ pub enum ClickPipeBigQueryPipeTableMappingTableengine {
     Unknown(String),
 }
 
+impl ClickPipeBigQueryPipeTableMappingTableengine {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["MergeTree", "ReplacingMergeTree", "Null"];
+}
+
 impl std::fmt::Display for ClickPipeBigQueryPipeTableMappingTableengine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -377,6 +382,11 @@ pub enum ClickPipeMongoDBPipeTableMappingTableengine {
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
+}
+
+impl ClickPipeMongoDBPipeTableMappingTableengine {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["MergeTree", "ReplacingMergeTree", "Null"];
 }
 
 impl std::fmt::Display for ClickPipeMongoDBPipeTableMappingTableengine {
@@ -683,6 +693,11 @@ pub enum ClickPipeMySQLPipeTableMappingTableengine {
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
+}
+
+impl ClickPipeMySQLPipeTableMappingTableengine {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["MergeTree", "ReplacingMergeTree", "Null"];
 }
 
 impl std::fmt::Display for ClickPipeMySQLPipeTableMappingTableengine {

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -638,6 +638,30 @@ fn postgres_table_mapping_table_engines_round_trip_and_match_values() {
 }
 
 #[test]
+fn database_table_mapping_table_engines_round_trip_and_match_values() {
+    macro_rules! assert_values {
+        ($engine:ty) => {{
+            assert_eq!(
+                <$engine>::VALUES,
+                &["MergeTree", "ReplacingMergeTree", "Null"]
+            );
+            for value in <$engine>::VALUES {
+                let parsed: $engine = serde_json::from_str(&format!(r#""{value}""#)).unwrap();
+                assert_eq!(parsed.to_string(), *value);
+                assert_eq!(
+                    serde_json::to_string(&parsed).unwrap(),
+                    format!(r#""{value}""#)
+                );
+            }
+        }};
+    }
+
+    assert_values!(ClickPipeMySQLPipeTableMappingTableengine);
+    assert_values!(ClickPipeMongoDBPipeTableMappingTableengine);
+    assert_values!(ClickPipeBigQueryPipeTableMappingTableengine);
+}
+
+#[test]
 fn deserialize_activity() {
     let json = r#"{
         "actorType": "api",


### PR DESCRIPTION
The MySQL, MongoDB, and BigQuery table-mapping engine enums had no analyzer-checked value lists for CLI validation. This adds their `VALUES` constants and serialization coverage, so the analyzer can catch any divergence from the typed wire enums.

API prerequisite for #691; the CLI mapping changes follow separately.

Validation: both library/analyzer crates passed all-target clippy and their complete tests; the Python script tests and formatting checks passed.
