### PR TITLE
fix(cli): omit unset ClickPipe create booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1327,8 +1327,7 @@ jq '.source.postgres.credentials.password = env.CLICKPIPE_PASSWORD' patch-templa
 
 Root fields can rename a pipe, replace destination columns or field mappings,
 and update the root settings object. Nested objects use Cloud API wire names.
-A settings patch currently must contain `kafka_read_committed` because that
-field is required by the shared typed settings model.
+The `kafka_read_committed` setting applies only to Kafka pipes.
 
 ```json
 {
@@ -1544,8 +1543,9 @@ Each source type has its own subcommand under `clickpipe create`:
 
 Every create subcommand accepts source sample validation through
 `--validate-samples true|false`. The value is written under `source`; omission
-keeps the historical `false` value. The API documents sample validation as
-having no effect for PostgreSQL and MySQL.
+leaves `validateSamples` out of the request, while explicit `false` remains an
+explicit value. The API documents sample validation as having no effect for
+PostgreSQL and MySQL.
 
 Kafka, Kinesis, object-storage, and Pub/Sub creates also accept repeatable
 `--field-mapping '{"sourceField":"...","destinationField":"..."}'` values and
@@ -1558,9 +1558,10 @@ Those four source types also accept the ingestion-setting flags shown under
 `clickpipe settings update`. The JSON pair form preserves field names containing
 punctuation and rejects missing or unknown keys before a request. Object-storage
 settings only apply to object-storage creates, and `--kafka-read-committed` only
-applies to Kafka. Database-source creates use their source-specific CDC setting
-and table-mapping flags instead. With no common setting flag, the request omits
-the whole `settings` block; explicit `0` and `false` remain present.
+applies to Kafka. Other source types omit that Kafka-only setting even when their
+request contains other settings. Database-source creates use their source-specific
+CDC setting and table-mapping flags instead. With no common setting flag, the
+request omits the whole `settings` block; explicit `0` and `false` remain present.
 
 ```bash
 clickhousectl cloud clickpipe create kafka <service-id> \

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -3823,7 +3823,7 @@ fn parse_create_field_mappings(
 
 #[derive(Debug)]
 struct BuiltCreateRequestArgs {
-    validate_samples: bool,
+    validate_samples: Option<bool>,
     scaling: Option<clickhouse_cloud_api::models::ClickPipeScaling>,
     settings: Option<clickhouse_cloud_api::models::ClickPipeSettings>,
     field_mappings: Vec<clickhouse_cloud_api::models::ClickPipeFieldMapping>,
@@ -3910,7 +3910,7 @@ fn build_create_request_args(
                     .settings
                     .clickhouse_parallel_distributed_insert_select
                     .map(i64::from),
-                kafka_read_committed: Some(args.settings.kafka_read_committed.unwrap_or(false)),
+                kafka_read_committed: args.settings.kafka_read_committed,
                 object_storage_use_cluster_function: args
                     .settings
                     .object_storage_use_cluster_function,
@@ -3920,7 +3920,7 @@ fn build_create_request_args(
             });
 
     Ok(BuiltCreateRequestArgs {
-        validate_samples: args.validation.validate_samples.unwrap_or(false),
+        validate_samples: args.validation.validate_samples,
         scaling,
         settings,
         field_mappings: parse_create_field_mappings(&args.field_mappings)?,
@@ -3929,7 +3929,7 @@ fn build_create_request_args(
 
 fn build_create_validation_args(args: &ClickPipeCreateValidationArgs) -> BuiltCreateRequestArgs {
     BuiltCreateRequestArgs {
-        validate_samples: args.validate_samples.unwrap_or(false),
+        validate_samples: args.validate_samples,
         scaling: None,
         settings: None,
         field_mappings: Vec::new(),
@@ -3940,7 +3940,7 @@ fn apply_create_request_args(
     request: &mut clickhouse_cloud_api::models::ClickPipePostRequest,
     args: BuiltCreateRequestArgs,
 ) {
-    request.source.validate_samples = Some(args.validate_samples);
+    request.source.validate_samples = args.validate_samples;
     request.scaling = args.scaling;
     request.settings = args.settings;
     request.field_mappings = args.field_mappings;
@@ -6623,7 +6623,7 @@ mod tests {
             ClickPipeSourceKind::Kafka,
         )
         .unwrap();
-        assert!(!minimal.validate_samples);
+        assert_eq!(minimal.validate_samples, None);
         assert_eq!(minimal.scaling, None);
         assert_eq!(minimal.settings, None);
         assert!(minimal.field_mappings.is_empty());
@@ -6654,7 +6654,7 @@ mod tests {
             ClickPipeSourceKind::Kafka,
         )
         .unwrap();
-        assert!(!maximal.validate_samples);
+        assert_eq!(maximal.validate_samples, Some(false));
         let scaling = maximal.scaling.unwrap();
         assert_eq!(scaling.replicas, 1);
         assert_eq!(scaling.replica_cpu_millicores, 125);
@@ -6687,7 +6687,7 @@ mod tests {
         let settings = object_storage.settings.unwrap();
         assert_eq!(settings.object_storage_concurrency, Some(1));
         assert_eq!(settings.object_storage_use_cluster_function, Some(false));
-        assert_eq!(settings.kafka_read_committed, Some(false));
+        assert_eq!(settings.kafka_read_committed, None);
     }
 
     #[test]
@@ -10533,7 +10533,7 @@ mod tests {
         assert!(request.source.mysql.is_none());
         assert!(request.source.object_storage.is_none());
         assert!(request.source.pubsub.is_none());
-        assert_eq!(request.source.validate_samples, Some(false));
+        assert_eq!(request.source.validate_samples, None);
 
         let source = request.source.postgres.as_ref().expect("postgres source");
         assert_eq!(source.r#type.as_ref().unwrap().to_string(), "postgres");

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -6010,7 +6010,14 @@ async fn cross_source_create_controls_reach_all_eight_request_shapes() {
                 body["settings"]["clickhouse_parallel_view_processing"], false,
                 "{source}"
             );
-            assert_eq!(body["settings"]["kafka_read_committed"], false, "{source}");
+            if source == "kafka" {
+                assert_eq!(body["settings"]["kafka_read_committed"], false, "{source}");
+            } else {
+                assert!(
+                    body["settings"].get("kafka_read_committed").is_none(),
+                    "{source}: {body}"
+                );
+            }
             if source == "objectStorage" {
                 assert_eq!(body["settings"]["object_storage_concurrency"], 1);
                 assert_eq!(
@@ -6106,6 +6113,32 @@ async fn kafka_optional_fields_absent_when_flags_omitted() {
         kafka["offset"].get("timestamp").is_none(),
         "offset.timestamp leaked when --offset-timestamp not passed: {kafka}",
     );
+    assert!(body["source"].get("validateSamples").is_none(), "{body}");
+    assert!(body.get("settings").is_none(), "{body}");
+}
+
+#[tokio::test]
+async fn kafka_create_preserves_explicit_read_committed_true_and_false() {
+    for (value, expected) in [("true", true), ("false", false)] {
+        let mock = start_mock_clickpipes_api().await;
+        let mut args = kafka_args_minimal()
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        args.extend([
+            "--kafka-read-committed".into(),
+            value.into(),
+            "--validate-samples".into(),
+            "false".into(),
+        ]);
+
+        let body = invoke_cli_capture_body(&mock, &as_str_args(&args)).await;
+        assert_eq!(
+            body["settings"],
+            serde_json::json!({ "kafka_read_committed": expected })
+        );
+        assert_eq!(body["source"]["validateSamples"], false, "{body}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
ClickPipe creates previously replaced omitted booleans with `false`. That made every non-Kafka create containing another settings flag serialize the rejected Kafka-only `kafka_read_committed` key, and it prevented minimal creates from omitting `source.validateSamples` as intended.

The create builder now carries both optional booleans through unchanged: omitted values stay absent, while explicit `true` and `false` remain present. Real-binary request tests cover exact Kafka true/false payloads, minimal omission, and `kafka_read_committed` omission for object-storage, Kinesis, and Pub/Sub creates that contain other settings. The README documents both omission rules and the existing PostgreSQL/MySQL sample-validation no-op.

Validation:

- `cargo fmt --all`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- `cargo test -q -p clickhousectl` (1,727 passed, 0 failed, 2 ignored)
- `cargo check --workspace --all-features`

Closes #595.
