### PR TITLE
fix(api): preserve partial ClickPipe PATCH fields

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -2801,11 +2801,15 @@ pub struct ClickPipePatchKafkaSource {
     pub authentication: Option<ClickPipePatchKafkaSourceAuthentication>,
     #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    pub credentials: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<serde_json::Value>,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(rename = "reversePrivateEndpointIds")]
-    pub reverse_private_endpoint_ids: Vec<String>,
+    #[serde(
+        rename = "reversePrivateEndpointIds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reverse_private_endpoint_ids: Option<Vec<String>>,
 }
 
 /// `ClickPipePatchKinesisSource` from the ClickHouse Cloud API.
@@ -2997,7 +3001,8 @@ pub struct ClickPipePatchPostgresPipeSettings {
 pub struct ClickPipePatchPostgresSource {
     #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    pub credentials: PLAIN,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<PLAIN>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
     #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
@@ -3006,16 +3011,20 @@ pub struct ClickPipePatchPostgresSource {
     pub host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<i64>,
-    pub settings: ClickPipePatchPostgresPipeSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipePatchPostgresPipeSettings>,
     #[serde(
         rename = "skipCertVerification",
         skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappingsToAdd")]
-    pub table_mappings_to_add: Vec<ClickPipePostgresPipeTableMapping>,
-    #[serde(rename = "tableMappingsToRemove")]
-    pub table_mappings_to_remove: Vec<ClickPipePatchPostgresPipeRemoveTableMapping>,
+    #[serde(rename = "tableMappingsToAdd", skip_serializing_if = "Option::is_none")]
+    pub table_mappings_to_add: Option<Vec<ClickPipePostgresPipeTableMapping>>,
+    #[serde(
+        rename = "tableMappingsToRemove",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub table_mappings_to_remove: Option<Vec<ClickPipePatchPostgresPipeRemoveTableMapping>>,
     #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
 }
@@ -3063,8 +3072,8 @@ pub struct ClickPipePatchSource {
     pub postgres: Option<ClickPipePatchPostgresSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pubsub: Option<ClickPipePatchPubSubSource>,
-    #[serde(rename = "validateSamples")]
-    pub validate_samples: bool,
+    #[serde(rename = "validateSamples", skip_serializing_if = "Option::is_none")]
+    pub validate_samples: Option<bool>,
 }
 
 /// `ClickPipePostKafkaSource` from the ClickHouse Cloud API.

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6453,6 +6453,79 @@ fn api_key_patch_deserialization_rejects_invalid_recognized_fields() {
     }
 }
 
+#[test]
+fn kafka_patch_source_preserves_partial_and_explicit_list_updates() {
+    let partial: ClickPipePatchKafkaSource = serde_json::from_value(serde_json::json!({
+        "caCertificate": "new-ca"
+    }))
+    .unwrap();
+    assert!(partial.credentials.is_none());
+    assert!(partial.reverse_private_endpoint_ids.is_none());
+    assert_eq!(
+        serde_json::to_value(partial).unwrap(),
+        serde_json::json!({"caCertificate": "new-ca"})
+    );
+
+    let cleared: ClickPipePatchKafkaSource = serde_json::from_value(serde_json::json!({
+        "reversePrivateEndpointIds": []
+    }))
+    .unwrap();
+    assert_eq!(cleared.reverse_private_endpoint_ids, Some(vec![]));
+    assert_eq!(
+        serde_json::to_value(cleared).unwrap(),
+        serde_json::json!({"reversePrivateEndpointIds": []})
+    );
+
+    let nulls: ClickPipePatchKafkaSource = serde_json::from_value(serde_json::json!({
+        "credentials": null,
+        "reversePrivateEndpointIds": null
+    }))
+    .unwrap();
+    assert_eq!(nulls, ClickPipePatchKafkaSource::default());
+    assert_eq!(serde_json::to_value(nulls).unwrap(), serde_json::json!({}));
+}
+
+#[test]
+fn clickpipe_patch_nested_objects_preserve_omission_and_explicit_empty_values() {
+    let partial = serde_json::json!({
+        "source": {
+            "postgres": {"host": "postgres.example.com"}
+        }
+    });
+    let request: ClickPipePatchRequest = serde_json::from_value(partial.clone()).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), partial);
+
+    let explicit = serde_json::json!({
+        "destination": {"columns": []},
+        "source": {
+            "postgres": {
+                "tableMappingsToAdd": [],
+                "tableMappingsToRemove": []
+            },
+            "validateSamples": false
+        }
+    });
+    let request: ClickPipePatchRequest = serde_json::from_value(explicit.clone()).unwrap();
+    assert_eq!(serde_json::to_value(request).unwrap(), explicit);
+
+    let nulls: ClickPipePatchRequest = serde_json::from_value(serde_json::json!({
+        "source": {
+            "postgres": {
+                "credentials": null,
+                "settings": null,
+                "tableMappingsToAdd": null,
+                "tableMappingsToRemove": null
+            },
+            "validateSamples": null
+        }
+    }))
+    .unwrap();
+    assert_eq!(
+        serde_json::to_value(nulls).unwrap(),
+        serde_json::json!({"source": {"postgres": {}}})
+    );
+}
+
 #[cfg(feature = "deprecated-fields")]
 #[test]
 fn api_key_patch_deserialization_preserves_deprecated_roles() {

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -81,6 +81,19 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // Non-Postgres pipe requests must be able to omit the Postgres union arm.
     ("ClickPipePostSource", "postgres"),
     ("ClickPipePatchSource", "postgres"),
+    // A live object-storage PATCH on 2026-09-05 omitted validateSamples and
+    // succeeded without changing source or destination state. The nested
+    // schema has no required[], but the description fallback marks the field
+    // required because it cannot inherit the parent PATCH method.
+    ("ClickPipePatchSource", "validateSamples"),
+    // The official Terraform provider's merged #618 sends Postgres mapping-only
+    // PATCHes with credentials/settings omitted and with only the non-empty
+    // add/remove delta. Its maintainers verified this shape against the API:
+    // https://github.com/ClickHouse/terraform-provider-clickhouse/pull/618
+    ("ClickPipePatchPostgresSource", "credentials"),
+    ("ClickPipePatchPostgresSource", "settings"),
+    ("ClickPipePatchPostgresSource", "tableMappingsToAdd"),
+    ("ClickPipePatchPostgresSource", "tableMappingsToRemove"),
     // Empty/default scaling and settings objects fail server-side validation.
     ("ClickPipePostRequest", "scaling"),
     ("ClickPipePostRequest", "settings"),
@@ -109,6 +122,13 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // field is `omitempty` and the equivalent PATCH property is nullable.
     // Keeping this `T` would force every request to claim an auth mechanism.
     ("ClickPipePostKafkaSource", "authentication"),
+    // The official Terraform provider's released Kafka update path omits
+    // unchanged credentials and reversePrivateEndpointIds, including for a
+    // CA-only update. The API schema also has authentication modes IAM_ROLE
+    // (using iamRole) and workload identity with no credentials-union arm:
+    // https://github.com/ClickHouse/terraform-provider-clickhouse/blob/7c1d20d485f260f410698a17936cf7793bb5d9e1/internal/service/clickhouse/resource/clickpipe_kafka_update_payload_test.go
+    ("ClickPipePatchKafkaSource", "credentials"),
+    ("ClickPipePatchKafkaSource", "reversePrivateEndpointIds"),
     // `kafka_read_committed` is Kafka-only: the settings PUT is rejected with
     // "Setting 'kafka_read_committed' is only supported for Kafka ClickPipes"
     // for every other source, and the schema carries no `required[]`, so


### PR DESCRIPTION
Corrects the ClickPipe PATCH request models so fields proven optional can be omitted instead of forcing callers to fabricate credentials, settings, arrays, or `validateSamples: false`. Kafka credentials and reverse private endpoint IDs, Postgres credentials/settings/add/remove mappings, and source `validateSamples` now use omission-preserving `Option` fields. Destination `columns` remains required because the live API rejects an included empty destination object.

The narrow analyzer exemptions are grounded by a live object-storage PATCH on 2026-09-05 and the official Terraform provider's released Kafka update path and merged mappings-only fix (ClickHouse/terraform-provider-clickhouse#618). Model tests distinguish omission from explicit false and empty arrays, including Kafka CA-only changes and partial Postgres changes.

Validation:

- `cargo fmt --all --check`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `python3 scripts/check-openapi-drift.py --dry-run` — 0 actionable drift
- Python script tests: 90 passed in the aggregate; the single sandbox-blocked temporary Git commit fixture passed on its exact unsandboxed rerun

Prerequisite for #569.
