### PR TITLE
feat(cloud): manage service upgrade windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,11 @@ clickhousectl cloud service start <service-id>
 clickhousectl cloud service wake <service-id>   # Explicitly wake an idled service
 clickhousectl cloud service stop <service-id>
 
+# Read, set, or remove the six-hour upgrade window
+clickhousectl cloud service upgrade-window get <service-id>
+clickhousectl cloud service upgrade-window set <service-id> --weekday 1 --start-hour 12
+clickhousectl cloud service upgrade-window delete <service-id>
+
 # Run SQL over HTTP via the Query API (no local clickhouse binary needed)
 clickhousectl cloud service query --name my-service --query "SELECT 1"
 clickhousectl cloud service query --id <service-id> --query "SELECT count() FROM system.tables" --format JSONEachRow
@@ -916,6 +921,8 @@ Scaling schedule hours are always UTC, with weekdays numbered Sunday `0` through
 ```
 
 `scaling-schedule set` replaces the complete entry list, including when `--file -` reads the request from stdin; `{"entries":[]}` clears it. A safe edit flow is to run `get --json`, copy only the entry request fields into a request file, edit that full list, then run `set`. The GET response also contains response-only `id`, `isActiveNow`, `activeEntryId`, and `baseConfig` fields, so it cannot be sent back unchanged. The base config applies outside scheduled windows and is managed separately with `cloud service scale`. `scaling-schedule delete` removes all entries and restores that base config when an entry is active.
+
+Upgrade-window days are numeric: `0` is Sunday, `1` Monday, through `6` Saturday. `--start-hour` is UTC and must be `0`, `6`, `12`, or `18`; the window lasts six hours. `set` replaces the whole window, so both flags are required. `delete` removes the configured window and restores the platform's default upgrade scheduling behaviour. Upgrade windows can only be changed on primary services; secondary services inherit their primary service's window.
 
 `query-endpoint create` adds and deduplicates API keys while preserving existing browser origins. `--role` is required and replaces the endpoint-wide roles for **all** authorized keys; roles are not assigned per key.
 Pass `--allowed-origins` on first creation or to change browser access (`'*'` explicitly allows every origin). Use `--replace-open-api-keys` with `--open-api-key` to deliberately replace the entire authorized-key list.

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -18,7 +18,7 @@ pub(crate) use crate::cloud::clickstack::ClickStackCommands;
 pub(crate) use crate::cloud::organizations::{InvitationCommands, MemberCommands, OrgCommands};
 #[allow(unused_imports)]
 pub(crate) use crate::cloud::services::{
-    PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands,
+    PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands, UpgradeWindowCommands,
 };
 use crate::cloud::udfs::UdfArgs;
 use clap::{Args, Subcommand};
@@ -121,8 +121,9 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Service ID: `clickhousectl cloud service list`.
-  Reads: list, get, settings list/get/schema, prometheus, query, query-endpoint get,
-    private-endpoint get-config, backup-config get. Other commands need API key auth.
+  Reads: list, get, profile list, settings list/get/schema, prometheus, query,
+    query-endpoint get, private-endpoint get-config, backup-config get,
+    scaling-schedule get, upgrade-window get. Other commands need API key auth.
   Typical flow: `create --name X` -> `get <id>` until state is `running` -> `query --id <id> -q 'SELECT 1'`.")]
     Service {
         #[command(subcommand)]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -26,7 +26,8 @@ use clickhouse_cloud_api::models::{
     ServicePostRequestCompliancetype, ServicePostRequestProfile, ServicePostRequestProvider,
     ServicePostRequestRegion, ServicePostRequestReleasechannel, ServiceProfile,
     ServiceQueryAPIEndpoint, ServiceReplicaScalingPatchRequest, ServiceState,
-    ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
+    ServiceStatePatchRequest, ServiceStatePatchRequestCommand, UpgradeWindow,
+    UpgradeWindowPutRequest, UpgradeWindowStartHourUtc,
 };
 #[cfg(test)]
 use clickhouse_cloud_api::models::{IpAccessListEntryResponse, ResourceTagsV1Response};
@@ -483,6 +484,13 @@ CONTEXT FOR AGENTS:
         command: BackupConfigCommands,
     },
 
+    /// Manage the service upgrade window
+    #[command(name = "upgrade-window")]
+    UpgradeWindow {
+        #[command(subcommand)]
+        command: UpgradeWindowCommands,
+    },
+
     /// Get Prometheus metrics
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
@@ -792,6 +800,63 @@ CONTEXT FOR AGENTS:
     },
 }
 
+#[derive(Subcommand)]
+pub enum UpgradeWindowCommands {
+    /// Get the service upgrade window
+    Get {
+        /// Service ID
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Set the service upgrade window
+    Set {
+        /// Service ID
+        service_id: String,
+
+        /// Start day: 0=Sunday through 6=Saturday
+        #[arg(
+            long,
+            allow_hyphen_values = true,
+            value_parser = clap::value_parser!(i64).range(0..=6)
+        )]
+        weekday: i64,
+
+        /// UTC start hour
+        #[arg(long, value_parser = PossibleValuesParser::new(["0", "6", "12", "18"]))]
+        start_hour: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete the service upgrade window
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Restores the default upgrade scheduling behaviour."
+    )]
+    Delete {
+        /// Service ID
+        service_id: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl UpgradeWindowCommands {
+    fn is_write(&self) -> bool {
+        match self {
+            UpgradeWindowCommands::Get { .. } => false,
+            UpgradeWindowCommands::Set { .. } | UpgradeWindowCommands::Delete { .. } => true,
+        }
+    }
+}
+
 impl ServiceProfileCommands {
     fn is_write(&self) -> bool {
         match self {
@@ -849,6 +914,7 @@ impl ServiceCommands {
                 PrivateEndpointCommands::GetConfig { .. } => false,
             },
             ServiceCommands::BackupConfig { command } => command.is_write(),
+            ServiceCommands::UpgradeWindow { command } => command.is_write(),
         }
     }
 }
@@ -1125,6 +1191,30 @@ pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> 
         ServiceCommands::BackupConfig { command } => {
             crate::cloud::backups::run_config(client, command, json).await
         }
+        ServiceCommands::UpgradeWindow { command } => match command {
+            UpgradeWindowCommands::Get { service_id, org_id } => {
+                upgrade_window_get(client, &service_id, org_id.as_deref(), json).await
+            }
+            UpgradeWindowCommands::Set {
+                service_id,
+                weekday,
+                start_hour,
+                org_id,
+            } => {
+                upgrade_window_set(
+                    client,
+                    &service_id,
+                    weekday,
+                    &start_hour,
+                    org_id.as_deref(),
+                    json,
+                )
+                .await
+            }
+            UpgradeWindowCommands::Delete { service_id, org_id } => {
+                upgrade_window_delete(client, &service_id, org_id.as_deref(), json).await
+            }
+        },
         ServiceCommands::Prometheus {
             service_id,
             org_id,
@@ -1355,6 +1445,32 @@ fn parse_instance_tags_patch(
     Ok((!patch.add.is_empty() || !patch.remove.is_empty()).then_some(patch))
 }
 
+fn build_upgrade_window_request(
+    weekday: i64,
+    start_hour: &str,
+) -> CloudResult<UpgradeWindowPutRequest> {
+    let start_hour_utc = match start_hour {
+        "0" => UpgradeWindowStartHourUtc::Hour0,
+        "6" => UpgradeWindowStartHourUtc::Hour6,
+        "12" => UpgradeWindowStartHourUtc::Hour12,
+        "18" => UpgradeWindowStartHourUtc::Hour18,
+        value => {
+            return Err(CloudError::new(format!(
+                "invalid start_hour '{value}': expected one of 0, 6, 12, 18"
+            )));
+        }
+    };
+    if !(0..=6).contains(&weekday) {
+        return Err(CloudError::new(format!(
+            "invalid weekday '{weekday}': expected a number from 0 through 6"
+        )));
+    }
+    Ok(UpgradeWindowPutRequest {
+        start_hour_utc,
+        weekday,
+    })
+}
+
 async fn service_list(
     client: &CloudClient,
     org_id: Option<&str>,
@@ -1420,6 +1536,59 @@ async fn service_get(
         println!("{}", serde_json::to_string_pretty(&service)?);
     } else {
         print_human(&service)?;
+    }
+    Ok(())
+}
+
+async fn upgrade_window_get(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let window = client.get_upgrade_window(&org_id, service_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&window)?);
+    } else {
+        print_human(&window)?;
+    }
+    Ok(())
+}
+
+async fn upgrade_window_set(
+    client: &CloudClient,
+    service_id: &str,
+    weekday: i64,
+    start_hour: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let request = build_upgrade_window_request(weekday, start_hour)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let window = client
+        .set_upgrade_window(&org_id, service_id, &request)
+        .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&window)?);
+    } else {
+        print_human(&window)?;
+    }
+    Ok(())
+}
+
+async fn upgrade_window_delete(
+    client: &CloudClient,
+    service_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_upgrade_window(&org_id, service_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Upgrade window deleted for service {service_id}");
     }
     Ok(())
 }
@@ -4077,6 +4246,49 @@ impl CloudClient {
         Self::unwrap_response(response)
     }
 
+    pub async fn get_upgrade_window(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<UpgradeWindow> {
+        let response = self
+            .api()
+            .upgrade_window_get(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn set_upgrade_window(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        request: &UpgradeWindowPutRequest,
+    ) -> crate::cloud::client::Result<UpgradeWindow> {
+        let response = self
+            .api()
+            .upgrade_window_update(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_upgrade_window(
+        &self,
+        org_id: &str,
+        service_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .upgrade_window_delete(org_id, service_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
     pub async fn get_service_if_exists(
         &self,
         org_id: &str,
@@ -4733,6 +4945,147 @@ mod tests {
             error.kind(),
             clap::error::ErrorKind::MissingRequiredArgument
         );
+    }
+
+    #[test]
+    fn parses_upgrade_window_commands_and_classifies_writes() {
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "upgrade-window",
+            "set",
+            "svc-1",
+            "--weekday",
+            "3",
+            "--start-hour",
+            "12",
+            "--org-id",
+            "org-1",
+        ]);
+        let ServiceCommands::UpgradeWindow {
+            command:
+                UpgradeWindowCommands::Set {
+                    service_id,
+                    weekday,
+                    start_hour,
+                    org_id,
+                },
+        } = command
+        else {
+            panic!("expected upgrade-window set");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert_eq!(weekday, 3);
+        assert_eq!(start_hour, "12");
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "get",
+                "svc-1",
+            ],
+            false,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "set",
+                "svc-1",
+                "--weekday",
+                "0",
+                "--start-hour",
+                "0",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "delete",
+                "svc-1",
+            ],
+            true,
+        );
+    }
+
+    #[test]
+    fn upgrade_window_set_rejects_missing_and_out_of_range_values() {
+        for args in [
+            vec![
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "set",
+                "svc-1",
+                "--start-hour",
+                "6",
+            ],
+            vec![
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "set",
+                "svc-1",
+                "--weekday",
+                "2",
+            ],
+        ] {
+            let error = Cli::try_parse_from(args).err().expect("should fail");
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument
+            );
+        }
+
+        for (flag, value) in [
+            ("--weekday", "7"),
+            ("--weekday", "-1"),
+            ("--start-hour", "3"),
+        ] {
+            let mut args = vec![
+                "clickhousectl",
+                "cloud",
+                "service",
+                "upgrade-window",
+                "set",
+                "svc-1",
+                "--weekday",
+                "2",
+                "--start-hour",
+                "6",
+            ];
+            let index = args.iter().position(|arg| *arg == flag).unwrap() + 1;
+            args[index] = value;
+            let error = Cli::try_parse_from(args).err().expect("should fail");
+            assert!(matches!(
+                error.kind(),
+                clap::error::ErrorKind::ValueValidation | clap::error::ErrorKind::InvalidValue
+            ));
+        }
+    }
+
+    #[test]
+    fn build_upgrade_window_request_supports_minimal_and_maximal_values() {
+        let earliest = build_upgrade_window_request(0, "0").unwrap();
+        assert_eq!(earliest.weekday, 0);
+        assert_eq!(earliest.start_hour_utc, UpgradeWindowStartHourUtc::Hour0);
+
+        let latest = build_upgrade_window_request(6, "18").unwrap();
+        assert_eq!(latest.weekday, 6);
+        assert_eq!(latest.start_hour_utc, UpgradeWindowStartHourUtc::Hour18);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -21461,3 +21461,168 @@ async fn service_settings_schema_human_output_renders_nested_sparse_entries() {
     assert!(stdout.contains("enum: [0, 1]"));
     assert!(stdout.contains("warning: future warning"));
 }
+
+const UPGRADE_WINDOW_PATH: &str = "/v1/organizations/org-1/services/svc-1/upgradeWindow";
+
+#[tokio::test]
+async fn upgrade_window_get_supports_oauth_and_preserves_sparse_json() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(UPGRADE_WINDOW_PATH))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "startHourUtc": 3,
+                "duration": 8,
+                "futureField": "ignored safely"
+            },
+            "status": 200,
+            "requestId": "stub-upgrade-window-get"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &mock.uri());
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "service",
+            "upgrade-window",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({"startHourUtc": 3, "duration": 8})
+    );
+}
+
+#[tokio::test]
+async fn upgrade_window_set_sends_exact_body_with_basic_auth() {
+    let mock = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path(UPGRADE_WINDOW_PATH))
+        .and(wiremock::matchers::basic_auth(
+            "fake-key-for-tests",
+            "fake-secret-for-tests",
+        ))
+        .and(body_json(serde_json::json!({
+            "weekday": 1,
+            "startHourUtc": 18
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {"weekday": 1, "startHourUtc": 18, "duration": 6},
+            "status": 200,
+            "requestId": "stub-upgrade-window-set"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "upgrade-window",
+            "set",
+            "svc-1",
+            "--weekday",
+            "1",
+            "--start-hour",
+            "18",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({"weekday": 1, "startHourUtc": 18, "duration": 6})
+    );
+}
+
+#[tokio::test]
+async fn upgrade_window_delete_uses_basic_auth_and_prints_delete_envelope() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(UPGRADE_WINDOW_PATH))
+        .and(wiremock::matchers::basic_auth(
+            "fake-key-for-tests",
+            "fake-secret-for-tests",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "stub-upgrade-window-delete"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "upgrade-window",
+            "delete",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        serde_json::json!({
+            "status": 200,
+            "requestId": "stub-upgrade-window-delete"
+        })
+    );
+}
+
+#[tokio::test]
+async fn upgrade_window_errors_preserve_the_api_message() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(UPGRADE_WINDOW_PATH))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "status": 404,
+            "error": "no upgrade window is configured",
+            "requestId": "stub-upgrade-window-missing"
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "service",
+            "upgrade-window",
+            "get",
+            "svc-1",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("no upgrade window is configured"));
+}


### PR DESCRIPTION
Expose service upgrade windows

Adds `cloud service upgrade-window get|set|delete` for reading, fully replacing, and removing a ClickHouse Cloud service's six-hour upgrade window. `set` requires a weekday from 0 (Sunday) through 6 (Saturday) and a UTC start hour of 0, 6, 12, or 18; `delete` restores the platform's default scheduling behavior. Reads support OAuth, while set and delete use the existing API-key-only write guard.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl upgrade_window`
- `cargo test -p clickhousectl --test cli_request_shape_test upgrade_window`

Closes #573
