### PR TITLE
docs: clarify partial local server configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,9 @@ Version removal and server-data removal are separate operations:
 
 #### Custom config files
 
-Drop ClickHouse config files into `~/.clickhouse/configs/` and apply one by name when starting a server:
+`clickhousectl local server start` uses ClickHouse's embedded defaults without creating an editable main config file or loading `/etc/clickhouse-server/config.xml`. To customize the server, supply a **partial config** containing only the settings you want to change; everything else inherits the defaults.
+
+Create a file in the global `~/.clickhouse/configs/` directory and select it by name. This example enables the query log and sets the default user's `max_threads` query setting:
 
 ```bash
 mkdir -p ~/.clickhouse/configs
@@ -499,15 +501,35 @@ cat > ~/.clickhouse/configs/analytics.xml <<'EOF'
         <database>system</database>
         <table>query_log</table>
     </query_log>
+    <profiles>
+        <default>
+            <max_threads>4</max_threads>
+        </default>
+    </profiles>
 </clickhouse>
 EOF
-clickhousectl local server configs                          # List available config files
-clickhousectl local server start --config analytics         # Start a server with it
+clickhousectl local server configs                          # Show the directory and available files
+clickhousectl local server start dev --config analytics     # Apply the partial config to server "dev"
 ```
 
-The named file is **overlaid on top of ClickHouse's built-in defaults** (it is staged into the server's `config.d/` directory), so it only needs to contain the settings you want to change — you don't have to reproduce a full config. Files may be `.xml`, `.yaml`, or `.yml`; reference them by name with or without the extension (e.g. `--config analytics` or `--config analytics.xml`). `--config` takes a name within `~/.clickhouse/configs/` **not a path**. (`--config-file` remains supported as a legacy alias.)
+**Using an existing fragment:** A file intended for ClickHouse's `config.d/`, such as `tokenizers.xml`, can go directly into `~/.clickhouse/configs/`; select it with `--config tokenizers`. Each XML file needs a `<clickhouse>` root. You do not need to scaffold the default config first.
 
-The managed data directory (`.clickhouse/servers/<name>/data/`) and the HTTP/TCP ports are always forced as command-line overrides, which take precedence over the config file. This means a custom config can never break the managed server lifecycle (`list`, `stop`, `remove`, `dotenv`) regardless of its contents. Starting a server again without `--config` reverts it to plain defaults.
+**Users and query settings:** A packaged ClickHouse installation usually puts users, profiles and quotas in `users.xml`. The embedded defaults keep them in the main configuration, so your partial config can contain `<users>`, `<profiles>` and `<quotas>` alongside server settings. Put query settings under a profile, as above. A separate `users.xml` or `users.d/` is not required or automatically loaded.
+
+**Selecting a file:** Files may be `.xml`, `.yaml`, or `.yml`; use the name with or without its extension (e.g. `--config analytics.xml`). If two files share a stem, include the extension. `--config` selects one file directly inside `~/.clickhouse/configs/`, not a path or directory. Sibling files and directories are not copied. `--config-file` remains a legacy alias.
+
+**Applying edits:** The selected file is copied into the project's `.clickhouse/servers/<name>/data/config.d/chctl-config.<ext>` at each start. Edit the source in `~/.clickhouse/configs/`, then stop and start the same server with `--config` again:
+
+```bash
+clickhousectl local server stop dev
+clickhousectl local server start dev --config analytics
+```
+
+The selection is not remembered: starting without `--config` removes chctl's previously copied overlay. Other manually added runtime fragments are left in place. Referenced files, such as tokenizer dictionaries, must be accessible to the server; its working directory is `.clickhouse/servers/<name>/data/`, not the source config directory.
+
+**Inspecting configuration:** ClickHouse writes the merged configuration to `.clickhouse/servers/<name>/data/preprocessed_configs/config.xml`. This is generated output and is overwritten; edit the source overlay instead. chctl passes the managed data path and HTTP/TCP ports as command-line overrides, which take precedence over values in config files.
+
+ClickHouse merges partial configurations recursively; XML `replace` and `remove` attributes explicitly replace or delete settings. See [ClickHouse configuration files](https://clickhouse.com/docs/operations/configuration-files) for merge rules and XML/YAML syntax.
 
 #### Local Postgres (Docker-backed)
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -274,6 +274,7 @@ CONTEXT FOR AGENTS:
   Data persists across stop/start; only `remove` deletes it.
   Retain the name `start` returns (it may be generated) for later `stop`/`remove`.
   `local remove <version>` deletes an installed binary, not server data.
+  Custom configs inherit built-in defaults; find available names with `server configs`.
   Typical flow: `server start dev` -> `local client --name dev` -> `server stop dev`")]
     Server {
         #[command(subcommand)]
@@ -301,7 +302,9 @@ CONTEXT FOR AGENTS:
   Starting a name that is already running is an error; a bare start with \"default\" already
   running picks a new generated name instead.
   With no --version and no default set, start installs \"latest\" first (~150 MB) without making
-  it the default.")]
+  it the default.
+  After editing a custom config, stop the server and start again with the same --config.
+  Omitting --config on a later start removes the previously selected override.")]
     Start {
         /// Server name (default: "default", or random if default is already running)
         #[arg(value_name = "NAME", conflicts_with = "name_flag")]
@@ -339,7 +342,9 @@ CONTEXT FOR AGENTS:
         #[arg(long, conflicts_with = "foreground")]
         no_wait: bool,
 
-        /// Named config file from ~/.clickhouse/configs/ (see `server configs`)
+        /// Overlay defaults with a named partial config (see `server configs`)
+        ///
+        /// Select one file from ~/.clickhouse/configs/; paths are not accepted.
         #[arg(long = "config", alias = "config-file", value_name = "NAME")]
         config_file: Option<String>,
 
@@ -353,10 +358,10 @@ CONTEXT FOR AGENTS:
     /// List custom config files available to `server start --config`
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Lists ~/.clickhouse/configs/ (.xml, .yaml, .yml) and prints that path.
-  Drop a file there, then `clickhousectl local server start --config <name>`; the extension is
-  optional in <name>, but an ambiguous stem is an error.
-  Merged as a config.d overlay on ClickHouse's defaults, so it needs only the settings you change.")]
+  Run this command to find the config directory, then add an XML or YAML file.
+  Include only the server, user, profile or quota settings you want to change.
+  Select one file with `server start --config <name>`; its extension is optional.
+  If names share a stem, specify the extension.")]
     Configs,
 
     /// List all server instances (running and stopped)

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -849,7 +849,9 @@ impl fmt::Display for ServerConfigsOutput {
             writeln!(f, "No config files in {}", self.dir)?;
             write!(
                 f,
-                "Drop a ClickHouse config file there, then start with: \
+                "Create an XML or YAML file there with only the settings you want to change.\n\
+                 Other settings inherit ClickHouse's built-in defaults.\n\
+                 Start with: \
                  clickhousectl local server start --config <NAME>"
             )?;
             return Ok(());


### PR DESCRIPTION
Stacked on #756 (`docs/755-readme-products`).

`local server start --config` was described as a custom config file at the point of use, making it easy to assume a complete default config was required. The flag and empty config-list guidance now explain that files contain only changed settings and inherit the remaining defaults.

The README demonstrates server and profile settings in one overlay, explains how to use an existing `config.d` fragment, and documents source edits, restart selection, generated output, and file lookup. Help keeps the short operational guidance; config loading and JSON output are unchanged.

Closes #764.

Validation (run before restacking; patch unchanged):

- `cargo fmt --all` and `git diff --check`
- `cargo clippy -p clickhousectl -- -D warnings`
- `cargo test -p clickhousectl`: one existing port-dependent stderr assertion fails (details below); all other executed tests pass, with one ignored test.
- `cargo test -p clickhousectl --test local_version_error_test --test telemetry_test` covers the binaries the full run stopped before reaching.
- `cargo check -p clickhousectl --no-default-features`
- `cargo clippy -p clickhousectl --all-targets --no-default-features -- -D warnings`
- Manually reviewed rendered server/start/configs help against the repository help standard.

Local test limitation: `config_and_argument_failures_carry_their_full_human_detail_in_json` fails because OrbStack already listens on 8123 and 9000. The CLI emits `Note: default ports in use, auto-assigned HTTP:8124 TCP:9001` before the missing-config error, while the unchanged test expects only the error. A focused rerun reproduces it. The change does not touch port selection or error rendering.


Restacking validation: `git range-diff` confirms the same single-commit patch; `cargo fmt --all` and `git diff --check` pass on the new base.
