### PR TITLE
fix(api): preserve omitted organization role fields on update

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/rbac.rs
+++ b/crates/clickhouse-cloud-api/src/models/rbac.rs
@@ -173,7 +173,10 @@ pub struct RoleCreateRequest {
 /// `RoleUpdateRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RoleUpdateRequest {
-    pub actors: Vec<String>,
-    pub name: String,
-    pub policies: Vec<RBACPolicyCreateRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actors: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policies: Option<Vec<RBACPolicyCreateRequest>>,
 }

--- a/crates/clickhouse-cloud-api/tests/integration_org_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_org_test.rs
@@ -796,9 +796,9 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                         async move {
                             let org_resource = format!("organization/{org_id}");
                             let body = RoleUpdateRequest {
-                                name,
-                                actors: vec![],
-                                policies: vec![
+                                name: Some(name),
+                                actors: Some(vec![]),
+                                policies: Some(vec![
                                     RBACPolicyCreateRequest {
                                         allow_deny: RBACPolicyCreateRequestAllowdeny::ALLOW,
                                         permissions: org_perms,
@@ -811,7 +811,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                         resources: vec!["instance/*".to_string()],
                                         tags: None,
                                     },
-                                ],
+                                ]),
                             };
                             client
                                 .organization_role_patch(&org_id, &role_id, &body)
@@ -856,6 +856,67 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                     )
                                     .into());
                                 }
+                            }
+                            Ok(())
+                        }
+                    },
+                )
+                .await?;
+
+            // The API contract says every RoleUpdateRequest field is
+            // optional. Exercise a name-only PATCH and prove omitted actors
+            // and policies are preserved rather than replaced with defaults.
+            let role_id_clone = role_id.clone();
+            let renamed_role_name = format!("{role_name}-renamed");
+            failures
+                .run(
+                    &ctx,
+                    StepKind::NonBlocking,
+                    "rename custom role without replacing actors or policies",
+                    || {
+                        let client = client.clone();
+                        let org_id = ctx.org_id.clone();
+                        let role_id = role_id_clone;
+                        let expected_name = renamed_role_name.clone();
+                        async move {
+                            let before = client
+                                .organization_role_get(&org_id, &role_id)
+                                .await?
+                                .result
+                                .ok_or("role get before rename returned no result")?;
+                            let body = RoleUpdateRequest {
+                                name: Some(expected_name.clone()),
+                                actors: None,
+                                policies: None,
+                            };
+                            client
+                                .organization_role_patch(&org_id, &role_id, &body)
+                                .await?;
+                            let after = client
+                                .organization_role_get(&org_id, &role_id)
+                                .await?
+                                .result
+                                .ok_or("role get after rename returned no result")?;
+                            if after.name.as_deref() != Some(expected_name.as_str()) {
+                                return Err(format!(
+                                    "renamed role name mismatch: expected {expected_name}, got {:?}",
+                                    after.name
+                                )
+                                .into());
+                            }
+                            if after.actors != before.actors {
+                                return Err(format!(
+                                    "name-only role patch changed actors: before {:?}, after {:?}",
+                                    before.actors, after.actors
+                                )
+                                .into());
+                            }
+                            if after.policies != before.policies {
+                                return Err(format!(
+                                    "name-only role patch changed policies: before {:?}, after {:?}",
+                                    before.policies, after.policies
+                                )
+                                .into());
                             }
                             Ok(())
                         }

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6462,6 +6462,20 @@ fn api_key_patch_deserialization_preserves_deprecated_roles() {
 }
 
 #[test]
+fn role_update_request_omits_fields_that_are_not_being_changed() {
+    let request = RoleUpdateRequest {
+        name: Some("auditor".to_string()),
+        actors: None,
+        policies: None,
+    };
+
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        serde_json::json!({"name": "auditor"})
+    );
+}
+
+#[test]
 fn udf_request_inline_variants_preserve_determinism_and_memory() {
     fn check<T: serde::de::DeserializeOwned + serde::Serialize>(kind: &str, create: bool) {
         let mut input = serde_json::json!({"uploadId": "upload-1", "runtime": "native",

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -134,6 +134,12 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // Deprecated request fields are feature-gated out in favour of replacements.
     ("InvitationPostRequest", "role"),
     ("OrganizationPrivateEndpointsPatch", "add"),
+    // Despite its non-Patch name and descriptions that omit the "Optional"
+    // prefix, RoleUpdateRequest is used only by PATCH and the operation states
+    // that all three fields are optional and only supplied fields are changed.
+    ("RoleUpdateRequest", "actors"),
+    ("RoleUpdateRequest", "name"),
+    ("RoleUpdateRequest", "policies"),
     // PgConfig is partial: zero-value defaults fail, omission selects server defaults.
     ("PgConfig", "autovacuum_analyze_scale_factor"),
     ("PgConfig", "autovacuum_max_workers"),


### PR DESCRIPTION
`RoleUpdateRequest` required `name`, `actors`, and `policies` even though the role PATCH endpoint documents every field as optional. Callers therefore had to resend complete role state for a one-field update, risking accidental replacement of actors or policies.

This makes all three request fields optional and omits absent fields during serialization. Because the schema is named `RoleUpdateRequest` rather than `*PatchRequest`, the analyzer receives a narrow, documented optionality exemption for these exact fields. The organization lifecycle integration now performs a name-only PATCH and verifies that actors and policies remain unchanged.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `python3 scripts/check-openapi-drift.py --dry-run` (0 actionable drift)

Prerequisite for #577.
