### PR TITLE
fix(postgres): execute files and stdin through Docker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ clickhousectl local postgres remove                       # Remove "default"
 clickhousectl local postgres remove dev
 ```
 
-`local postgres client --queries-file` accepts relative or absolute host paths, or `-` to read stdin (for example, `cat seed.sql | clickhousectl local postgres client --queries-file -`). This also works when host `psql` is unavailable: the Docker fallback streams the SQL to container `psql`. When combined, `--query` executes before the file; append `-- -v ON_ERROR_STOP=1` to stop on SQL errors and preserve psql's nonzero exit status. In Docker mode, file contents are streamed as `psql -f -`; paths used inside SQL (such as `\i` or `\copy`) still refer to the container filesystem.
+`local postgres client --queries-file` accepts relative or absolute host paths, or `-` to read stdin. Plain pipes also work, for example `cat seed.sql | clickhousectl local postgres client`. Both forms work when host `psql` is unavailable: the Docker fallback streams SQL to container `psql`, preserves EOF and returns psql's exit status. When combined, `--query` executes before the file; append native arguments such as `-- -v ON_ERROR_STOP=1` to stop on SQL errors. In Docker mode, file contents are streamed as `psql -f -`; paths used inside SQL (such as `\i` or `\copy`) still refer to the container filesystem.
 
 Postgres `--name` and `--version` select a managed instance and cannot be combined with direct `--host` or `--port` selectors.
 

--- a/README.md
+++ b/README.md
@@ -569,6 +569,8 @@ clickhousectl local postgres remove                       # Remove "default"
 clickhousectl local postgres remove dev
 ```
 
+`local postgres client --queries-file` accepts relative or absolute host paths, or `-` to read stdin (for example, `cat seed.sql | clickhousectl local postgres client --queries-file -`). This also works when host `psql` is unavailable: the Docker fallback streams the SQL to container `psql`. When combined, `--query` executes before the file; append `-- -v ON_ERROR_STOP=1` to stop on SQL errors and preserve psql's nonzero exit status. In Docker mode, file contents are streamed as `psql -f -`; paths used inside SQL (such as `\i` or `\copy`) still refer to the container filesystem.
+
 Postgres `--name` and `--version` select a managed instance and cannot be combined with direct `--host` or `--port` selectors.
 
 The Postgres `dotenv` command includes the generated password. Do not commit its output; prefer `--local` when your application reads `.env.local`.

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -725,13 +725,13 @@ pub async fn list_project_postgres(
     Ok(out)
 }
 
-/// Run `psql` inside a container in non-interactive mode: no TTY, no raw
-/// mode, no stdin. Streams stdout+stderr to the host. Used when the caller
-/// passes `--query` or `--queries-file` so the output can be piped/scripted.
+/// Run `psql` without a TTY, streaming an optional host SQL file or stdin
+/// into the exec stream while forwarding stdout and stderr independently.
 pub async fn exec_psql_one_shot(
     docker: &Docker,
     container_id: &str,
     psql_args: &[String],
+    reader: Option<Box<dyn io::Read + Send>>,
 ) -> Result<()> {
     use bollard::exec::StartExecResults;
     use bollard::models::ExecConfig;
@@ -746,7 +746,7 @@ pub async fn exec_psql_one_shot(
             ExecConfig {
                 attach_stdout: Some(true),
                 attach_stderr: Some(true),
-                attach_stdin: Some(false),
+                attach_stdin: Some(reader.is_some()),
                 tty: Some(false),
                 cmd: Some(cmd),
                 ..Default::default()
@@ -760,32 +760,97 @@ pub async fn exec_psql_one_shot(
         .start_exec(&exec_id, None)
         .await
         .map_err(|e| Error::DockerError(e.to_string()))?;
-    let mut output = match started {
-        StartExecResults::Attached { output, .. } => output,
-        StartExecResults::Detached => return Ok(()),
+    let (mut output, mut input) = match started {
+        StartExecResults::Attached { output, input } => (output, input),
+        StartExecResults::Detached => {
+            return Err(Error::DockerError("psql exec unexpectedly detached".into()));
+        }
     };
 
-    let mut stdout = tokio::io::stdout();
-    let mut stderr = tokio::io::stderr();
-    while let Some(chunk) = output.next().await {
-        match chunk {
-            Ok(bollard::container::LogOutput::StdErr { message }) => {
-                let _ = stderr.write_all(&message).await;
-            }
-            Ok(out) => {
-                let _ = stdout.write_all(&out.into_bytes()).await;
-            }
-            Err(_) => break,
+    let write_input = async {
+        if let Some(reader) = reader {
+            let result = stream_psql_input(reader, &mut input).await;
+            // Docker needs a half-close to deliver EOF to psql's -f -. Keep
+            // the read half alive until all output and the exit status arrive.
+            let shutdown = input.shutdown().await;
+            result?;
+            shutdown?;
         }
-    }
-    let _ = stdout.flush().await;
-    let _ = stderr.flush().await;
+        Ok::<_, Error>(())
+    };
+    let read_output = async {
+        let mut stdout = tokio::io::stdout();
+        let mut stderr = tokio::io::stderr();
+        while let Some(chunk) = output.next().await {
+            match chunk.map_err(|error| Error::DockerError(error.to_string()))? {
+                bollard::container::LogOutput::StdErr { message } => {
+                    stderr.write_all(&message).await?;
+                    stderr.flush().await?;
+                }
+                out => {
+                    stdout.write_all(&out.into_bytes()).await?;
+                    stdout.flush().await?;
+                }
+            }
+        }
+        Ok::<_, Error>(())
+    };
+    tokio::pin!(write_input, read_output);
+    let (input_result, output_result) = tokio::select! {
+        result = &mut write_input => (result, read_output.await),
+        result = &mut read_output => (Ok(()), result),
+    };
 
-    if let Ok(info) = docker.inspect_exec(&exec_id).await
-        && let Some(code) = info.exit_code
-        && code != 0
-    {
-        return Err(Error::ChildExit(code as i32));
+    let info = docker
+        .inspect_exec(&exec_id)
+        .await
+        .map_err(|error| Error::DockerError(error.to_string()))?;
+    match info.exit_code {
+        Some(code) if code != 0 => Err(Error::ChildExit(code as i32)),
+        Some(0) if info.running != Some(true) => {
+            output_result?;
+            input_result
+        }
+        _ => Err(Error::DockerError(
+            "psql exec has no final exit status".into(),
+        )),
+    }
+}
+
+async fn stream_psql_input(
+    mut reader: Box<dyn io::Read + Send>,
+    input: &mut (impl tokio::io::AsyncWrite + Unpin),
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    // A dedicated reader thread and bounded channel keep pipes streaming with
+    // bounded memory. Unlike tokio::io::stdin's blocking-pool task, this thread
+    // cannot hold runtime shutdown hostage when psql exits before stdin EOF.
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
+    std::thread::Builder::new()
+        .name("psql-input".into())
+        .spawn(move || {
+            loop {
+                let mut buffer = vec![0; 8192];
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        buffer.truncate(count);
+                        if sender.blocking_send(Ok(buffer)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) => {
+                        let _ = sender.blocking_send(Err(error));
+                        break;
+                    }
+                }
+            }
+        })?;
+    while let Some(chunk) = receiver.recv().await {
+        input.write_all(&chunk?).await?;
+        input.flush().await?;
     }
     Ok(())
 }

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -1102,16 +1102,28 @@ async fn client(
         psql_args.push("-c".into());
         psql_args.push(q);
     }
-    if let Some(f) = queries_file {
-        psql_args.push("-f".into());
-        psql_args.push(f);
-    }
+    // Host paths do not exist inside the container. Stream the selected file
+    // through psql's explicit stdin file argument, after any -c command.
+    let input: Option<Box<dyn std::io::Read + Send>> = match queries_file {
+        Some(file) => {
+            let reader: Box<dyn std::io::Read + Send> = if file == "-" {
+                Box::new(std::io::stdin())
+            } else {
+                Box::new(std::fs::File::open(&file).map_err(|error| {
+                    Error::Postgres(format!("could not open SQL file {file:?}: {error}"))
+                })?)
+            };
+            psql_args.extend(["-f".into(), "-".into()]);
+            Some(reader)
+        }
+        None => None,
+    };
     psql_args.extend(extra_args);
 
     if one_shot {
         // Non-interactive: no TTY, no raw mode, output goes to stdout/stderr
         // so the caller can pipe / capture / redirect.
-        docker::exec_psql_one_shot(&docker, container_id, &psql_args).await
+        docker::exec_psql_one_shot(&docker, container_id, &psql_args, input).await
     } else {
         docker::exec_psql_in_container(&docker, container_id, &psql_args).await
     }

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -12,6 +12,7 @@ use crate::local::server::{self, Engine, ServerInfo};
 use rand::distr::{Alphanumeric, SampleString};
 use std::collections::HashSet;
 use std::future::Future;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
@@ -1096,7 +1097,9 @@ async fn client(
         );
     }
 
-    let one_shot = query.is_some() || queries_file.is_some();
+    let explicit_input = query.is_some() || queries_file.is_some();
+    let interactive =
+        !explicit_input && std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
     let mut psql_args: Vec<String> = vec!["-U".into(), user, "-d".into(), database];
     if let Some(q) = query {
         psql_args.push("-c".into());
@@ -1116,11 +1119,14 @@ async fn client(
             psql_args.extend(["-f".into(), "-".into()]);
             Some(reader)
         }
+        // Match host psql: without an explicit wrapper input, a non-terminal
+        // stdin is still SQL input. Docker must attach it and receive EOF.
+        None if !explicit_input && !interactive => Some(Box::new(std::io::stdin())),
         None => None,
     };
     psql_args.extend(extra_args);
 
-    if one_shot {
+    if !interactive {
         // Non-interactive: no TTY, no raw mode, output goes to stdout/stderr
         // so the caller can pipe / capture / redirect.
         docker::exec_psql_one_shot(&docker, container_id, &psql_args, input).await

--- a/crates/clickhousectl/tests/local_postgres_client_input_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_client_input_test.rs
@@ -267,6 +267,56 @@ fn explicit_stdin_and_empty_input_reach_eof() {
 }
 
 #[test]
+fn plain_piped_stdin_uses_non_tty_exec_and_reaches_eof() {
+    let fixture = Fixture::new(0, false);
+    let mut child = fixture
+        .command(&[])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"SELECT 1;\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output);
+
+    let execution = fixture.execution.lock().unwrap();
+    assert_eq!(execution.input, b"SELECT 1;\n");
+    let config = execution.config.as_ref().unwrap();
+    assert_eq!(config["AttachStdin"], true);
+    assert_eq!(config["Tty"], false);
+    assert_eq!(
+        config["Cmd"],
+        json!(["psql", "-U", "postgres", "-d", "postgres"])
+    );
+}
+
+#[test]
+fn native_command_passthrough_uses_non_tty_exec() {
+    let fixture = Fixture::new(0, false);
+    let output = fixture
+        .command(&["--", "-c", "SELECT 2"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_success(&output);
+
+    let execution = fixture.execution.lock().unwrap();
+    let config = execution.config.as_ref().unwrap();
+    assert_eq!(config["AttachStdin"], true);
+    assert_eq!(config["Tty"], false);
+    assert_eq!(
+        config["Cmd"],
+        json!(["psql", "-U", "postgres", "-d", "postgres", "-c", "SELECT 2"])
+    );
+}
+
+#[test]
 fn file_and_stdin_preserve_psql_error_status() {
     for stdin in [false, true] {
         let fixture = Fixture::new(3, false);
@@ -294,6 +344,27 @@ fn file_and_stdin_preserve_psql_error_status() {
         assert_eq!(output.status.code(), Some(3));
         assert!(String::from_utf8_lossy(&output.stderr).contains("psql diagnostic"));
     }
+}
+
+#[test]
+fn plain_piped_stdin_preserves_psql_error_status() {
+    let fixture = Fixture::new(3, false);
+    let mut child = fixture
+        .command(&[])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"BAD SQL;\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("psql diagnostic"));
 }
 
 #[test]

--- a/crates/clickhousectl/tests/local_postgres_client_input_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_client_input_test.rs
@@ -1,0 +1,461 @@
+//! SQL input and exit-status coverage for the managed Docker psql fallback.
+
+use serde_json::{Value, json};
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct Execution {
+    config: Option<Value>,
+    input: Vec<u8>,
+}
+
+struct Fixture {
+    project: tempfile::TempDir,
+    home: tempfile::TempDir,
+    execution: Arc<Mutex<Execution>>,
+    stop: Arc<AtomicBool>,
+    daemon: Option<JoinHandle<()>>,
+}
+
+impl Fixture {
+    fn new(exit_code: i32, early_exit: bool) -> Self {
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        write_metadata(project.path(), "pg-id");
+        let listener = UnixListener::bind(home.path().join("docker.sock")).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop.clone();
+        let execution = Arc::new(Mutex::new(Execution::default()));
+        let thread_execution = execution.clone();
+        let daemon = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Relaxed) {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(connection) => connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(error) => panic!("accept: {error}"),
+                };
+                stream.set_nonblocking(false).unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let (path, body) = read_request(&mut stream);
+                if path == "/_ping" {
+                    respond(&mut stream, "OK");
+                } else if path.starts_with("/containers/json") {
+                    respond(&mut stream, "[]");
+                } else if path == "/containers/pg-id/json" {
+                    respond(
+                        &mut stream,
+                        r#"{"Id":"pg-id","State":{"Running":true},"Config":{"Env":["POSTGRES_USER=postgres","POSTGRES_DB=postgres"]}}"#,
+                    );
+                } else if path == "/containers/pg-id/exec" {
+                    thread_execution.lock().unwrap().config =
+                        Some(serde_json::from_slice(&body).unwrap());
+                    respond(&mut stream, r#"{"Id":"psql-exec"}"#);
+                } else if path == "/exec/psql-exec/start" {
+                    stream.write_all(b"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n").unwrap();
+                    let attach = thread_execution.lock().unwrap().config.as_ref().unwrap()["AttachStdin"]
+                        == true;
+                    if attach && !early_exit {
+                        let mut input = Vec::new();
+                        stream
+                            .read_to_end(&mut input)
+                            .expect("SQL input must reach EOF");
+                        thread_execution.lock().unwrap().input = input;
+                    }
+                    write_frame(&mut stream, 1, b"query output\n");
+                    write_frame(&mut stream, 2, b"psql diagnostic\n");
+                } else if path == "/exec/psql-exec/json" {
+                    respond(
+                        &mut stream,
+                        &json!({"ExitCode":exit_code,"Running":false}).to_string(),
+                    );
+                } else {
+                    panic!("unexpected Docker request: {path}");
+                }
+            }
+        });
+        Self {
+            project,
+            home,
+            execution,
+            stop,
+            daemon: Some(daemon),
+        }
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut command = client_command(self.project.path());
+        command
+            .env("HOME", self.home.path())
+            .env(
+                "DOCKER_HOST",
+                format!("unix://{}", self.home.path().join("docker.sock").display()),
+            )
+            .args(args);
+        command
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(daemon) = self.daemon.take() {
+            let result = daemon.join();
+            if !std::thread::panicking() {
+                result.unwrap();
+            }
+        }
+    }
+}
+
+fn client_command(project: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_clickhousectl"));
+    command
+        .env("DO_NOT_TRACK", "1")
+        // An empty directory forces fallback regardless of the host's tools.
+        .env("PATH", project.join("empty-path"))
+        .current_dir(project)
+        .args(["local", "postgres", "client"]);
+    command
+}
+
+fn write_metadata(project: &Path, container: &str) {
+    let servers = project.join(".clickhouse/servers");
+    std::fs::create_dir_all(&servers).unwrap();
+    std::fs::create_dir_all(project.join("empty-path")).unwrap();
+    std::fs::write(
+        servers.join("default-pg18.json"),
+        json!({
+            "name":"default-pg18", "pid":0, "version":"postgres:18", "http_port":0,
+            "tcp_port":5432, "started_at":"1700000000", "cwd":project,
+            "engine":"postgres", "container_id":container
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+fn read_request(stream: &mut UnixStream) -> (String, Vec<u8>) {
+    let mut headers = Vec::new();
+    while !headers.ends_with(b"\r\n\r\n") {
+        let mut byte = [0];
+        stream.read_exact(&mut byte).unwrap();
+        headers.push(byte[0]);
+    }
+    let headers = String::from_utf8(headers).unwrap();
+    let path = headers
+        .lines()
+        .next()
+        .unwrap()
+        .split_whitespace()
+        .nth(1)
+        .unwrap()
+        .to_string();
+    let count: usize = headers
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .map(|s| s.trim().parse().unwrap())
+        })
+        .unwrap_or(0);
+    let mut body = vec![0; count];
+    stream.read_exact(&mut body).unwrap();
+    (path, body)
+}
+
+fn respond(stream: &mut UnixStream, body: &str) {
+    write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).unwrap();
+}
+
+fn write_frame(stream: &mut UnixStream, channel: u8, body: &[u8]) {
+    stream.write_all(&[channel, 0, 0, 0]).unwrap();
+    stream
+        .write_all(&(body.len() as u32).to_be_bytes())
+        .unwrap();
+    stream.write_all(body).unwrap();
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn relative_and_absolute_host_files_stream_in_query_order() {
+    for absolute in [false, true] {
+        let fixture = Fixture::new(0, false);
+        let sql = "INSERT INTO data VALUES ('Grüße');\n".repeat(4096);
+        let file = fixture.project.path().join("input with spaces.sql");
+        std::fs::write(&file, &sql).unwrap();
+        let path = if absolute {
+            file.to_str().unwrap()
+        } else {
+            "input with spaces.sql"
+        };
+        let output = fixture
+            .command(&[
+                "--query",
+                "CREATE TABLE data (value text)",
+                "--queries-file",
+                path,
+            ])
+            .output()
+            .unwrap();
+        assert_success(&output);
+        assert_eq!(output.stdout, b"query output\n");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("psql diagnostic"));
+        let execution = fixture.execution.lock().unwrap();
+        assert_eq!(execution.input, sql.as_bytes());
+        let config = execution.config.as_ref().unwrap();
+        assert_eq!(
+            config["Cmd"],
+            json!([
+                "psql",
+                "-U",
+                "postgres",
+                "-d",
+                "postgres",
+                "-c",
+                "CREATE TABLE data (value text)",
+                "-f",
+                "-"
+            ])
+        );
+        assert_eq!(config["AttachStdin"], true);
+        assert_eq!(config["Tty"], false);
+    }
+}
+
+#[test]
+fn explicit_stdin_and_empty_input_reach_eof() {
+    for sql in ["INSERT INTO data VALUES (2);\n", ""] {
+        let fixture = Fixture::new(0, false);
+        let mut child = fixture
+            .command(&["--queries-file", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(sql.as_bytes())
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert_success(&output);
+        assert_eq!(fixture.execution.lock().unwrap().input, sql.as_bytes());
+    }
+}
+
+#[test]
+fn file_and_stdin_preserve_psql_error_status() {
+    for stdin in [false, true] {
+        let fixture = Fixture::new(3, false);
+        std::fs::write(fixture.project.path().join("bad.sql"), "BAD SQL;\n").unwrap();
+        let mut child = fixture
+            .command(&[
+                "--queries-file",
+                if stdin { "-" } else { "bad.sql" },
+                "--",
+                "-v",
+                "ON_ERROR_STOP=1",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"BAD SQL;\n")
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert_eq!(output.status.code(), Some(3));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("psql diagnostic"));
+    }
+}
+
+#[test]
+fn missing_host_file_fails_before_executing_query() {
+    let fixture = Fixture::new(0, false);
+    let output = fixture
+        .command(&[
+            "--query",
+            "DROP TABLE data",
+            "--queries-file",
+            "missing.sql",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(fixture.execution.lock().unwrap().config.is_none());
+}
+
+#[test]
+fn query_only_keeps_stdin_detached() {
+    let fixture = Fixture::new(0, false);
+    assert_success(&fixture.command(&["--query", "SELECT 1"]).output().unwrap());
+    assert_eq!(
+        fixture.execution.lock().unwrap().config.as_ref().unwrap()["AttachStdin"],
+        false
+    );
+}
+
+#[test]
+fn early_psql_exit_does_not_wait_for_open_stdin() {
+    let fixture = Fixture::new(3, true);
+    let mut child = fixture
+        .command(&["--queries-file", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let _held_open = child.stdin.take().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert_eq!(status.code(), Some(3));
+            break;
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("psql exit blocked on an upstream pipe that stayed open");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Exercises actual database effects. Requires Docker and postgres:18 (pulled
+/// on demand); creates one uniquely named disposable container with tmpfs data.
+#[test]
+#[ignore = "requires a running Docker daemon"]
+fn real_docker_file_and_stdin_apply_sql_and_propagate_errors() {
+    struct Container(String);
+    impl Drop for Container {
+        fn drop(&mut self) {
+            let output = Command::new("docker")
+                .args(["rm", "-f", &self.0])
+                .output()
+                .unwrap();
+            assert_success(&output);
+        }
+    }
+    let container = Container(format!("chctl-760-{}", uuid::Uuid::new_v4()));
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--name",
+            &container.0,
+            "--tmpfs",
+            "/var/lib/postgresql",
+            "-e",
+            "POSTGRES_HOST_AUTH_METHOD=trust",
+            "postgres:18",
+        ])
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let project = tempfile::tempdir().unwrap();
+    write_metadata(project.path(), &container.0);
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        if Command::new("docker")
+            .args(["exec", &container.0, "pg_isready", "-U", "postgres"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "Postgres readiness timeout");
+        thread::sleep(Duration::from_millis(200));
+    }
+    let run = |args: &[&str], input: Option<&str>| {
+        let mut child = client_command(project.path())
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        if let Some(input) = input {
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(input.as_bytes())
+                .unwrap();
+        }
+        child.wait_with_output().unwrap()
+    };
+    let file = project.path().join("seed file.sql");
+    std::fs::write(&file, "INSERT INTO qa_files VALUES (1);\n").unwrap();
+    // The INSERT depends on the preceding --query in this same psql session.
+    assert_success(&run(
+        &[
+            "--query",
+            "CREATE TABLE qa_files (id integer)",
+            "--queries-file",
+            "seed file.sql",
+        ],
+        None,
+    ));
+    std::fs::write(&file, "INSERT INTO qa_files VALUES (2);\n").unwrap();
+    assert_success(&run(&["--queries-file", file.to_str().unwrap()], None));
+    assert_success(&run(
+        &["--queries-file", "-"],
+        Some("INSERT INTO qa_files VALUES (3);\n"),
+    ));
+    let rows = run(
+        &[
+            "--query",
+            "SELECT string_agg(id::text, ',' ORDER BY id) FROM qa_files",
+            "--",
+            "-tA",
+        ],
+        None,
+    );
+    assert_success(&rows);
+    assert_eq!(String::from_utf8_lossy(&rows.stdout).trim(), "1,2,3");
+    for path in [file.to_str().unwrap(), "-"] {
+        let bad_sql = "THIS IS INVALID SQL;\nINSERT INTO qa_files VALUES (99);\n";
+        std::fs::write(&file, bad_sql).unwrap();
+        let output = run(
+            &["--queries-file", path, "--", "-v", "ON_ERROR_STOP=1"],
+            Some(bad_sql),
+        );
+        assert_eq!(output.status.code(), Some(3), "{output:?}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("ERROR"));
+    }
+    let rows = run(
+        &["--query", "SELECT count(*) FROM qa_files", "--", "-tA"],
+        None,
+    );
+    assert_success(&rows);
+    assert_eq!(String::from_utf8_lossy(&rows.stdout).trim(), "3");
+}

--- a/crates/clickhousectl/tests/local_postgres_client_input_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_client_input_test.rs
@@ -384,7 +384,17 @@ fn real_docker_file_and_stdin_apply_sql_and_propagate_errors() {
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
         if Command::new("docker")
-            .args(["exec", &container.0, "pg_isready", "-U", "postgres"])
+            // The image's temporary initdb server only listens on a Unix
+            // socket. Wait for TCP so we cannot race its shutdown/restart.
+            .args([
+                "exec",
+                &container.0,
+                "pg_isready",
+                "-h",
+                "127.0.0.1",
+                "-U",
+                "postgres",
+            ])
             .output()
             .unwrap()
             .status

--- a/scripts/classify-cloud-integration.py
+++ b/scripts/classify-cloud-integration.py
@@ -92,6 +92,7 @@ SOURCE_PATH_SUITES = {
 }
 
 TEST_PATH_SUITES = {
+    "crates/clickhousectl/tests/local_postgres_client_input_test.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/tests/clickpipes/driver.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/tests/clickpipes/e2e_test.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/tests/clickpipes/kafka_test.rs": NO_SUITES,

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -59,6 +59,7 @@ NON_INSTALL_EXACT_PATHS = frozenset(
         "crates/clickhousectl/tests/local_docker_diagnostics_test.rs",
         "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
         "crates/clickhousectl/tests/local_init_json_test.rs",
+        "crates/clickhousectl/tests/local_postgres_client_input_test.rs",
         "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
         "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
         "crates/clickhousectl/tests/local_remove_default_test.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -132,6 +132,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
                     "crates/clickhousectl/tests/local_docker_diagnostics_test.rs",
                     "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
                     "crates/clickhousectl/tests/local_init_json_test.rs",
+                    "crates/clickhousectl/tests/local_postgres_client_input_test.rs",
                     "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
                     "crates/clickhousectl/tests/local_postgres_start_validation_test.rs",
                     "crates/clickhousectl/tests/local_remove_default_test.rs",


### PR DESCRIPTION
When host `psql` is absent, relative and absolute host files and `--queries-file -` stream through Docker to `psql -f -`; a wrapper query runs before the file.

Docker fallback now chooses interactivity from stdin/stdout terminal status. Plain piped SQL and native passthrough such as `-- -c` work without a terminal; file/stdin streaming retains EOF handling and child exit codes.

Subprocess tests cover file and piped input, native `-- -c`, stdin EOF, open-pipe early exits, and child exit codes. SQL files stream with bounded buffering; paths inside psql `\i` / `\copy` still refer to the container.

Closes #856; existing #760 scope remains covered.

Closes #760.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.

Real Postgres 18 Docker validation on that final revision passed startup-ignore creation/custom preservation, plain pipe/EOF, native `-- -c`, exit 3 on SQL errors, missing-file diagnostics, redirected terminal input and a genuine PTY query followed by Ctrl-D/exit 0. The disposable container, volume and project were removed.
