### PR TITLE
feat(cloud): manage organization custom roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1971,9 +1971,45 @@ clickhousectl cloud clickpipe schema-discover <service-id> pubsub \
 
 Add `--json` (or run as a coding agent) for machine-readable output.
 
-### Members
+### Organization roles
 
-Role IDs used by member, invitation, and API-key commands currently come from the ClickHouse Cloud Console or API.
+List system and custom roles to discover the role IDs used by member, invitation,
+and API-key commands. Custom roles are created and updated from strict JSON files;
+pass `--config-file -` to read the body from stdin.
+
+```bash
+clickhousectl cloud org role list
+clickhousectl cloud org role get <role-id>
+
+cat > role.json <<'JSON'
+{
+  "name": "service-auditor",
+  "actors": ["user/<user-id>", "apiKey/<api-key-id>"],
+  "policies": [
+    {
+      "allowDeny": "ALLOW",
+      "permissions": ["control-plane:organization:view"],
+      "resources": ["organization/<org-id>"],
+      "tags": {
+        "grants": ["SELECT"],
+        "roleV2": "sql-console-readonly"
+      }
+    }
+  ]
+}
+JSON
+clickhousectl cloud org role create --config-file role.json
+
+# Updates are partial; actors and policies replace their complete lists when present.
+printf '%s\n' '{"name":"renamed-auditor"}' | \
+  clickhousectl cloud org role update <role-id> --config-file -
+clickhousectl cloud org role delete <role-id>
+```
+
+Only custom roles can be updated or deleted. `allowDeny` accepts `ALLOW` or
+`DENY`; `roleV2` accepts `sql-console-readonly` or `sql-console-admin`.
+
+### Members
 
 ```bash
 clickhousectl cloud member list

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -175,7 +175,7 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   User IDs come from `cloud member list`; role IDs from `cloud member list --json`
-  (the table shows role names). `update` replaces the member's whole role set.
+  or `cloud org role list`. `update` replaces the member's whole role set.
   `remove` takes effect immediately with no confirmation.
   Next: `cloud invitation create --email ...` to add someone who is not yet a member.")]
     Member {
@@ -186,7 +186,7 @@ CONTEXT FOR AGENTS:
     /// Manage organization invitations
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Role IDs come from `cloud member list --json` (roleId), not from the human table.
+  Role IDs come from `cloud org role list`.
   The invitee must accept from the email.
   Next: `cloud member list` once the invitation is accepted.")]
     Invitation {
@@ -198,7 +198,7 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   `create` prints a generated key secret exactly once — capture stdout or create a new key.
-  Role IDs come from `cloud member list --json` (roleId) and must be UUIDs here.
+  Role IDs come from `cloud org role list` and must be UUIDs here.
   `update` replaces --role-id and --ip-allow wholesale; omitted flags are left as-is.
   Next: `cloud auth login --api-key <id> --api-secret <secret>` to use a new key.")]
     Key {

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,4 +1,5 @@
 use crate::cloud::client::{CloudClient, CloudError, ResourceLookup, Result as CloudResult};
+use crate::cloud::config::read_typed_config;
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
@@ -8,7 +9,8 @@ use clickhouse_cloud_api::models::{
     ByocInfrastructurePostRequestRegionid, InvitationPostRequest, MemberPatchRequest,
     OrganizationPatchPrivateEndpoint, OrganizationPatchPrivateEndpointCloudprovider,
     OrganizationPatchPrivateEndpointRegion, OrganizationPatchRequest,
-    OrganizationPrivateEndpointsPatch,
+    OrganizationPrivateEndpointsPatch, RBACPolicyCreateRequest, RBACPolicyCreateRequestAllowdeny,
+    RBACPolicyTagsRolev2, RoleCreateRequest, RoleUpdateRequest,
 };
 use tabled::{Table, Tabled, settings::Style};
 
@@ -40,6 +42,17 @@ pub enum OrgCommands {
     Byoc {
         #[command(subcommand)]
         command: ByocCommands,
+    },
+
+    /// Manage organization roles
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Role IDs from `list` can be used with member, invitation, and API key commands.
+  Create/update read JSON request bodies from --config-file; `-` reads stdin.
+  Only custom roles can be updated or deleted.")]
+    Role {
+        #[command(subcommand)]
+        command: RoleCommands,
     },
 
     /// Update organization settings
@@ -126,9 +139,77 @@ impl OrgCommands {
             OrgCommands::Quota { .. } => false,
             OrgCommands::Balance { .. } => false,
             OrgCommands::Byoc { command } => command.is_write(),
+            OrgCommands::Role { command } => command.is_write(),
             OrgCommands::Prometheus { .. } => false,
             OrgCommands::Usage { .. } => false,
             OrgCommands::Update { .. } => true,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum RoleCommands {
+    /// List organization roles
+    List {
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Get organization role details
+    Get {
+        /// Role ID (from `cloud org role list`)
+        role_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Create a custom organization role
+    Create {
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Update a custom organization role
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Only fields present in the JSON body change; actors and policies replace their whole lists.")]
+    Update {
+        /// Role ID (from `cloud org role list`)
+        role_id: String,
+
+        /// JSON request body path, or `-` for stdin
+        #[arg(long, value_name = "PATH|-", required = true)]
+        config_file: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete a custom organization role
+    Delete {
+        /// Role ID (from `cloud org role list`)
+        role_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl RoleCommands {
+    fn is_write(&self) -> bool {
+        match self {
+            Self::List { .. } | Self::Get { .. } => false,
+            Self::Create { .. } | Self::Update { .. } | Self::Delete { .. } => true,
         }
     }
 }
@@ -349,6 +430,7 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         OrgCommands::Quota { command } => run_quota(client, command, json).await,
         OrgCommands::Balance { org_id } => org_balance(client, org_id.as_deref(), json).await,
         OrgCommands::Byoc { command } => run_byoc(client, command, json).await,
+        OrgCommands::Role { command } => run_role(client, command, json).await,
         OrgCommands::Update {
             org_id,
             name,
@@ -385,6 +467,33 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
         } => {
             let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
             org_usage(client, org_id, &from_date, &to_date, &filter, json).await
+        }
+    }
+}
+
+async fn run_role(client: &CloudClient, command: RoleCommands, json: bool) -> CloudResult<()> {
+    match command {
+        RoleCommands::List { org_id } => role_list(client, org_id.as_deref(), json).await,
+        RoleCommands::Get { role_id, org_id } => {
+            role_get(client, &role_id, org_id.as_deref(), json).await
+        }
+        RoleCommands::Create {
+            config_file,
+            org_id,
+        } => {
+            let request = build_role_create_request(&config_file)?;
+            role_create(client, request, org_id.as_deref(), json).await
+        }
+        RoleCommands::Update {
+            role_id,
+            config_file,
+            org_id,
+        } => {
+            let request = build_role_update_request(&config_file)?;
+            role_update(client, &role_id, request, org_id.as_deref(), json).await
+        }
+        RoleCommands::Delete { role_id, org_id } => {
+            role_delete(client, &role_id, org_id.as_deref(), json).await
         }
     }
 }
@@ -641,6 +750,48 @@ fn build_byoc_update_request(display_name: &str) -> ByocInfrastructurePatchReque
     }
 }
 
+fn invalid_role_request(source: &str, message: impl std::fmt::Display) -> CloudError {
+    CloudError::new(format!(
+        "invalid request body in config {source}: {message}"
+    ))
+}
+
+fn validate_role_policies(policies: &[RBACPolicyCreateRequest], source: &str) -> CloudResult<()> {
+    for (index, policy) in policies.iter().enumerate() {
+        if let RBACPolicyCreateRequestAllowdeny::Unknown(value) = &policy.allow_deny {
+            return Err(invalid_role_request(
+                source,
+                format!("unknown policies[{index}].allowDeny `{value}`; expected ALLOW or DENY"),
+            ));
+        }
+        if let Some(tags) = &policy.tags
+            && let Some(RBACPolicyTagsRolev2::Unknown(value)) = &tags.role_v2
+        {
+            return Err(invalid_role_request(
+                source,
+                format!(
+                    "unknown policies[{index}].tags.roleV2 `{value}`; expected sql-console-readonly or sql-console-admin"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn build_role_create_request(config_file: &str) -> CloudResult<RoleCreateRequest> {
+    let request: RoleCreateRequest = read_typed_config(config_file)?;
+    validate_role_policies(&request.policies, config_file)?;
+    Ok(request)
+}
+
+fn build_role_update_request(config_file: &str) -> CloudResult<RoleUpdateRequest> {
+    let request: RoleUpdateRequest = read_typed_config(config_file)?;
+    if let Some(policies) = &request.policies {
+        validate_role_policies(policies, config_file)?;
+    }
+    Ok(request)
+}
+
 fn build_member_update_request(role_ids: &[String], clear_roles: bool) -> MemberPatchRequest {
     MemberPatchRequest {
         assigned_role_ids: if clear_roles {
@@ -891,6 +1042,123 @@ async fn byoc_delete(
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
         println!("BYOC infrastructure {byoc_id} deleted");
+    }
+    Ok(())
+}
+
+async fn role_list(client: &CloudClient, org_id: Option<&str>, json: bool) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let roles = client.list_organization_roles(&org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&roles)?);
+    } else {
+        if roles.is_empty() {
+            println!("No organization roles found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Name")]
+            name: String,
+            #[tabled(rename = "ID")]
+            id: String,
+            #[tabled(rename = "Type")]
+            role_type: String,
+            #[tabled(rename = "Actors")]
+            actors: String,
+            #[tabled(rename = "Policies")]
+            policies: String,
+        }
+        let rows = roles
+            .into_iter()
+            .map(|role| Row {
+                name: or_absent(role.name.as_deref()),
+                id: or_absent(role.id.as_deref()),
+                role_type: or_absent(role.r#type.as_ref()),
+                actors: role
+                    .actors
+                    .as_ref()
+                    .map(|actors| actors.len().to_string())
+                    .unwrap_or_else(|| ABSENT.to_string()),
+                policies: role
+                    .policies
+                    .as_ref()
+                    .map(|policies| policies.len().to_string())
+                    .unwrap_or_else(|| ABSENT.to_string()),
+            })
+            .collect::<Vec<_>>();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn role_get(
+    client: &CloudClient,
+    role_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let role = client.get_organization_role(&org_id, role_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&role)?);
+    } else {
+        print_human(&role)?;
+    }
+    Ok(())
+}
+
+async fn role_create(
+    client: &CloudClient,
+    request: RoleCreateRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let role = client.create_organization_role(&org_id, &request).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&role)?);
+    } else {
+        print_human(&role)?;
+    }
+    Ok(())
+}
+
+async fn role_update(
+    client: &CloudClient,
+    role_id: &str,
+    request: RoleUpdateRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let role = client
+        .update_organization_role(&org_id, role_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&role)?);
+    } else {
+        print_human(&role)?;
+    }
+    Ok(())
+}
+
+async fn role_delete(
+    client: &CloudClient,
+    role_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_organization_role(&org_id, role_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Organization role {role_id} deleted");
     }
     Ok(())
 }
@@ -1327,6 +1595,74 @@ impl CloudClient {
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
+    }
+
+    pub async fn list_organization_roles(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::RBACRole>> {
+        let response = self
+            .api()
+            .organization_roles_get_list(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_organization_role(
+        &self,
+        org_id: &str,
+        role_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::RBACRole> {
+        let response = self
+            .api()
+            .organization_role_get(org_id, role_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn create_organization_role(
+        &self,
+        org_id: &str,
+        request: &RoleCreateRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::RBACRole> {
+        let response = self
+            .api()
+            .organization_role_post(org_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_organization_role(
+        &self,
+        org_id: &str,
+        role_id: &str,
+        request: &RoleUpdateRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::RBACRole> {
+        let response = self
+            .api()
+            .organization_role_patch(org_id, role_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_organization_role(
+        &self,
+        org_id: &str,
+        role_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .organization_role_delete(org_id, role_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
     }
 
     pub async fn list_members(
@@ -2399,5 +2735,149 @@ mod tests {
             serde_json::to_value(update).unwrap(),
             serde_json::json!({"displayName": "renamed"})
         );
+    }
+
+    #[test]
+    fn parses_role_body_commands_and_classifies_access() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "role",
+            "create",
+            "--config-file",
+            "role.json",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Role {
+            command:
+                RoleCommands::Create {
+                    config_file,
+                    org_id,
+                },
+        } = command
+        else {
+            panic!("expected role create");
+        };
+        assert_eq!(config_file, "role.json");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        assert_write(&["clickhousectl", "cloud", "org", "role", "list"], false);
+        assert_write(
+            &["clickhousectl", "cloud", "org", "role", "get", "role-1"],
+            false,
+        );
+        for verb in ["create", "update", "delete"] {
+            let mut args = vec!["clickhousectl", "cloud", "org", "role", verb];
+            if verb != "create" {
+                args.push("role-1");
+            }
+            if verb != "delete" {
+                args.extend(["--config-file", "role.json"]);
+            }
+            assert_write(&args, true);
+        }
+    }
+
+    #[test]
+    fn role_builders_preserve_minimal_and_maximal_bodies() {
+        let directory = tempfile::tempdir().unwrap();
+        let create_file = directory.path().join("create.json");
+        std::fs::write(
+            &create_file,
+            r#"{"name":"reader","actors":[],"policies":[]}"#,
+        )
+        .unwrap();
+        let minimal = build_role_create_request(create_file.to_str().unwrap()).unwrap();
+        assert_eq!(minimal.name, "reader");
+        assert!(minimal.actors.is_empty());
+        assert!(minimal.policies.is_empty());
+
+        std::fs::write(
+            &create_file,
+            serde_json::json!({
+                "name": "console-admin",
+                "actors": ["user/user-1", "apiKey/key-1"],
+                "policies": [{
+                    "allowDeny": "DENY",
+                    "permissions": ["control-plane:organization:update"],
+                    "resources": ["organization/org-1", "instance/*"],
+                    "tags": {
+                        "grants": ["select", "insert"],
+                        "roleV2": "sql-console-admin"
+                    }
+                }, {
+                    "allowDeny": "ALLOW",
+                    "permissions": ["control-plane:service:view"],
+                    "resources": ["instance/*"]
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let maximal = build_role_create_request(create_file.to_str().unwrap()).unwrap();
+        assert_eq!(maximal.actors.len(), 2);
+        assert_eq!(maximal.policies.len(), 2);
+        let policy = &maximal.policies[0];
+        assert_eq!(policy.allow_deny, RBACPolicyCreateRequestAllowdeny::DENY);
+        let tags = policy.tags.as_ref().unwrap();
+        assert_eq!(
+            tags.grants.as_deref(),
+            Some(&["select".into(), "insert".into()][..])
+        );
+        assert_eq!(tags.role_v2, Some(RBACPolicyTagsRolev2::Sql_console_admin));
+
+        let update_file = directory.path().join("update.json");
+        std::fs::write(&update_file, r#"{"name":"renamed"}"#).unwrap();
+        let minimal_update = build_role_update_request(update_file.to_str().unwrap()).unwrap();
+        assert_eq!(minimal_update.name.as_deref(), Some("renamed"));
+        assert!(minimal_update.actors.is_none());
+        assert!(minimal_update.policies.is_none());
+
+        std::fs::write(
+            &update_file,
+            serde_json::json!({
+                "name": "full-update",
+                "actors": [],
+                "policies": [{
+                    "allowDeny": "ALLOW",
+                    "permissions": [],
+                    "resources": [],
+                    "tags": {"grants": [], "roleV2": "sql-console-readonly"}
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let maximal_update = build_role_update_request(update_file.to_str().unwrap()).unwrap();
+        assert_eq!(maximal_update.actors, Some(vec![]));
+        assert_eq!(maximal_update.policies.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn role_builders_reject_unknown_nested_fields_and_enums() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_file = directory.path().join("role.json");
+        for (body, expected) in [
+            (
+                serde_json::json!({"name":"bad","actors":[],"policies":[{"allowDeny":"ALLOW","permissions":[],"resources":[],"tagz":{}}]}),
+                "tagz",
+            ),
+            (
+                serde_json::json!({"name":"bad","actors":[],"policies":[{"allowDeny":"AUDIT","permissions":[],"resources":[]}]}),
+                "allowDeny",
+            ),
+            (
+                serde_json::json!({"name":"bad","actors":[],"policies":[{"allowDeny":"ALLOW","permissions":[],"resources":[],"tags":{"roleV2":"future-role"}}]}),
+                "roleV2",
+            ),
+        ] {
+            std::fs::write(&config_file, body.to_string()).unwrap();
+            let error = build_role_create_request(config_file.to_str().unwrap()).unwrap_err();
+            assert!(error.message.contains(expected), "{error}");
+        }
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -241,6 +241,39 @@ fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> st
         .expect("failed to spawn clickhousectl")
 }
 
+fn invoke_cli_with_cloud_credentials_and_stdin(
+    mock: &MockServer,
+    cli_args: &[&str],
+    stdin: &str,
+) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = mock.uri();
+    let mut args = vec!["cloud", "--url", &url, "--json"];
+    args.extend(cli_args);
+    let mut child = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+    child
+        .stdin
+        .take()
+        .expect("stdin pipe")
+        .write_all(stdin.as_bytes())
+        .expect("write clickhousectl stdin");
+    child.wait_with_output().expect("wait for clickhousectl")
+}
+
 fn invoke_cli_with_cloud_credentials_human(
     mock: &MockServer,
     cli_args: &[&str],
@@ -391,6 +424,280 @@ async fn org_balance_human_output_handles_empty_balances() {
         String::from_utf8_lossy(&output.stdout),
         "Total remaining credits: 0 CHC\nNo active credit balances found\n"
     );
+}
+
+const ORG_ROLES_PATH: &str = "/v1/organizations/org-1/roles";
+const BASIC_TEST_AUTH: &str = "Basic ZmFrZS1rZXktZm9yLXRlc3RzOmZha2Utc2VjcmV0LWZvci10ZXN0cw==";
+
+fn organization_role_envelope(result: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "result": result,
+        "status": 200,
+        "requestId": "stub-org-role"
+    }))
+}
+
+#[tokio::test]
+async fn organization_role_writes_use_expected_routes_auth_and_bodies() {
+    let mock = MockServer::start().await;
+    let create_body = serde_json::json!({
+        "name": "auditor",
+        "actors": ["user/user-1", "apiKey/key-1"],
+        "policies": [{
+            "allowDeny": "ALLOW",
+            "permissions": ["control-plane:organization:view"],
+            "resources": ["organization/org-1"],
+            "tags": {
+                "grants": ["SELECT"],
+                "roleV2": "sql-console-readonly"
+            }
+        }]
+    });
+    Mock::given(method("POST"))
+        .and(path(ORG_ROLES_PATH))
+        .and(header("authorization", BASIC_TEST_AUTH))
+        .and(body_json(create_body.clone()))
+        .respond_with(organization_role_envelope(serde_json::json!({
+            "id": "role-1",
+            "name": "auditor",
+            "type": "custom"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let directory = tempfile::tempdir().unwrap();
+    let config_file = directory.path().join("role.json");
+    std::fs::write(&config_file, create_body.to_string()).unwrap();
+    let create = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "org",
+            "role",
+            "create",
+            "--config-file",
+            config_file.to_str().unwrap(),
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&create);
+
+    let update_body = serde_json::json!({"name": "renamed"});
+    Mock::given(method("PATCH"))
+        .and(path(format!("{ORG_ROLES_PATH}/role-1")))
+        .and(header("authorization", BASIC_TEST_AUTH))
+        .and(body_json(update_body.clone()))
+        .respond_with(organization_role_envelope(serde_json::json!({
+            "id": "role-1",
+            "name": "renamed",
+            "type": "custom"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let update = invoke_cli_with_cloud_credentials_and_stdin(
+        &mock,
+        &[
+            "org",
+            "role",
+            "update",
+            "role-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        &update_body.to_string(),
+    );
+    assert_success(&update);
+
+    Mock::given(method("DELETE"))
+        .and(path(format!("{ORG_ROLES_PATH}/role-1")))
+        .and(header("authorization", BASIC_TEST_AUTH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "stub-role-delete"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let delete = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["org", "role", "delete", "role-1", "--org-id", "org-1"],
+    );
+    assert_success(&delete);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&delete.stdout).unwrap(),
+        serde_json::json!({"status": 200, "requestId": "stub-role-delete"})
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 3);
+    assert!(requests.iter().all(|request| request.url.query().is_none()));
+}
+
+#[tokio::test]
+async fn organization_role_reads_support_oauth_and_writes_fail_before_http() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ORG_ROLES_PATH))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(organization_role_envelope(serde_json::json!([
+            {"id": "role-1", "name": "reader", "type": "custom"}
+        ])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{ORG_ROLES_PATH}/role-1")))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(organization_role_envelope(serde_json::json!({
+            "id": "role-1", "name": "reader", "type": "custom"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let invoke = |args: &[&str], stdin: Option<&str>| {
+        let mut command = Command::new(clickhousectl_binary());
+        clear_inherited_env(&mut command);
+        command
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", &home)
+            .current_dir(project.path())
+            .args(["cloud", "--url", &mock.uri(), "--json"])
+            .args(args);
+        if let Some(input) = stdin {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(input.as_bytes())
+                .unwrap();
+            child.wait_with_output().unwrap()
+        } else {
+            command.output().unwrap()
+        }
+    };
+    assert_success(&invoke(&["org", "role", "list", "--org-id", "org-1"], None));
+    assert_success(&invoke(
+        &["org", "role", "get", "role-1", "--org-id", "org-1"],
+        None,
+    ));
+    let write = invoke(
+        &[
+            "org",
+            "role",
+            "create",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        Some(r#"{"name":"x","actors":[],"policies":[]}"#),
+    );
+    assert_eq!(write.status.code(), Some(4));
+    assert!(String::from_utf8_lossy(&write.stderr).contains("API key"));
+    assert_eq!(mock.received_requests().await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn organization_role_human_output_handles_sparse_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(ORG_ROLES_PATH))
+        .respond_with(organization_role_envelope(serde_json::json!([
+            {},
+            {"id": "system-1", "name": "admin", "type": "system"},
+            {"id": "role-1", "name": "reader", "type": "custom"}
+        ])))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("{ORG_ROLES_PATH}/role-sparse")))
+        .respond_with(organization_role_envelope(serde_json::json!({})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let list = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &["org", "role", "list", "--org-id", "org-1"],
+    );
+    assert_success(&list);
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    for heading in ["Name", "ID", "Type", "Actors", "Policies"] {
+        assert!(
+            stdout.contains(heading),
+            "missing {heading} column:\n{stdout}"
+        );
+    }
+    assert!(stdout.contains("| -"), "{stdout}");
+    assert!(stdout.contains("| admin  | system-1 | system"), "{stdout}");
+    assert!(stdout.contains("| reader | role-1   | custom"), "{stdout}");
+
+    let get = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &["org", "role", "get", "role-sparse", "--org-id", "org-1"],
+    );
+    assert_success(&get);
+}
+
+#[tokio::test]
+async fn organization_role_get_preserves_404_detail() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{ORG_ROLES_PATH}/missing")))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "status": 404,
+            "error": "role not found",
+            "requestId": "stub-role-not-found"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &["org", "role", "get", "missing", "--org-id", "org-1"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("role not found"), "{stderr}");
+}
+
+#[tokio::test]
+async fn organization_role_create_rejects_invalid_nested_config_before_http() {
+    let mock = MockServer::start().await;
+    let output = invoke_cli_with_cloud_credentials_and_stdin(
+        &mock,
+        &[
+            "org",
+            "role",
+            "create",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        r#"{"name":"bad","actors":[],"policies":[{"allowDeny":"AUDIT","permissions":[],"resources":[],"tagz":{}}]}"#,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("tagz"), "{stderr}");
+    assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Organization role IDs were required by member, invitation, and API-key commands, but the CLI could neither discover nor manage those roles. This adds `cloud org role list|get|create|update|delete` over the five existing GA API methods.

Create and update accept the complete typed role request as a JSON file or stdin, including actors, multiple policies, ALLOW/DENY, resources, permissions, grants, and roleV2 tags. Input rejects unknown fields at every nesting level and rejects unknown enum values before HTTP. Updates are partial: omitted fields stay unchanged, while supplied actor and policy arrays replace their complete lists. List/get support OAuth; writes fail fast unless API-key authentication is active. Human output preserves the system/custom distinction and tolerates sparse responses, while JSON output returns the typed API data.

The README now documents role discovery and a complete nested custom-role workflow, and member/invitation/key help points to `cloud org role list` for role IDs.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl`

Closes #577.
