### PR TITLE
fix(api): preserve optional ClickPipe create fields

### DIFF
--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -3277,8 +3277,10 @@ pub struct ClickPipePostSource {
     pub postgres: Option<ClickPipeMutatePostgresSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pubsub: Option<ClickPipePostPubSubSource>,
-    #[serde(rename = "validateSamples")]
-    pub validate_samples: bool,
+    // The control plane accepted an object-storage create with this key
+    // omitted on 2026-09-05. Preserve that absence rather than inventing false.
+    #[serde(rename = "validateSamples", skip_serializing_if = "Option::is_none")]
+    pub validate_samples: Option<bool>,
 }
 
 /// `ClickPipePostgresPipeSettings` from the ClickHouse Cloud API.
@@ -3550,8 +3552,13 @@ pub struct ClickPipeSettings {
     pub clickhouse_parallel_distributed_insert_select: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_view_processing: Option<bool>,
-    #[serde(rename = "kafka_read_committed")]
-    pub kafka_read_committed: bool,
+    // The control plane rejected this key on an object-storage create on
+    // 2026-09-05, even when false. It must be absent outside Kafka creates.
+    #[serde(
+        rename = "kafka_read_committed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub kafka_read_committed: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_concurrency: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -394,7 +394,7 @@ fn deserialize_clickpipe_settings() {
     assert_eq!(settings.streaming_max_insert_wait_ms, Some(5000));
     assert_eq!(settings.object_storage_concurrency, None);
     assert_eq!(settings.clickhouse_max_threads, Some(4));
-    assert!(settings.kafka_read_committed);
+    assert_eq!(settings.kafka_read_committed, Some(true));
 }
 
 #[test]
@@ -4191,10 +4191,16 @@ fn shared_clickpipe_nested_types_stay_strict_on_the_request_side() {
         serde_json::from_str::<ClickPipePostgresPipeTableMappingResponse>("{}").unwrap(),
         ClickPipePostgresPipeTableMappingResponse::default()
     );
-    // The new non-nullable Kafka setting is required in the create-position
-    // settings object, while the settings PUT omits it for non-Kafka pipes and
-    // the response variant remains tolerant of a dropped key.
-    assert!(serde_json::from_str::<ClickPipeSettings>("{}").is_err());
+    // Source-conditional create values stay absent unless the caller supplies
+    // them, while explicit false remains distinguishable from omission.
+    assert_eq!(
+        serde_json::from_str::<ClickPipeSettings>("{}").unwrap(),
+        ClickPipeSettings::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickPipePostSource>("{}").unwrap(),
+        ClickPipePostSource::default()
+    );
     assert_eq!(
         serde_json::from_str::<ClickPipeSettingsPutRequest>("{}").unwrap(),
         ClickPipeSettingsPutRequest::default()
@@ -4202,6 +4208,37 @@ fn shared_clickpipe_nested_types_stay_strict_on_the_request_side() {
     assert_eq!(
         serde_json::from_str::<ClickPipeSettingsResponse>("{}").unwrap(),
         ClickPipeSettingsResponse::default()
+    );
+}
+
+#[test]
+fn clickpipe_create_optional_controls_omit_absence_and_preserve_false() {
+    let source = ClickPipePostSource::default();
+    let settings = ClickPipeSettings::default();
+    assert_eq!(
+        serde_json::to_value(&source).unwrap(),
+        serde_json::json!({})
+    );
+    assert_eq!(
+        serde_json::to_value(&settings).unwrap(),
+        serde_json::json!({})
+    );
+
+    let source = ClickPipePostSource {
+        validate_samples: Some(false),
+        ..Default::default()
+    };
+    let settings = ClickPipeSettings {
+        kafka_read_committed: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(&source).unwrap(),
+        serde_json::json!({ "validateSamples": false })
+    );
+    assert_eq!(
+        serde_json::to_value(&settings).unwrap(),
+        serde_json::json!({ "kafka_read_committed": false })
     );
 }
 

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -97,6 +97,9 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // Empty/default scaling and settings objects fail server-side validation.
     ("ClickPipePostRequest", "scaling"),
     ("ClickPipePostRequest", "settings"),
+    // The control plane accepted an object-storage create with validateSamples
+    // absent on 2026-09-05. Omission must stay distinct from explicit false.
+    ("ClickPipePostSource", "validateSamples"),
     // CDC mode and numeric ranges require absence unless meaningful values exist.
     ("ClickPipePostgresPipeSettings", "publicationName"),
     ("ClickPipePostgresPipeSettings", "replicationSlotName"),
@@ -136,6 +139,10 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // way a non-Kafka settings update can express "does not apply"; keeping this
     // `T` would put the key on every request and break all non-Kafka pipes.
     ("ClickPipeSettingsPutRequest", "kafka_read_committed"),
+    // The same source-conditional contract applies to settings nested in a
+    // create request: on 2026-09-05 an object-storage create with the key set
+    // to false was rejected, while omitting it succeeded.
+    ("ClickPipeSettings", "kafka_read_committed"),
     // Empty TLS/IAM strings fail validation for sources that do not use them.
     ("ClickPipeMutatePostgresSource", "caCertificate"),
     ("ClickPipeMutatePostgresSource", "iamRole"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -3910,7 +3910,7 @@ fn build_create_request_args(
                     .settings
                     .clickhouse_parallel_distributed_insert_select
                     .map(i64::from),
-                kafka_read_committed: args.settings.kafka_read_committed.unwrap_or(false),
+                kafka_read_committed: Some(args.settings.kafka_read_committed.unwrap_or(false)),
                 object_storage_use_cluster_function: args
                     .settings
                     .object_storage_use_cluster_function,
@@ -3940,7 +3940,7 @@ fn apply_create_request_args(
     request: &mut clickhouse_cloud_api::models::ClickPipePostRequest,
     args: BuiltCreateRequestArgs,
 ) {
-    request.source.validate_samples = args.validate_samples;
+    request.source.validate_samples = Some(args.validate_samples);
     request.scaling = args.scaling;
     request.settings = args.settings;
     request.field_mappings = args.field_mappings;

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -6661,7 +6661,7 @@ mod tests {
         assert_eq!(scaling.replica_memory_gb, 0.5);
         let settings = maximal.settings.unwrap();
         assert_eq!(settings.clickhouse_max_threads, Some(0));
-        assert!(!settings.kafka_read_committed);
+        assert_eq!(settings.kafka_read_committed, Some(false));
         assert_eq!(maximal.field_mappings.len(), 1);
         assert_eq!(maximal.field_mappings[0].source_field, "source:a=b");
         assert_eq!(
@@ -6687,7 +6687,7 @@ mod tests {
         let settings = object_storage.settings.unwrap();
         assert_eq!(settings.object_storage_concurrency, Some(1));
         assert_eq!(settings.object_storage_use_cluster_function, Some(false));
-        assert!(!settings.kafka_read_committed);
+        assert_eq!(settings.kafka_read_committed, Some(false));
     }
 
     #[test]
@@ -10533,7 +10533,7 @@ mod tests {
         assert!(request.source.mysql.is_none());
         assert!(request.source.object_storage.is_none());
         assert!(request.source.pubsub.is_none());
-        assert!(!request.source.validate_samples);
+        assert_eq!(request.source.validate_samples, Some(false));
 
         let source = request.source.postgres.as_ref().expect("postgres source");
         assert_eq!(source.r#type.as_ref().unwrap().to_string(), "postgres");


### PR DESCRIPTION
`ClickPipeSettings.kafka_read_committed` and `ClickPipePostSource.validate_samples` were modeled as required booleans, which forced callers to serialize `false` when those source-conditional create fields were unset. On 2026-09-05, a live object-storage create that omitted `source.validateSamples` succeeded; the same request with `settings.kafka_read_committed:false` failed with `Setting 'kafka_read_committed' is only supported for Kafka ClickPipes`, and omitting that setting succeeded.

This changes both request fields to `Option<bool>` with absent values omitted from JSON. Explicit `Some(false)` remains serialized. Narrow analyzer exemptions document the observed control-plane behavior, and model tests cover omitted and explicit-false payloads. The CLI receives compile-only `Some(...)` adaptations in this prerequisite commit, so its wire behavior remains unchanged until the follow-up CLI commit.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (91 passed with commit signing disabled for the temporary-repository test)
- `cargo check --workspace --all-features`

The prerequisite also adapts three CLI unit assertions to the new types. Its no-default all-target Clippy, affected unit tests and full CLI test compilation pass before the behavior-changing follow-up.

Prerequisite for #595.
