### PR TITLE
fix(cloud): tolerate closed stderr for notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,8 @@ inactive and identifies the source that outranked them.
 
 Pass `--debug` to a Cloud resource command to print the resolved credential source (and the API URL) to stderr before the command runs. This works with and without `--json`.
 
+Cloud notices on stderr are best-effort: if their reader goes away, the operation still runs and reports its outcome through the exit status.
+
 ```bash
 clickhousectl cloud --debug service list
 # [debug] auth source: credentials file (.clickhouse/credentials.json)

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -1,4 +1,5 @@
 use crate::cloud::credentials;
+use crate::cloud::output::eprint_line;
 use crate::cloud::{
     AuthSource, dotenv_env_provenance, env_cred_presence, resolve_active_auth_source,
 };
@@ -265,8 +266,10 @@ pub async fn run(
 
             if debug {
                 match active {
-                    Some(source) => eprintln!("[debug] auth source: {}", source.describe()),
-                    None => eprintln!("[debug] auth source: none (no credentials configured)"),
+                    Some(source) => {
+                        eprint_line(format!("[debug] auth source: {}", source.describe()))
+                    }
+                    None => eprint_line("[debug] auth source: none (no credentials configured)"),
                 }
             }
 
@@ -682,8 +685,10 @@ pub async fn ensure_fresh_tokens() -> Result<(), Box<dyn std::error::Error>> {
         Err(_) => {
             // Refresh failed — clear stale tokens so we fall back to API keys
             clear_tokens();
-            eprintln!("Warning: OAuth token refresh failed. Tokens cleared.");
-            eprintln!("Run `clickhousectl cloud auth login` to re-authenticate, or use API keys.");
+            eprint_line("Warning: OAuth token refresh failed. Tokens cleared.");
+            eprint_line(
+                "Run `clickhousectl cloud auth login` to re-authenticate, or use API keys.",
+            );
         }
     }
 

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -28,6 +28,7 @@ pub use client::{
 
 use crate::error::{Error, Result};
 use cli::{CloudArgs, CloudCommands};
+use output::eprint_line;
 
 /// Explain when a configured environment credential cannot participate in
 /// authentication because a higher-precedence source won. Keep this notice on
@@ -75,12 +76,15 @@ pub async fn run(args: CloudArgs, json: bool) -> Result<()> {
 
     if let Some(notice) = ignored_env_credentials_notice(client.auth_source(), env_cred_presence())
     {
-        eprintln!("{notice}");
+        eprint_line(notice);
     }
 
     if args.debug {
-        eprintln!("[debug] auth source: {}", client.auth_source().describe());
-        eprintln!("[debug] api url: {}", client.base_url());
+        eprint_line(format!(
+            "[debug] auth source: {}",
+            client.auth_source().describe()
+        ));
+        eprint_line(format!("[debug] api url: {}", client.base_url()));
     }
 
     // OAuth (Bearer) tokens are read-only. Block write commands early

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -3582,10 +3582,10 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                         return Err(refused_query_provisioning_error(&service_id, &error)
                             .at_stage(FailureStage::QueryRequest));
                     }
-                    eprintln!(
+                    eprint_line(format!(
                         "Provisioning Query API endpoint + key for service '{}'...",
                         service_name
-                    );
+                    ));
                     failure::set_provisioning_state(ProvisioningState::Provisioning);
                     let key = crate::cloud::service_query::ensure_service_query_setup(
                         client,
@@ -3645,7 +3645,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
         QueryOutputCompletion::Newline => handle
             .write_all(b"\n")
             .map_err(|error| stream_failure(CloudError::from(error)))?,
-        QueryOutputCompletion::Acknowledge => eprintln!("OK"),
+        QueryOutputCompletion::Acknowledge => eprint_line("OK"),
     }
     handle
         .flush()
@@ -3683,7 +3683,9 @@ fn query_format_uses_text_lines(format: &str) -> bool {
 }
 
 fn eprint_waking_service(service_name: &str) {
-    eprintln!("Service '{service_name}' is idle; waking it (this may take a minute)...");
+    eprint_line(format!(
+        "Service '{service_name}' is idle; waking it (this may take a minute)..."
+    ));
 }
 
 /// A service's native-protocol (`nativesecure`) endpoint.

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2402,6 +2402,62 @@ async fn credentials_file_reports_that_environment_credentials_are_ignored() {
     assert_eq!(authorization, expected);
 }
 
+/// #677: credential-precedence and debug notices are emitted before dispatch.
+/// A reader may close stderr before either notice is written; the command must
+/// still reach the API and report its outcome through the exit status.
+#[tokio::test]
+async fn cloud_command_survives_closed_stderr_with_credential_notice_and_debug() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [],
+            "status": 200,
+            "requestId": "stub-org-list",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_project_api_credentials(dir.path(), "file-key", "file-secret");
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    let mut child = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "env-key")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "env-secret")
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "--debug",
+            "org",
+            "list",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+
+    drop(child.stderr.take().expect("stderr was piped"));
+    let status = child.wait().expect("failed to wait for clickhousectl");
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a closed stderr must not prevent cloud command dispatch"
+    );
+    assert_eq!(
+        received_request_shape(&mock).await,
+        vec![("GET".to_string(), "/v1/organizations".to_string())]
+    );
+}
+
 #[test]
 fn auth_status_marks_outranked_environment_credentials_inactive() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
fix(cloud): tolerate closed stderr for notices

Cloud resource commands could panic with exit 101 before dispatch when credential-precedence or debug notices encountered a closed stderr. Route informational Cloud stderr lines through the existing best-effort writer so the command continues and its exit status reflects the operation; this also covers the remaining auth and service-query status notices in the same bug class.

Add a subprocess regression with environment credentials shadowed by project credentials and `--debug`: it closes the stderr reader before waiting, asserts exit 0, and verifies the organization request reached the mock API. Document that Cloud stderr notices are best-effort.

Validation:
- `cargo fmt --all`
- `cargo test -p clickhousectl --test cli_request_shape_test closed_stderr` (4 passed)

Closes #677
