### PR TITLE
feat(cloud): manage service backup buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,52 @@ Use `clickhousectl cloud postgres create --help` for the complete option list. S
 ```bash
 clickhousectl cloud backup list <service-id>
 clickhousectl cloud backup get <service-id> <backup-id>
+
+# Inspect or remove the service's bring-your-own backup bucket
+clickhousectl cloud backup bucket get <service-id>
+clickhousectl cloud backup bucket delete <service-id>
 ```
+
+The backup-bucket commands use the beta Cloud API. Create and update a bucket from a strict provider-specific JSON document. Pass a file path to `--config-file`, or `-` to read JSON from stdin so credentials do not appear in the process arguments. The provider must be exactly `AWS`, `GCP`, or `AZURE`; unknown and cross-provider fields are rejected before the request is sent.
+
+```json
+{
+  "bucketProvider": "AWS",
+  "bucketPath": "s3://company-backups/clickhouse",
+  "iamRoleArn": "arn:aws:iam::123456789012:role/clickhouse-backups",
+  "iamRoleSessionName": "clickhouse-cloud"
+}
+```
+
+```json
+{
+  "bucketProvider": "GCP",
+  "bucketPath": "gs://company-backups/clickhouse",
+  "accessKeyId": "<access-key-id>",
+  "secretAccessKey": "<secret-access-key>"
+}
+```
+
+```json
+{
+  "bucketProvider": "AZURE",
+  "containerName": "clickhouse-backups",
+  "connectionString": "<azure-storage-connection-string>"
+}
+```
+
+Save one object as a permissions-restricted file, then use it for the matching operation:
+
+```bash
+chmod 600 backup-bucket.json
+clickhousectl cloud backup bucket create <service-id> --config-file backup-bucket.json
+clickhousectl cloud backup bucket update <service-id> --config-file backup-bucket.json
+
+# Or keep the document out of a named file
+generate-backup-bucket-json | clickhousectl cloud backup bucket create <service-id> --config-file -
+```
+
+`update` calls the API's PATCH operation, but its provider schema still requires every field shown above except AWS `iamRoleSessionName`, which is optional on update. AWS create requires that session name. GCP and Azure credentials must be supplied again on every update; no bucket ID argument is used because each service has one backup-bucket resource.
 
 ### ClickPipes
 

--- a/crates/clickhousectl/src/cloud/backups.rs
+++ b/crates/clickhousectl/src/cloud/backups.rs
@@ -1,8 +1,16 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::config::{deserialize_strict_config, read_config_value};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::resolve_org_id;
+use crate::cloud::types::DeleteResponse;
 use clap::Subcommand;
-use clickhouse_cloud_api::models::BackupConfigurationPatchRequest;
+use clickhouse_cloud_api::models::{
+    AwsBackupBucketPatchRequestV1, AwsBackupBucketPostRequestV1, AzureBackupBucketPatchRequestV1,
+    AzureBackupBucketPostRequestV1, BackupBucket, BackupBucketPatchRequest,
+    BackupBucketPostRequest, BackupConfigurationPatchRequest, GcpBackupBucketPatchRequestV1,
+    GcpBackupBucketPostRequestV1,
+};
+use serde_json::Value;
 use tabled::{Table, Tabled, settings::Style};
 
 #[derive(Subcommand)]
@@ -29,6 +37,10 @@ pub enum BackupCommands {
         #[arg(long)]
         org_id: Option<String>,
     },
+
+    /// Manage a service backup bucket
+    #[command(subcommand)]
+    Bucket(BackupBucketCommands),
 }
 
 impl BackupCommands {
@@ -36,6 +48,69 @@ impl BackupCommands {
         match self {
             BackupCommands::List { .. } => false,
             BackupCommands::Get { .. } => false,
+            BackupCommands::Bucket(command) => command.is_write(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum BackupBucketCommands {
+    /// Get backup bucket details
+    Get {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Create a backup bucket
+    Create {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+
+        /// Provider-specific JSON file, or - to read from stdin
+        #[arg(long, value_name = "PATH", alias = "config")]
+        config_file: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Update a backup bucket
+    Update {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+
+        /// Provider-specific update JSON file, or - to read from stdin
+        #[arg(long, value_name = "PATH", alias = "config")]
+        config_file: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete a backup bucket
+    Delete {
+        /// Service ID (from `cloud service list`)
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl BackupBucketCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            BackupBucketCommands::Get { .. } => false,
+            BackupBucketCommands::Create { .. }
+            | BackupBucketCommands::Update { .. }
+            | BackupBucketCommands::Delete { .. } => true,
         }
     }
 }
@@ -106,6 +181,40 @@ pub async fn run(client: &CloudClient, command: BackupCommands, json: bool) -> C
             backup_id,
             org_id,
         } => backup_get(client, &service_id, &backup_id, org_id.as_deref(), json).await,
+        BackupCommands::Bucket(command) => run_bucket(client, command, json).await,
+    }
+}
+
+async fn run_bucket(
+    client: &CloudClient,
+    command: BackupBucketCommands,
+    json: bool,
+) -> CloudResult<()> {
+    match command {
+        BackupBucketCommands::Get { service_id, org_id } => {
+            backup_bucket_get(client, &service_id, org_id.as_deref(), json).await
+        }
+        BackupBucketCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request =
+                build_backup_bucket_create_request(read_config_value(&config_file)?, &config_file)?;
+            backup_bucket_create(client, &service_id, request, org_id.as_deref(), json).await
+        }
+        BackupBucketCommands::Update {
+            service_id,
+            config_file,
+            org_id,
+        } => {
+            let request =
+                build_backup_bucket_update_request(read_config_value(&config_file)?, &config_file)?;
+            backup_bucket_update(client, &service_id, request, org_id.as_deref(), json).await
+        }
+        BackupBucketCommands::Delete { service_id, org_id } => {
+            backup_bucket_delete(client, &service_id, org_id.as_deref(), json).await
+        }
     }
 }
 
@@ -215,6 +324,64 @@ fn check_stored_period_allows_start_time(stored_period_hours: Option<f64>) -> Cl
     }
 }
 
+fn bucket_provider<'a>(value: &'a Value, source: &str) -> CloudResult<&'a str> {
+    value
+        .as_object()
+        .ok_or_else(|| {
+            CloudError::new(format!(
+                "invalid request body in config {source}: expected a JSON object"
+            ))
+        })?
+        .get("bucketProvider")
+        .ok_or_else(|| {
+            CloudError::new(format!(
+                "invalid request body in config {source}: missing field `bucketProvider`"
+            ))
+        })?
+        .as_str()
+        .ok_or_else(|| {
+            CloudError::new(format!(
+                "invalid request body in config {source}: `bucketProvider` must be a string"
+            ))
+        })
+}
+
+fn unsupported_bucket_provider(source: &str, provider: &str) -> CloudError {
+    CloudError::new(format!(
+        "invalid request body in config {source}: unsupported `bucketProvider` {provider:?}; expected AWS, GCP, or AZURE"
+    ))
+}
+
+fn build_backup_bucket_create_request(
+    value: Value,
+    source: &str,
+) -> CloudResult<BackupBucketPostRequest> {
+    match bucket_provider(&value, source)? {
+        "AWS" => deserialize_strict_config::<AwsBackupBucketPostRequestV1>(value, source)
+            .map(BackupBucketPostRequest::AwsBackupBucketPostRequestV1),
+        "GCP" => deserialize_strict_config::<GcpBackupBucketPostRequestV1>(value, source)
+            .map(BackupBucketPostRequest::GcpBackupBucketPostRequestV1),
+        "AZURE" => deserialize_strict_config::<AzureBackupBucketPostRequestV1>(value, source)
+            .map(BackupBucketPostRequest::AzureBackupBucketPostRequestV1),
+        provider => Err(unsupported_bucket_provider(source, provider)),
+    }
+}
+
+fn build_backup_bucket_update_request(
+    value: Value,
+    source: &str,
+) -> CloudResult<BackupBucketPatchRequest> {
+    match bucket_provider(&value, source)? {
+        "AWS" => deserialize_strict_config::<AwsBackupBucketPatchRequestV1>(value, source)
+            .map(BackupBucketPatchRequest::AwsBackupBucketPatchRequestV1),
+        "GCP" => deserialize_strict_config::<GcpBackupBucketPatchRequestV1>(value, source)
+            .map(BackupBucketPatchRequest::GcpBackupBucketPatchRequestV1),
+        "AZURE" => deserialize_strict_config::<AzureBackupBucketPatchRequestV1>(value, source)
+            .map(BackupBucketPatchRequest::AzureBackupBucketPatchRequestV1),
+        provider => Err(unsupported_bucket_provider(source, provider)),
+    }
+}
+
 async fn backup_list(
     client: &CloudClient,
     service_id: &str,
@@ -270,6 +437,80 @@ async fn backup_get(
         println!("{}", serde_json::to_string_pretty(&backup)?);
     } else {
         print_human(&backup)?;
+    }
+    Ok(())
+}
+
+async fn backup_bucket_get(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let bucket = client.get_backup_bucket(&org_id, service_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&bucket)?);
+    } else {
+        print_human(&bucket)?;
+    }
+    Ok(())
+}
+
+async fn backup_bucket_create(
+    client: &CloudClient,
+    service_id: &str,
+    request: BackupBucketPostRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let bucket = client
+        .create_backup_bucket(&org_id, service_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&bucket)?);
+    } else {
+        print_human(&bucket)?;
+    }
+    Ok(())
+}
+
+async fn backup_bucket_update(
+    client: &CloudClient,
+    service_id: &str,
+    request: BackupBucketPatchRequest,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let bucket = client
+        .update_backup_bucket(&org_id, service_id, &request)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&bucket)?);
+    } else {
+        print_human(&bucket)?;
+    }
+    Ok(())
+}
+
+async fn backup_bucket_delete(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_backup_bucket(&org_id, service_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Backup bucket deleted for service {service_id}");
     }
     Ok(())
 }
@@ -376,6 +617,63 @@ impl CloudClient {
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
+    }
+
+    pub async fn get_backup_bucket(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<BackupBucket> {
+        let response = self
+            .api()
+            .backup_bucket_get(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn create_backup_bucket(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &BackupBucketPostRequest,
+    ) -> crate::cloud::client::Result<BackupBucket> {
+        let response = self
+            .api()
+            .backup_bucket_create(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_backup_bucket(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &BackupBucketPatchRequest,
+    ) -> crate::cloud::client::Result<BackupBucket> {
+        let response = self
+            .api()
+            .backup_bucket_update(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_backup_bucket(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .backup_bucket_delete(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
     }
 
     pub async fn get_backup_config(
@@ -611,6 +909,183 @@ mod tests {
             ])
             .is_write()
         );
+        assert!(
+            !parse_backup(&["clickhousectl", "cloud", "backup", "bucket", "get", "svc-1",])
+                .is_write()
+        );
+        for action in ["create", "update"] {
+            assert!(
+                parse_backup(&[
+                    "clickhousectl",
+                    "cloud",
+                    "backup",
+                    "bucket",
+                    action,
+                    "svc-1",
+                    "--config-file",
+                    "bucket.json",
+                ])
+                .is_write()
+            );
+        }
+        assert!(
+            parse_backup(&[
+                "clickhousectl",
+                "cloud",
+                "backup",
+                "bucket",
+                "delete",
+                "svc-1",
+            ])
+            .is_write()
+        );
+    }
+
+    #[test]
+    fn parses_backup_bucket_config_input() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "backup",
+            "bucket",
+            "create",
+            "svc-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Backup { command } = args.command else {
+            panic!("expected backup command");
+        };
+        let BackupCommands::Bucket(BackupBucketCommands::Create {
+            service_id,
+            config_file,
+            org_id,
+        }) = command
+        else {
+            panic!("expected backup bucket create");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(config_file, "-");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn builds_all_backup_bucket_create_variants() {
+        let cases = [
+            serde_json::json!({
+                "bucketProvider": "AWS",
+                "bucketPath": "s3://backups/prefix",
+                "iamRoleArn": "arn:aws:iam::123456789012:role/backups",
+                "iamRoleSessionName": "clickhouse-cloud",
+            }),
+            serde_json::json!({
+                "bucketProvider": "GCP",
+                "bucketPath": "gs://backups/prefix",
+                "accessKeyId": "gcp-access-key",
+                "secretAccessKey": "gcp-secret-key",
+            }),
+            serde_json::json!({
+                "bucketProvider": "AZURE",
+                "containerName": "backups",
+                "connectionString": "DefaultEndpointsProtocol=https;AccountName=account",
+            }),
+        ];
+
+        for expected in cases {
+            let request =
+                build_backup_bucket_create_request(expected.clone(), "test input").unwrap();
+            assert_eq!(serde_json::to_value(request).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn builds_all_backup_bucket_update_variants() {
+        let cases = [
+            serde_json::json!({
+                "bucketProvider": "AWS",
+                "bucketPath": "s3://backups/new-prefix",
+                "iamRoleArn": "arn:aws:iam::123456789012:role/backups",
+            }),
+            serde_json::json!({
+                "bucketProvider": "AWS",
+                "bucketPath": "s3://backups/new-prefix",
+                "iamRoleArn": "arn:aws:iam::123456789012:role/backups",
+                "iamRoleSessionName": "rotated-session",
+            }),
+            serde_json::json!({
+                "bucketProvider": "GCP",
+                "bucketPath": "gs://backups/new-prefix",
+                "accessKeyId": "new-gcp-access-key",
+                "secretAccessKey": "new-gcp-secret-key",
+            }),
+            serde_json::json!({
+                "bucketProvider": "AZURE",
+                "containerName": "new-backups",
+                "connectionString": "DefaultEndpointsProtocol=https;AccountName=new-account",
+            }),
+        ];
+
+        for expected in cases {
+            let request =
+                build_backup_bucket_update_request(expected.clone(), "test input").unwrap();
+            assert_eq!(serde_json::to_value(request).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn backup_bucket_create_requires_every_provider_field() {
+        let cases = [
+            serde_json::json!({
+                "bucketProvider": "AWS",
+                "bucketPath": "s3://backups",
+                "iamRoleArn": "arn:aws:iam::123456789012:role/backups",
+            }),
+            serde_json::json!({
+                "bucketProvider": "GCP",
+                "bucketPath": "gs://backups",
+                "accessKeyId": "key",
+            }),
+            serde_json::json!({
+                "bucketProvider": "AZURE",
+                "containerName": "backups",
+            }),
+        ];
+
+        for value in cases {
+            assert!(build_backup_bucket_create_request(value, "test input").is_err());
+        }
+    }
+
+    #[test]
+    fn backup_bucket_input_rejects_unknown_providers_and_fields() {
+        let unknown_provider = build_backup_bucket_create_request(
+            serde_json::json!({"bucketProvider": "S3"}),
+            "test input",
+        )
+        .unwrap_err();
+        assert!(
+            unknown_provider
+                .message
+                .contains("expected AWS, GCP, or AZURE")
+        );
+
+        let contradictory_field = build_backup_bucket_update_request(
+            serde_json::json!({
+                "bucketProvider": "AZURE",
+                "containerName": "backups",
+                "connectionString": "secret",
+                "bucketPath": "s3://wrong-provider",
+            }),
+            "test input",
+        )
+        .unwrap_err();
+        assert!(contradictory_field.message.contains("bucketPath"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -129,10 +129,12 @@ CONTEXT FOR AGENTS:
         command: ServiceCommands,
     },
 
-    /// View service backups
+    /// Manage service backups and backup buckets
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Service IDs come from `cloud service list`; backup IDs from `cloud backup list <service-id>`.
+  Backup list/get and bucket get support OAuth; bucket writes require API key auth.
+  Bucket create/update read strict provider JSON from `--config-file`, with `-` for stdin.
   Restore a backup into a new service: `cloud service create --backup-id <backup-id>`.
   Change schedule or retention with `cloud service backup-config update`, not here.")]
     Backup {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -991,6 +991,280 @@ async fn backup_config_rejects_incompatible_period_before_any_request() {
     assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
+// ── Bring-your-own backup buckets (issue #576) ─────────────────────────────
+
+const BACKUP_BUCKET_PATH: &str = "/v1/organizations/org-1/services/svc-1/backupBucket";
+const TEST_BASIC_AUTH: &str = "Basic ZmFrZS1rZXktZm9yLXRlc3RzOmZha2Utc2VjcmV0LWZvci10ZXN0cw==";
+
+#[tokio::test]
+async fn backup_bucket_get_uses_oauth_and_preserves_sparse_output() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(BACKUP_BUCKET_PATH))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "bucketProvider": "AWS" },
+            "status": 200,
+            "requestId": "bucket-get",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "backup",
+            "bucket",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .expect("run backup bucket get");
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({ "bucketProvider": "AWS" })
+    );
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].url.query().is_none());
+}
+
+#[tokio::test]
+async fn backup_bucket_create_reads_secret_from_stdin_and_sends_exact_gcp_body() {
+    let mock = MockServer::start().await;
+    let expected = serde_json::json!({
+        "bucketProvider": "GCP",
+        "bucketPath": "gs://company-backups/clickhouse",
+        "accessKeyId": "gcp-access",
+        "secretAccessKey": "gcp-secret",
+    });
+    Mock::given(method("POST"))
+        .and(path(BACKUP_BUCKET_PATH))
+        .and(header("authorization", TEST_BASIC_AUTH))
+        .and(body_json(expected.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "bucketProvider": "GCP",
+                "bucketPath": "gs://company-backups/clickhouse",
+                "accessKeyId": "gcp-access"
+            },
+            "status": 200,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let body = invoke_cli_capture_body_with_stdin(
+        &mock,
+        &[
+            "backup",
+            "bucket",
+            "create",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--config-file",
+            "-",
+        ],
+        serde_json::to_string(&expected).unwrap().as_bytes(),
+    )
+    .await;
+    assert_eq!(body, expected);
+}
+
+#[tokio::test]
+async fn backup_bucket_update_reads_file_and_delete_use_the_service_resource_path() {
+    let mock = MockServer::start().await;
+    let expected = serde_json::json!({
+        "bucketProvider": "AZURE",
+        "containerName": "backups",
+        "connectionString": "DefaultEndpointsProtocol=https;AccountName=company",
+    });
+    Mock::given(method("PATCH"))
+        .and(path(BACKUP_BUCKET_PATH))
+        .and(header("authorization", TEST_BASIC_AUTH))
+        .and(body_json(expected.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "bucketProvider": "AZURE", "containerName": "backups" },
+            "status": 200,
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(BACKUP_BUCKET_PATH))
+        .and(header("authorization", TEST_BASIC_AUTH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "bucket-delete",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let config_dir = tempfile::tempdir().unwrap();
+    let config = config_dir.path().join("azure-bucket.json");
+    std::fs::write(&config, serde_json::to_vec(&expected).unwrap()).unwrap();
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "backup",
+            "bucket",
+            "update",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--config-file",
+            config.to_str().unwrap(),
+        ],
+    );
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({ "bucketProvider": "AZURE", "containerName": "backups" })
+    );
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["backup", "bucket", "delete", "svc-1", "--org-id", "org-1"],
+    );
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({ "status": 200, "requestId": "bucket-delete" })
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().all(|request| request.url.query().is_none()));
+}
+
+#[tokio::test]
+async fn backup_bucket_invalid_stdin_unknown_provider_and_field_fail_before_http() {
+    let mock = MockServer::start().await;
+
+    for input in [
+        b"not JSON".as_slice(),
+        br#"{"bucketProvider":"S3"}"#.as_slice(),
+        br#"{"bucketProvider":"AZURE","containerName":"backups","connectionString":"secret","bucketPath":"s3://wrong"}"#.as_slice(),
+    ] {
+        let url = mock.uri();
+        let mut child = Command::new(clickhousectl_binary())
+            .env("DO_NOT_TRACK", "1")
+            .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+            .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+            .args([
+                "cloud",
+                "--url",
+                &url,
+                "--json",
+                "backup",
+                "bucket",
+                "create",
+                "svc-1",
+                "--org-id",
+                "org-1",
+                "--config-file",
+                "-",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(input).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+    }
+
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn backup_bucket_api_error_is_reported() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(BACKUP_BUCKET_PATH))
+        .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+            "status": 503,
+            "error": "backup bucket temporarily unavailable",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["backup", "bucket", "get", "svc-1", "--org-id", "org-1"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("backup bucket temporarily unavailable")
+    );
+}
+
+#[tokio::test]
+async fn backup_bucket_writes_reject_oauth_before_http() {
+    let mock = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let config = project.path().join("bucket.json");
+    std::fs::write(
+        &config,
+        br#"{"bucketProvider":"AWS","bucketPath":"s3://backups","iamRoleArn":"arn:aws:iam::123:role/backups","iamRoleSessionName":"clickhouse"}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "backup",
+            "bucket",
+            "create",
+            "svc-1",
+            "--org-id",
+            "org-1",
+            "--config-file",
+            config.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
 // ── Backup start time against the stored period (issue #642) ────────────────
 
 /// The API keeps the stored period when a start-time update omits one, and


### PR DESCRIPTION
Expose service-scoped bring-your-own backup bucket management through `cloud backup bucket get|create|update|delete`. Create and update accept strict provider-specific JSON from a file or stdin, preserving the Cloud API's exact AWS, GCP, and Azure required fields while rejecting unknown providers, unknown fields, and cross-provider payloads before any request.

Read operations support OAuth; writes use the existing API-key guard. Detail responses use the shared JSON/human renderer, and delete JSON retains response status and request ID. The README includes complete provider payloads, credential-safe input examples, and the PATCH required-field behavior.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` (1143 unit passed, 1 ignored; 377 cloud wiremock passed, 1 ignored; all local/telemetry binaries passed)

Closes #576
