### PR TITLE
feat(cloud): expose complete ClickPipe updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,252 @@ the flag explicitly. The flag is refused unless the pipe is confirmed as Kafka.
 Other settings are validated by the API for source compatibility, so passing
 `--object-storage-max-file-count` to a Kafka pipe is rejected server-side.
 
+#### Updating ClickPipes
+
+`clickpipe update` accepts a typed JSON PATCH body from a file or stdin. Omitted
+and `null` top-level fields are not sent. Explicit `false`, `0`, empty strings,
+and empty arrays are preserved; an empty `{}` is refused. Unknown fields and
+enum values are rejected before a request is made.
+
+The file surface matches the current PATCH request models:
+
+| Object | Writable fields |
+|---|---|
+| Root | `name`, `source`, `destination`, `fieldMappings`, `settings` |
+| `destination` | `columns` |
+| `source.kafka` | `authentication`, `iamRole`, `caCertificate`, `reversePrivateEndpointIds`, `credentials` |
+| `source.kinesis` | `authentication`, `iamRole`, `accessKey` |
+| `source.objectStorage` | `skipInitialLoad`, `startAfter`, `authentication`, `iamRole`, `connectionString`, `path`, `azureContainerName`, `accessKey`, `serviceAccountKey` |
+| `source.pubsub` | `authentication`, `ackDeadline`, `serviceAccountKey` |
+| `source.postgres` | `credentials`, `host`, `port`, `database`, TLS fields, `settings`, `tableMappingsToAdd`, `tableMappingsToRemove` |
+| `source.mysql` | `credentials`, `host`, `port`, `authentication`, `iamRole`, TLS fields, `serverId`, `settings`, `tableMappingsToAdd`, `tableMappingsToRemove` |
+| `source.mongodb` | `credentials`, `uri`, `readPreference`, TLS fields, `settings`, `tableMappingsToAdd`, `tableMappingsToRemove` |
+
+TLS fields are `tlsHost`, `caCertificate`, `disableTls`, and
+`skipCertVerification`. The source object can also carry `validateSamples`.
+
+```bash
+clickhousectl cloud clickpipe update <service-id> <clickpipe-id> \
+  --config-file patch.json
+
+# Read a generated JSON PATCH body from stdin.
+jq '.source.postgres.credentials.password = env.CLICKPIPE_PASSWORD' patch-template.json |
+  clickhousectl cloud clickpipe update <service-id> <clickpipe-id> --config-file -
+```
+
+Root fields can rename a pipe, replace destination columns or field mappings,
+and update the root settings object. Nested objects use Cloud API wire names.
+A settings patch currently must contain `kafka_read_committed` because that
+field is required by the shared typed settings model.
+
+```json
+{
+  "name": "events-v2",
+  "destination": {
+    "columns": [{ "name": "id", "type": "UInt64" }]
+  },
+  "fieldMappings": [
+    { "sourceField": "event_id", "destinationField": "id" }
+  ],
+  "settings": {
+    "kafka_read_committed": false,
+    "streaming_max_insert_wait_ms": 0
+  }
+}
+```
+
+A source patch selects at most one of the seven supported arms.
+`validateSamples` is optional. Kafka credentials must match the selected
+authentication: username and password for PLAIN/SCRAM, access key and secret
+for IAM user, or certificate and private key for mutual TLS. Event Hubs
+connection-string credentials use PLAIN. IAM role uses `iamRole` without a
+credentials object, and workload identity uses neither field. Authentication,
+credentials, CA certificate, and reverse private endpoints can each be omitted
+when changing an unrelated Kafka field.
+
+```json
+{
+  "source": {
+    "kafka": {
+      "authentication": "SCRAM-SHA-512",
+      "credentials": { "username": "rotated", "password": "secret" },
+      "reversePrivateEndpointIds": []
+    },
+    "validateSamples": false
+  }
+}
+```
+
+For example, rotate only Kafka's CA certificate without resending credentials:
+
+```json
+{
+  "source": {
+    "kafka": { "caCertificate": "-----BEGIN CERTIFICATE-----..." }
+  }
+}
+```
+
+An IAM-role update carries the role separately:
+
+```json
+{
+  "source": {
+    "kafka": {
+      "authentication": "IAM_ROLE",
+      "iamRole": "arn:aws:iam::123456789012:role/clickpipe"
+    }
+  }
+}
+```
+
+Kinesis credentials use the access-key object:
+
+```json
+{
+  "source": {
+    "kinesis": {
+      "authentication": "IAM_USER",
+      "accessKey": { "accessKeyId": "key-id", "secretKey": "secret" }
+    },
+    "validateSamples": true
+  }
+}
+```
+
+Object-storage updates include credential changes and the post-create resume
+controls. `skipInitialLoad` and `startAfter` have the same mutual-exclusion
+semantics as create.
+
+```json
+{
+  "source": {
+    "objectStorage": {
+      "authentication": "SERVICE_ACCOUNT",
+      "serviceAccountKey": "base64-key",
+      "skipInitialLoad": false,
+      "startAfter": "events/2026-06-01/",
+      "path": "events/*.json"
+    },
+    "validateSamples": false
+  }
+}
+```
+
+Pub/Sub supports service-account key rotation and workload identity:
+
+```json
+{
+  "source": {
+    "pubsub": {
+      "authentication": "SERVICE_ACCOUNT",
+      "ackDeadline": 30,
+      "serviceAccountKey": { "serviceAccountFile": "base64-key" }
+    },
+    "validateSamples": true
+  }
+}
+```
+
+Postgres source fields are independent PATCH values, so a credential rotation,
+host change, settings change, or mapping change can omit the others. Empty
+mapping arrays remain explicit values. Add mappings use the full table shape;
+remove mappings can identify only the source and target tables.
+The API revalidates source connectivity when connection fields change. Include
+the matching credentials in the same patch when changing a host, URI, database,
+or TLS connection field; a failed validation rejects the whole update.
+
+```json
+{
+  "source": {
+    "postgres": {
+      "credentials": { "username": "rotated", "password": "secret" },
+      "host": "postgres.example.com",
+      "port": 5432,
+      "database": "source_db",
+      "settings": { "syncIntervalSeconds": 5, "pullBatchSize": 100000 },
+      "tableMappingsToAdd": [{
+        "sourceSchemaName": "public",
+        "sourceTable": "events",
+        "targetTable": "events",
+        "excludedColumns": [],
+        "useCustomSortingKey": false,
+        "sortingKeys": [],
+        "tableEngine": "ReplacingMergeTree",
+        "partitionKey": "id",
+        "partitionByExpr": "toYYYYMM(ts)"
+      }],
+      "tableMappingsToRemove": [{
+        "sourceSchemaName": "public",
+        "sourceTable": "old_events",
+        "targetTable": "old_events"
+      }]
+    },
+    "validateSamples": false
+  }
+}
+```
+
+MySQL supports connection and credential rotation, its three patchable
+settings, and add/remove mappings. `partitionByExpr` is accepted on both add
+and remove mappings.
+
+```json
+{
+  "source": {
+    "mysql": {
+      "authentication": "basic",
+      "credentials": { "username": "rotated", "password": "secret" },
+      "host": "mysql.example.com",
+      "port": 3306,
+      "serverId": 4242,
+      "settings": {
+        "syncIntervalSeconds": 5,
+        "pullBatchSize": 100000,
+        "useCompression": false
+      },
+      "tableMappingsToAdd": [],
+      "tableMappingsToRemove": [{
+        "sourceSchemaName": "sales",
+        "sourceTable": "old_orders",
+        "targetTable": "old_orders",
+        "partitionByExpr": "toYYYYMM(created_at)"
+      }]
+    },
+    "validateSamples": false
+  }
+}
+```
+
+MongoDB supports URI or username/password rotation, TLS and read-preference
+changes, its two patchable settings, and collection mapping changes:
+
+```json
+{
+  "source": {
+    "mongodb": {
+      "credentials": { "username": "rotated", "password": "secret" },
+      "uri": "mongodb+srv://mongo.example/source",
+      "readPreference": "secondaryPreferred",
+      "disableTls": false,
+      "skipCertVerification": false,
+      "settings": { "syncIntervalSeconds": 5, "pullBatchSize": 100000 },
+      "tableMappingsToAdd": [],
+      "tableMappingsToRemove": [{
+        "sourceDatabaseName": "source",
+        "sourceCollection": "old_events",
+        "targetTable": "old_events"
+      }]
+    },
+    "validateSamples": false
+  }
+}
+```
+
+BigQuery has no PATCH source arm in the Cloud API and is rejected by this
+command. Use a root-only patch for fields the API allows on an existing
+BigQuery pipe.
+
 #### Creating ClickPipes
 
 Each source type has its own subcommand under `clickpipe create`:

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1,5 +1,5 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
-use crate::cloud::config::read_typed_config;
+use crate::cloud::config::{deserialize_strict_config, read_config_value, read_typed_config};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, resolve_org_id};
 use clap::builder::PossibleValuesParser;
@@ -235,6 +235,29 @@ pub enum ClickPipeCommands {
         org_id: Option<String>,
     },
 
+    /// Update a ClickPipe
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  The file is a typed PATCH body; omitted top-level fields remain unchanged.
+  Source updates support kafka, kinesis, objectStorage, pubsub, postgres, mysql,
+  and mongodb. BigQuery sources cannot be updated by this API.
+  Use `-` to read the JSON body from stdin.")]
+    Update {
+        /// Service ID
+        service_id: String,
+
+        /// ClickPipe ID
+        clickpipe_id: String,
+
+        /// JSON PATCH body path, or `-` for stdin
+        #[arg(long, value_name = "FILE|-", required = true)]
+        config_file: String,
+
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
     /// Delete a ClickPipe
     Delete {
         /// Service ID
@@ -400,6 +423,7 @@ impl ClickPipeCommands {
         match self {
             ClickPipeCommands::List { .. } => false,
             ClickPipeCommands::Get { .. } => false,
+            ClickPipeCommands::Update { .. } => true,
             ClickPipeCommands::Delete { .. } => true,
             ClickPipeCommands::Start { .. } => true,
             ClickPipeCommands::Stop { .. } => true,
@@ -1865,6 +1889,22 @@ pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -
             clickpipe_id,
             org_id,
         } => clickpipe_get(client, &service_id, &clickpipe_id, org_id.as_deref(), json).await,
+        ClickPipeCommands::Update {
+            service_id,
+            clickpipe_id,
+            config_file,
+            org_id,
+        } => {
+            clickpipe_update(
+                client,
+                &service_id,
+                &clickpipe_id,
+                &config_file,
+                org_id.as_deref(),
+                json,
+            )
+            .await
+        }
         ClickPipeCommands::Delete {
             service_id,
             clickpipe_id,
@@ -3069,6 +3109,399 @@ async fn clickpipe_get(
     let org_id = resolve_org_id(client, org_id).await?;
     let clickpipe = client
         .get_clickpipe(&org_id, service_id, clickpipe_id)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&clickpipe)?);
+    } else {
+        print_human(&clickpipe)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KafkaPatchCredentialKind {
+    Plain,
+    IamUser,
+    AzureEventHub,
+    MutualTls,
+}
+
+fn parse_kafka_patch_credentials(
+    credentials: &serde_json::Value,
+    source: &str,
+) -> CloudResult<KafkaPatchCredentialKind> {
+    use clickhouse_cloud_api::models::{AzureEventHub, MskIamUser, MutualTLS, PLAIN};
+
+    let variants = [
+        (
+            KafkaPatchCredentialKind::Plain,
+            deserialize_strict_config::<PLAIN>(credentials.clone(), source).is_ok(),
+        ),
+        (
+            KafkaPatchCredentialKind::IamUser,
+            deserialize_strict_config::<MskIamUser>(credentials.clone(), source).is_ok(),
+        ),
+        (
+            KafkaPatchCredentialKind::AzureEventHub,
+            deserialize_strict_config::<AzureEventHub>(credentials.clone(), source).is_ok(),
+        ),
+        (
+            KafkaPatchCredentialKind::MutualTls,
+            deserialize_strict_config::<MutualTLS>(credentials.clone(), source).is_ok(),
+        ),
+    ];
+    let mut matches = variants
+        .into_iter()
+        .filter_map(|(kind, matched)| matched.then_some(kind));
+    match (matches.next(), matches.next()) {
+        (Some(kind), None) => Ok(kind),
+        _ => Err(CloudError::new(format!(
+            "invalid request body in config {source}: `source.kafka.credentials` must be exactly one supported credential object"
+        ))),
+    }
+}
+
+fn invalid_kafka_patch_auth(config_source: &str, message: &str) -> CloudError {
+    CloudError::new(format!(
+        "invalid request body in config {config_source}: {message}"
+    ))
+}
+
+fn require_patch_object_fields(
+    value: &serde_json::Value,
+    path: &str,
+    fields: &[&str],
+    config_source: &str,
+) -> CloudResult<()> {
+    let Some(object) = value.as_object() else {
+        return Ok(());
+    };
+    let missing = fields
+        .iter()
+        .filter(|field| !object.contains_key(**field))
+        .copied()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: `{path}` is missing required field{} {}",
+            if missing.len() == 1 { "" } else { "s" },
+            missing
+                .iter()
+                .map(|field| format!("`{field}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )))
+    }
+}
+
+fn validate_clickpipe_patch_required_fields(
+    value: &serde_json::Value,
+    config_source: &str,
+) -> CloudResult<()> {
+    let Some(source) = value.get("source").and_then(serde_json::Value::as_object) else {
+        return Ok(());
+    };
+
+    if let Some(mysql) = source.get("mysql") {
+        require_patch_object_fields(mysql, "source.mysql", &["host", "port"], config_source)?;
+        if let Some(mappings) = mysql
+            .get("tableMappingsToRemove")
+            .and_then(serde_json::Value::as_array)
+        {
+            for mapping in mappings {
+                require_patch_object_fields(
+                    mapping,
+                    "source.mysql.tableMappingsToRemove[]",
+                    &["sourceSchemaName", "sourceTable", "targetTable"],
+                    config_source,
+                )?;
+            }
+        }
+    }
+
+    if let Some(mongodb) = source.get("mongodb") {
+        require_patch_object_fields(
+            mongodb,
+            "source.mongodb",
+            &["uri", "readPreference"],
+            config_source,
+        )?;
+        if let Some(mappings) = mongodb
+            .get("tableMappingsToRemove")
+            .and_then(serde_json::Value::as_array)
+        {
+            for mapping in mappings {
+                require_patch_object_fields(
+                    mapping,
+                    "source.mongodb.tableMappingsToRemove[]",
+                    &["sourceDatabaseName", "sourceCollection", "targetTable"],
+                    config_source,
+                )?;
+            }
+        }
+    }
+
+    if let Some(pubsub) = source.get("pubsub") {
+        require_patch_object_fields(pubsub, "source.pubsub", &["authentication"], config_source)?;
+    }
+
+    Ok(())
+}
+
+fn validate_clickpipe_patch_source(
+    patch: &clickhouse_cloud_api::models::ClickPipePatchSource,
+    config_source: &str,
+) -> CloudResult<()> {
+    use clickhouse_cloud_api::models::{
+        ClickPipeMongoDBPipeTableMappingTableengine as MongoAddEngine,
+        ClickPipeMySQLPipeTableMappingTableengine as MySqlAddEngine,
+        ClickPipePatchKafkaSourceAuthentication as KafkaAuth,
+        ClickPipePatchKinesisSourceAuthentication as KinesisAuth,
+        ClickPipePatchMongoDBPipeRemoveTableMappingTableengine as MongoRemoveEngine,
+        ClickPipePatchMongoDBSourceReadpreference as MongoReadPreference,
+        ClickPipePatchMySQLPipeRemoveTableMappingTableengine as MySqlRemoveEngine,
+        ClickPipePatchMySQLSourceAuthentication as MySqlAuth,
+        ClickPipePatchObjectStorageSourceAuthentication as ObjectStorageAuth,
+        ClickPipePatchPostgresPipeRemoveTableMappingTableengine as PostgresRemoveEngine,
+        ClickPipePatchPubSubSourceAuthentication as PubSubAuth,
+        ClickPipePostgresPipeTableMappingTableengine as PostgresAddEngine,
+    };
+
+    let selected_sources = [
+        patch.kafka.is_some(),
+        patch.kinesis.is_some(),
+        patch.object_storage.is_some(),
+        patch.pubsub.is_some(),
+        patch.postgres.is_some(),
+        patch.mysql.is_some(),
+        patch.mongodb.is_some(),
+    ]
+    .into_iter()
+    .filter(|selected| *selected)
+    .count();
+    if selected_sources > 1 {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: `source` can update at most one provider"
+        )));
+    }
+
+    if let Some(source) = &patch.kafka {
+        if let Some(KafkaAuth::Unknown(value)) = &source.authentication {
+            return Err(CloudError::new(format!(
+                "invalid request body in config {config_source}: unknown `source.kafka.authentication` value `{value}`"
+            )));
+        }
+        let credentials = source
+            .credentials
+            .as_ref()
+            .map(|credentials| parse_kafka_patch_credentials(credentials, config_source))
+            .transpose()?;
+        match source.authentication.as_ref() {
+            None => {}
+            Some(KafkaAuth::PLAIN) => {
+                if credentials.is_some_and(|kind| {
+                    !matches!(
+                        kind,
+                        KafkaPatchCredentialKind::Plain | KafkaPatchCredentialKind::AzureEventHub
+                    )
+                }) || source.iam_role.is_some()
+                {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "PLAIN authentication accepts only username/password or Event Hubs credentials",
+                    ));
+                }
+            }
+            Some(KafkaAuth::SCRAM_SHA_256 | KafkaAuth::SCRAM_SHA_512) => {
+                if credentials.is_some_and(|kind| kind != KafkaPatchCredentialKind::Plain)
+                    || source.iam_role.is_some()
+                {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "SCRAM authentication accepts only username/password credentials",
+                    ));
+                }
+            }
+            Some(KafkaAuth::IAM_USER) => {
+                if credentials.is_some_and(|kind| kind != KafkaPatchCredentialKind::IamUser)
+                    || source.iam_role.is_some()
+                {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "IAM_USER authentication accepts only access-key credentials",
+                    ));
+                }
+            }
+            Some(KafkaAuth::IAM_ROLE) => {
+                if source.iam_role.is_none() || credentials.is_some() {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "IAM_ROLE authentication requires `iamRole` and no `credentials`",
+                    ));
+                }
+            }
+            Some(KafkaAuth::MUTUAL_TLS) => {
+                if credentials.is_some_and(|kind| kind != KafkaPatchCredentialKind::MutualTls)
+                    || source.iam_role.is_some()
+                {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "MUTUAL_TLS authentication accepts only certificate/private-key credentials",
+                    ));
+                }
+            }
+            Some(KafkaAuth::ServiceAccountWorkloadIdentity) => {
+                if source.iam_role.is_some() || credentials.is_some() {
+                    return Err(invalid_kafka_patch_auth(
+                        config_source,
+                        "SERVICE_ACCOUNT_WORKLOAD_IDENTITY accepts neither `iamRole` nor `credentials`",
+                    ));
+                }
+            }
+            Some(KafkaAuth::Unknown(_)) => unreachable!("unknown authentication rejected above"),
+        }
+    }
+
+    if let Some(source) = &patch.kinesis
+        && let Some(KinesisAuth::Unknown(value)) = &source.authentication
+    {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: unknown `source.kinesis.authentication` value `{value}`"
+        )));
+    }
+
+    if let Some(source) = &patch.object_storage
+        && let Some(ObjectStorageAuth::Unknown(value)) = &source.authentication
+    {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: unknown `source.objectStorage.authentication` value `{value}`"
+        )));
+    }
+
+    if let Some(source) = &patch.pubsub
+        && let Some(PubSubAuth::Unknown(value)) = &source.authentication
+    {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: unknown `source.pubsub.authentication` value `{value}`"
+        )));
+    }
+
+    if let Some(source) = &patch.postgres {
+        if let Some(mappings) = &source.table_mappings_to_add {
+            for mapping in mappings {
+                if let PostgresAddEngine::Unknown(value) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.postgres.tableMappingsToAdd[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+        if let Some(mappings) = &source.table_mappings_to_remove {
+            for mapping in mappings {
+                if let Some(PostgresRemoveEngine::Unknown(value)) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.postgres.tableMappingsToRemove[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+    }
+
+    if let Some(source) = &patch.mysql {
+        if let Some(MySqlAuth::Unknown(value)) = &source.authentication {
+            return Err(CloudError::new(format!(
+                "invalid request body in config {config_source}: unknown `source.mysql.authentication` value `{value}`"
+            )));
+        }
+        if let Some(mappings) = &source.table_mappings_to_add {
+            for mapping in mappings {
+                if let Some(MySqlAddEngine::Unknown(value)) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.mysql.tableMappingsToAdd[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+        if let Some(mappings) = &source.table_mappings_to_remove {
+            for mapping in mappings {
+                if let Some(MySqlRemoveEngine::Unknown(value)) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.mysql.tableMappingsToRemove[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+    }
+
+    if let Some(source) = &patch.mongodb {
+        if let Some(MongoReadPreference::Unknown(value)) = &source.read_preference {
+            return Err(CloudError::new(format!(
+                "invalid request body in config {config_source}: unknown `source.mongodb.readPreference` value `{value}`"
+            )));
+        }
+        if let Some(mappings) = &source.table_mappings_to_add {
+            for mapping in mappings {
+                if let Some(MongoAddEngine::Unknown(value)) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.mongodb.tableMappingsToAdd[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+        if let Some(mappings) = &source.table_mappings_to_remove {
+            for mapping in mappings {
+                if let Some(MongoRemoveEngine::Unknown(value)) = &mapping.table_engine {
+                    return Err(CloudError::new(format!(
+                        "invalid request body in config {config_source}: unknown `source.mongodb.tableMappingsToRemove[].tableEngine` value `{value}`"
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_clickpipe_update_request(
+    value: serde_json::Value,
+    config_source: &str,
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipePatchRequest> {
+    validate_clickpipe_patch_required_fields(&value, config_source)?;
+    let request: clickhouse_cloud_api::models::ClickPipePatchRequest =
+        deserialize_strict_config(value, config_source)?;
+    if let Some(source) = &request.source {
+        validate_clickpipe_patch_source(source, config_source)?;
+    }
+
+    if request.name.is_none()
+        && request.source.is_none()
+        && request.destination.is_none()
+        && request.field_mappings.is_none()
+        && request.settings.is_none()
+    {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: at least one PATCH field is required"
+        )));
+    }
+
+    Ok(request)
+}
+
+async fn clickpipe_update(
+    client: &CloudClient,
+    service_id: &str,
+    clickpipe_id: &str,
+    config_file: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> CloudResult<()> {
+    let request = build_clickpipe_update_request(read_config_value(config_file)?, config_file)?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let clickpipe = client
+        .update_clickpipe(&org_id, service_id, clickpipe_id, &request)
         .await?;
 
     if json {
@@ -5133,6 +5566,21 @@ impl CloudClient {
         let response = self
             .api()
             .click_pipe_create(org_id, service_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_clickpipe(
+        &self,
+        org_id: &str,
+        service_id: &str,
+        clickpipe_id: &str,
+        request: &clickhouse_cloud_api::models::ClickPipePatchRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::ClickPipe> {
+        let response = self
+            .api()
+            .click_pipe_update(org_id, service_id, clickpipe_id, request)
             .await
             .map_err(|error| self.convert_error_for_organization(error, org_id))?;
         Self::unwrap_response(response)
@@ -9051,6 +9499,10 @@ mod tests {
     fn clickpipe_write_classification_delegates_from_cloud_commands() {
         assert_write(&["list", "svc-1"], false);
         assert_write(&["get", "svc-1", "pipe-1"], false);
+        assert_write(
+            &["update", "svc-1", "pipe-1", "--config-file", "patch.json"],
+            true,
+        );
         assert_write(&["delete", "svc-1", "pipe-1"], true);
         assert_write(&["start", "svc-1", "pipe-1"], true);
         assert_write(&["stop", "svc-1", "pipe-1"], true);
@@ -9147,6 +9599,183 @@ mod tests {
             ],
             true,
         );
+    }
+
+    #[test]
+    fn clickpipe_update_parses_file_and_stdin_paths() {
+        for config_file in ["patch.json", "-"] {
+            let ClickPipeCommands::Update {
+                service_id,
+                clickpipe_id,
+                config_file: parsed_file,
+                org_id,
+            } = parse_clickpipe(&[
+                "update",
+                "svc-1",
+                "pipe-1",
+                "--config-file",
+                config_file,
+                "--org-id",
+                "org-1",
+            ])
+            else {
+                panic!("expected clickpipe update");
+            };
+            assert_eq!(service_id, "svc-1");
+            assert_eq!(clickpipe_id, "pipe-1");
+            assert_eq!(parsed_file, config_file);
+            assert_eq!(org_id.as_deref(), Some("org-1"));
+        }
+        assert_rejected(&["update", "svc-1", "pipe-1"]);
+    }
+
+    #[test]
+    fn clickpipe_update_builder_preserves_minimal_and_full_patch_shapes() {
+        let minimal = serde_json::json!({"name": ""});
+        let request = build_clickpipe_update_request(minimal.clone(), "test").unwrap();
+        assert_eq!(serde_json::to_value(request).unwrap(), minimal);
+
+        let full = serde_json::json!({
+            "name": "renamed",
+            "destination": {
+                "columns": [
+                    {"name": "id", "type": "UInt64"},
+                    {"name": "payload", "type": "String"}
+                ]
+            },
+            "fieldMappings": [
+                {"sourceField": "event_id", "destinationField": "id"}
+            ],
+            "settings": {
+                "streaming_max_insert_wait_ms": 0,
+                "clickhouse_parallel_view_processing": false,
+                "kafka_read_committed": false
+            },
+            "source": {
+                "mysql": {
+                    "authentication": "basic",
+                    "credentials": {"username": "rotated", "password": "secret"},
+                    "host": "mysql.example.com",
+                    "port": 3306,
+                    "tlsHost": "mysql-tls.example.com",
+                    "caCertificate": "certificate",
+                    "disableTls": false,
+                    "skipCertVerification": false,
+                    "serverId": 0,
+                    "settings": {
+                        "syncIntervalSeconds": 0,
+                        "pullBatchSize": 0,
+                        "useCompression": false
+                    },
+                    "tableMappingsToAdd": [{
+                        "sourceSchemaName": "sales",
+                        "sourceTable": "orders",
+                        "targetTable": "orders_v2",
+                        "excludedColumns": [],
+                        "useCustomSortingKey": false,
+                        "sortingKeys": [],
+                        "tableEngine": "ReplacingMergeTree",
+                        "partitionKey": "id",
+                        "partitionByExpr": "toYYYYMM(created_at)"
+                    }],
+                    "tableMappingsToRemove": [{
+                        "sourceSchemaName": "sales",
+                        "sourceTable": "old_orders",
+                        "targetTable": "old_orders",
+                        "tableEngine": "MergeTree",
+                        "partitionKey": "id",
+                        "partitionByExpr": "toYYYYMM(created_at)"
+                    }]
+                },
+                "validateSamples": false
+            }
+        });
+        let request = build_clickpipe_update_request(full.clone(), "test").unwrap();
+        assert_eq!(serde_json::to_value(request).unwrap(), full);
+
+        for partial in [
+            serde_json::json!({"source": {"kafka": {"caCertificate": "new-ca"}}}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "IAM_ROLE",
+                "iamRole": "arn:aws:iam::123456789012:role/clickpipe"
+            }}}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+            }}}),
+            serde_json::json!({"source": {"postgres": {
+                "host": "postgres.example.com"
+            }}}),
+        ] {
+            let request = build_clickpipe_update_request(partial.clone(), "test").unwrap();
+            assert_eq!(
+                serde_json::to_value(request).unwrap(),
+                partial,
+                "omitted PATCH fields must remain absent"
+            );
+        }
+    }
+
+    #[test]
+    fn clickpipe_update_builder_rejects_noop_unknowns_and_invalid_sources() {
+        for invalid in [
+            serde_json::json!({}),
+            serde_json::json!({"bigquery": {}}),
+            serde_json::json!({"destination": {}}),
+            serde_json::json!({"fieldMappings": [{"sourceFiled": "id", "destinationField": "id"}]}),
+            serde_json::json!({"source": {
+                "kinesis": {"authentication": "FUTURE_AUTH"},
+                "validateSamples": false
+            }}),
+            serde_json::json!({"source": {
+                "mongodb": {
+                    "uri": "mongodb://example/db",
+                    "readPreference": "futurePreference"
+                },
+                "validateSamples": false
+            }}),
+            serde_json::json!({"source": {
+                "kafka": {
+                    "credentials": {"username": "user", "password": "pw", "extra": true},
+                    "reversePrivateEndpointIds": []
+                },
+                "validateSamples": false
+            }}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "PLAIN",
+                "credentials": {"accessKeyId": "key", "secretKey": "secret"}
+            }}}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "IAM_ROLE",
+                "iamRole": "arn:aws:iam::123456789012:role/clickpipe",
+                "credentials": {"username": "user", "password": "secret"}
+            }}}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "IAM_ROLE"
+            }}}),
+            serde_json::json!({"source": {"kafka": {
+                "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY",
+                "credentials": {"username": "user", "password": "secret"}
+            }}}),
+            serde_json::json!({"source": {"mysql": {
+                "settings": {"syncIntervalSeconds": 5}
+            }}}),
+            serde_json::json!({"source": {"mongodb": {
+                "settings": {"syncIntervalSeconds": 5}
+            }}}),
+            serde_json::json!({"source": {"pubsub": {
+                "ackDeadline": 10
+            }}}),
+            serde_json::json!({"source": {
+                "kinesis": {},
+                "objectStorage": {},
+                "validateSamples": false
+            }}),
+        ] {
+            assert!(
+                build_clickpipe_update_request(invalid.clone(), "test").is_err(),
+                "accepted invalid patch: {invalid}"
+            );
+        }
     }
 
     /// Parse `schema-discover object-storage` args and return the source

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -21626,3 +21626,343 @@ async fn upgrade_window_errors_preserve_the_api_message() {
     assert!(output.stdout.is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("no upgrade window is configured"));
 }
+
+// ── Complete ClickPipe PATCH input (#569) ──────────────────────────────────
+
+const CLICKPIPE_UPDATE_PATH: &str = "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1";
+
+fn invoke_clickpipe_update_file(mock: &MockServer, patch: &Value) -> std::process::Output {
+    let project = tempfile::tempdir().unwrap();
+    let config_path = project.path().join("patch.json");
+    std::fs::write(&config_path, serde_json::to_vec(patch).unwrap()).unwrap();
+    let config_path = config_path.to_str().unwrap();
+    invoke_cli_with_cloud_credentials(
+        mock,
+        &[
+            "clickpipe",
+            "update",
+            "svc-1",
+            "pipe-1",
+            "--config-file",
+            config_path,
+            "--org-id",
+            "org-1",
+        ],
+    )
+}
+
+async fn mount_clickpipe_update(mock: &MockServer, patch: Value) {
+    Mock::given(method("PATCH"))
+        .and(path(CLICKPIPE_UPDATE_PATH))
+        .and(body_json(patch))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "updated"
+            },
+            "status": 200,
+            "requestId": "stub-clickpipe-update"
+        })))
+        .expect(1)
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn clickpipe_update_sends_patch_source_variants_and_partial_auth_exactly() {
+    let patches = [
+        serde_json::json!({
+            "name": "renamed",
+            "destination": {"columns": [{"name": "id", "type": "UInt64"}]},
+            "fieldMappings": [{"sourceField": "event_id", "destinationField": "id"}],
+            "settings": {
+                "kafka_read_committed": false,
+                "streaming_max_insert_wait_ms": 0
+            },
+            "source": {
+                "kafka": {
+                    "authentication": "MUTUAL_TLS",
+                    "caCertificate": "ca",
+                    "credentials": {"certificate": "cert", "privateKey": "key"},
+                    "reversePrivateEndpointIds": []
+                },
+                "validateSamples": false
+            }
+        }),
+        serde_json::json!({"source": {
+            "kinesis": {
+                "authentication": "IAM_USER",
+                "accessKey": {"accessKeyId": "key-id", "secretKey": "secret"}
+            },
+            "validateSamples": true
+        }}),
+        serde_json::json!({"source": {
+            "objectStorage": {
+                "authentication": "SERVICE_ACCOUNT",
+                "serviceAccountKey": "base64-key",
+                "skipInitialLoad": false,
+                "startAfter": "events/2026-06-01/",
+                "path": "events/*.json"
+            },
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "pubsub": {
+                "authentication": "SERVICE_ACCOUNT",
+                "ackDeadline": 10,
+                "serviceAccountKey": {"serviceAccountFile": "base64-key"}
+            },
+            "validateSamples": true
+        }}),
+        serde_json::json!({"source": {
+            "postgres": {
+                "credentials": {"username": "rotated", "password": "secret"},
+                "host": "postgres.example.com",
+                "port": 5432,
+                "database": "source_db",
+                "disableTls": false,
+                "skipCertVerification": false,
+                "settings": {"syncIntervalSeconds": 0, "pullBatchSize": 0},
+                "tableMappingsToAdd": [{
+                    "sourceSchemaName": "public",
+                    "sourceTable": "events",
+                    "targetTable": "events",
+                    "excludedColumns": [],
+                    "useCustomSortingKey": false,
+                    "sortingKeys": [],
+                    "tableEngine": "ReplacingMergeTree",
+                    "partitionKey": "id",
+                    "partitionByExpr": "toYYYYMM(ts)"
+                }],
+                "tableMappingsToRemove": [{
+                    "sourceSchemaName": "public",
+                    "sourceTable": "old_events",
+                    "targetTable": "old_events"
+                }]
+            },
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "mysql": {
+                "authentication": "basic",
+                "credentials": {"username": "rotated", "password": "secret"},
+                "host": "mysql.example.com",
+                "port": 3306,
+                "serverId": 0,
+                "settings": {
+                    "syncIntervalSeconds": 0,
+                    "pullBatchSize": 0,
+                    "useCompression": false
+                },
+                "tableMappingsToAdd": [],
+                "tableMappingsToRemove": [{
+                    "sourceSchemaName": "sales",
+                    "sourceTable": "old_orders",
+                    "targetTable": "old_orders",
+                    "tableEngine": "MergeTree",
+                    "partitionKey": "id",
+                    "partitionByExpr": "toYYYYMM(created_at)"
+                }]
+            },
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "mongodb": {
+                "credentials": {"username": "rotated", "password": "secret"},
+                "uri": "mongodb+srv://mongo.example/source",
+                "readPreference": "secondaryPreferred",
+                "disableTls": false,
+                "skipCertVerification": false,
+                "settings": {"syncIntervalSeconds": 0, "pullBatchSize": 0},
+                "tableMappingsToAdd": [],
+                "tableMappingsToRemove": [{
+                    "sourceDatabaseName": "source",
+                    "sourceCollection": "old_events",
+                    "targetTable": "old_events",
+                    "tableEngine": "Null"
+                }]
+            },
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "kafka": {"caCertificate": "new-ca"}
+        }}),
+        serde_json::json!({"source": {
+            "kafka": {
+                "authentication": "IAM_ROLE",
+                "iamRole": "arn:aws:iam::123456789012:role/clickpipe"
+            }
+        }}),
+        serde_json::json!({"source": {
+            "kafka": {
+                "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"
+            }
+        }}),
+        serde_json::json!({"source": {
+            "postgres": {"host": "postgres.example.com"}
+        }}),
+    ];
+
+    for patch in patches {
+        let mock = MockServer::start().await;
+        mount_clickpipe_update(&mock, patch.clone()).await;
+        let output = invoke_clickpipe_update_file(&mock, &patch);
+        assert_success(&output);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+            serde_json::json!({
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "updated"
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn clickpipe_update_reads_stdin_and_preserves_explicit_empty_values() {
+    let mock = MockServer::start().await;
+    let patch = serde_json::json!({"fieldMappings": []});
+    mount_clickpipe_update(&mock, patch.clone()).await;
+    let project = tempfile::tempdir().unwrap();
+    let mut child = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "clickpipe",
+            "update",
+            "svc-1",
+            "pipe-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&serde_json::to_vec(&patch).unwrap())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output);
+}
+
+#[tokio::test]
+async fn clickpipe_update_rejects_noop_unknown_nested_fields_and_bigquery_before_http() {
+    for patch in [
+        serde_json::json!({}),
+        serde_json::json!({"destination": {}}),
+        serde_json::json!({"destination": {"colums": []}}),
+        serde_json::json!({"source": {
+            "bigquery": {},
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "kafka": {
+                "credentials": {"username": "user", "password": "pw", "token": "bad"},
+                "reversePrivateEndpointIds": []
+            },
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {
+            "mysql": {"host": "db", "port": 3306, "authentication": "future"},
+            "validateSamples": false
+        }}),
+        serde_json::json!({"source": {"kafka": {
+            "authentication": "PLAIN",
+            "credentials": {"accessKeyId": "key", "secretKey": "secret"}
+        }}}),
+        serde_json::json!({"source": {"kafka": {
+            "authentication": "IAM_ROLE",
+            "iamRole": "arn:aws:iam::123456789012:role/clickpipe",
+            "credentials": {"username": "user", "password": "secret"}
+        }}}),
+        serde_json::json!({"source": {"kafka": {
+            "authentication": "SERVICE_ACCOUNT_WORKLOAD_IDENTITY",
+            "credentials": {"username": "user", "password": "secret"}
+        }}}),
+        serde_json::json!({"source": {"mysql": {
+            "settings": {"syncIntervalSeconds": 5}
+        }}}),
+        serde_json::json!({"source": {"mongodb": {
+            "settings": {"syncIntervalSeconds": 5}
+        }}}),
+        serde_json::json!({"source": {"pubsub": {
+            "ackDeadline": 10
+        }}}),
+    ] {
+        let mock = MockServer::start().await;
+        let output = invoke_clickpipe_update_file(&mock, &patch);
+        assert_eq!(output.status.code(), Some(1), "patch: {patch}");
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("invalid request body"),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(mock.received_requests().await.unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn clickpipe_update_propagates_api_errors_and_rejects_oauth_before_http() {
+    let error_mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path(CLICKPIPE_UPDATE_PATH))
+        .respond_with(
+            ResponseTemplate::new(409)
+                .set_body_json(serde_json::json!({"error": "update conflict"})),
+        )
+        .expect(1)
+        .mount(&error_mock)
+        .await;
+    let output = invoke_clickpipe_update_file(&error_mock, &serde_json::json!({"name": "new"}));
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("update conflict"));
+
+    let oauth_mock = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    write_oauth_tokens(&cloud_dir, &oauth_mock.uri());
+    let config_path = project.path().join("patch.json");
+    std::fs::write(&config_path, br#"{"name":"new"}"#).unwrap();
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project.path())
+        .args([
+            "cloud",
+            "--url",
+            &oauth_mock.uri(),
+            "--json",
+            "clickpipe",
+            "update",
+            "svc-1",
+            "pipe-1",
+            "--config-file",
+            config_path.to_str().unwrap(),
+            "--org-id",
+            "org-1",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    assert!(oauth_mock.received_requests().await.unwrap().is_empty());
+}


### PR DESCRIPTION
Adds `cloud clickpipe update <service-id> <clickpipe-id> --config-file FILE|-` for the complete current ClickPipe PATCH surface. Typed JSON input covers root fields and all seven supported source arms; omitted fields stay off the wire, explicit false/zero/empty values survive, and BigQuery is rejected because the API has no PATCH arm.

Input is validated before network access, including unknown nested fields, catch-all enum values, required nested MySQL/MongoDB/Pub/Sub fields, Kafka credential unions and authentication correspondence, multiple source providers, and empty no-op bodies. Kafka IAM role and workload identity updates omit credentials, while CA-only and reverse-private-endpoint-only updates no longer require fabricated credential data. The command uses the existing typed API method through an organization-aware `CloudClient` wrapper, is classified as a write for OAuth fail-fast behavior, and renders both JSON and human responses.

Tests cover file/stdin parsing, minimal and maximal builders, exact real-binary PATCH bodies for Kafka, Kinesis, object storage, Pub/Sub, Postgres, MySQL, and MongoDB, root fields, IAM role/workload identity and CA-only Kafka shapes, omission/empty-value behavior, sparse responses, API failures, invalid input, and OAuth rejection.

Validation:

- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -p clickhousectl` — 1144 unit passed/1 ignored, 377 Cloud request-shape passed/1 ignored, and all local/telemetry binaries passed

Closes #569
