### PR TITLE
fix(org): require complete private endpoint removal identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,10 @@ BYOC create, update, and delete require API key authentication. Update requires
 `--display-name`, so it cannot send an empty/no-op patch. The API has no separate
 BYOC list command; `cloud org get` returns the organization's `byocConfig` entries.
 
+Each `cloud org update --remove-private-endpoint` value must include both
+`cloud-provider` and `region`; incomplete endpoint identities are rejected before
+any request is sent.
+
 `cloud org prometheus discovery` returns the beta HTTP service-discovery target groups used by Prometheus `http_sd_configs`; `--json` preserves the complete target and label array. The command defaults discovered scrape targets to filtered metrics. The command without `discovery` still calls the deprecated organization metrics endpoint and emits raw Prometheus exposition text for compatibility.
 
 ### Services

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -70,10 +70,11 @@ CONTEXT FOR AGENTS:
 
         /// Remove a private endpoint from the org allow list (repeatable)
         ///
-        /// Format: id[,description=TEXT][,cloud-provider=aws|gcp|azure][,region=REGION]
-        ///
-        /// Omitting cloud-provider or region sends gcp / ap-northeast-1, not "unchanged".
-        #[arg(long = "remove-private-endpoint")]
+        /// Format: id[,description=TEXT],cloud-provider=aws|gcp|azure,region=REGION
+        #[arg(
+            long = "remove-private-endpoint",
+            value_parser = parse_org_private_endpoint_remove_arg
+        )]
         remove_private_endpoint: Vec<String>,
 
         /// Enable or disable core dump collection at the organization level
@@ -605,12 +606,10 @@ struct OrgUpdateOptions {
 }
 
 fn parse_org_private_endpoint_remove(value: &str) -> CloudResult<OrganizationPatchPrivateEndpoint> {
-    let mut endpoint = OrganizationPatchPrivateEndpoint {
-        id: String::new(),
-        description: None,
-        cloud_provider: OrganizationPatchPrivateEndpointCloudprovider::default(),
-        region: OrganizationPatchPrivateEndpointRegion::default(),
-    };
+    let mut id = String::new();
+    let mut description = None;
+    let mut cloud_provider = None;
+    let mut region = None;
 
     for (index, part) in value.split(',').enumerate() {
         let part = part.trim();
@@ -619,7 +618,7 @@ fn parse_org_private_endpoint_remove(value: &str) -> CloudResult<OrganizationPat
         }
 
         if index == 0 && !part.contains('=') {
-            endpoint.id = part.to_string();
+            id = part.to_string();
             continue;
         }
 
@@ -631,20 +630,35 @@ fn parse_org_private_endpoint_remove(value: &str) -> CloudResult<OrganizationPat
         })?;
 
         match key {
-            "id" => endpoint.id = raw_value.to_string(),
-            "description" => endpoint.description = Some(raw_value.to_string()),
+            "id" => id = raw_value.to_string(),
+            "description" => description = Some(raw_value.to_string()),
             "cloud-provider" => {
-                endpoint.cloud_provider =
+                if raw_value.trim().is_empty() {
+                    return Err(CloudError::new(format!(
+                        "remove-private-endpoint '{}' requires a non-empty cloud-provider",
+                        value
+                    )));
+                }
+                cloud_provider = Some(
                     serde_json::from_value::<OrganizationPatchPrivateEndpointCloudprovider>(
                         serde_json::Value::String(raw_value.to_string()),
                     )
-                    .expect("enum with Unknown variant should always deserialize");
+                    .expect("enum with Unknown variant should always deserialize"),
+                );
             }
             "region" => {
-                endpoint.region = serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
-                    serde_json::Value::String(raw_value.to_string()),
-                )
-                .expect("enum with Unknown variant should always deserialize");
+                if raw_value.trim().is_empty() {
+                    return Err(CloudError::new(format!(
+                        "remove-private-endpoint '{}' requires a non-empty region",
+                        value
+                    )));
+                }
+                region = Some(
+                    serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
+                        serde_json::Value::String(raw_value.to_string()),
+                    )
+                    .expect("enum with Unknown variant should always deserialize"),
+                );
             }
             _ => {
                 return Err(CloudError::new(format!(
@@ -655,14 +669,49 @@ fn parse_org_private_endpoint_remove(value: &str) -> CloudResult<OrganizationPat
         }
     }
 
-    if endpoint.id.trim().is_empty() {
+    if id.trim().is_empty() {
         return Err(CloudError::new(format!(
             "remove-private-endpoint '{}' requires a non-empty id",
             value
         )));
     }
 
-    Ok(endpoint)
+    let (cloud_provider, region) = match (cloud_provider, region) {
+        (Some(cloud_provider), Some(region)) => (cloud_provider, region),
+        (None, None) => {
+            return Err(CloudError::new(format!(
+                "remove-private-endpoint '{}' requires cloud-provider and region",
+                value
+            )));
+        }
+        (None, Some(_)) => {
+            return Err(CloudError::new(format!(
+                "remove-private-endpoint '{}' requires cloud-provider",
+                value
+            )));
+        }
+        (Some(_), None) => {
+            return Err(CloudError::new(format!(
+                "remove-private-endpoint '{}' requires region",
+                value
+            )));
+        }
+    };
+
+    Ok(OrganizationPatchPrivateEndpoint {
+        id,
+        description,
+        cloud_provider,
+        region,
+    })
+}
+
+/// Validate endpoint removals during clap parsing so incomplete endpoint
+/// identities fail as usage errors before credentials or networking are used.
+fn parse_org_private_endpoint_remove_arg(value: &str) -> Result<String, String> {
+    parse_org_private_endpoint_remove(value)
+        .map(|_| value.to_string())
+        .map_err(|error| error.message)
 }
 
 fn parse_org_private_endpoints_patch(
@@ -1982,6 +2031,65 @@ mod tests {
     }
 
     #[test]
+    fn parses_minimal_private_endpoint_removal() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "update",
+            "org-1",
+            "--remove-private-endpoint",
+            "pe-1,cloud-provider=aws,region=us-east-1",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Update {
+            remove_private_endpoint,
+            ..
+        } = command
+        else {
+            panic!("expected org update");
+        };
+
+        assert_eq!(
+            remove_private_endpoint,
+            ["pe-1,cloud-provider=aws,region=us-east-1"]
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_private_endpoint_removals_during_clap_parsing() {
+        for (value, required) in [
+            ("pe-1,region=us-east-1", "requires cloud-provider"),
+            ("pe-1,cloud-provider=aws", "requires region"),
+            ("pe-1,description=old", "requires cloud-provider and region"),
+            (
+                "pe-1,cloud-provider=,region=us-east-1",
+                "requires a non-empty cloud-provider",
+            ),
+            (
+                "pe-1,cloud-provider=aws,region= ",
+                "requires a non-empty region",
+            ),
+        ] {
+            let error = Cli::try_parse_from([
+                "clickhousectl",
+                "cloud",
+                "org",
+                "update",
+                "org-1",
+                "--remove-private-endpoint",
+                value,
+            ])
+            .err()
+            .expect("incomplete endpoint removal should fail");
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+            assert!(error.to_string().contains(required), "{error}");
+        }
+    }
+
+    #[test]
     fn parses_member_clear_roles() {
         let CloudCommands::Member { command } = parse_cloud_command(&[
             "clickhousectl",
@@ -2545,6 +2653,26 @@ mod tests {
                 error.to_string().contains("requires a non-empty id"),
                 "unexpected error for {value:?}: {error}"
             );
+        }
+    }
+
+    #[test]
+    fn parse_org_private_endpoint_remove_requires_provider_and_region() {
+        for (value, required) in [
+            ("pe-1,region=us-east-1", "requires cloud-provider"),
+            ("pe-1,cloud-provider=aws", "requires region"),
+            ("pe-1", "requires cloud-provider and region"),
+            (
+                "pe-1,cloud-provider= ,region=us-east-1",
+                "requires a non-empty cloud-provider",
+            ),
+            (
+                "pe-1,cloud-provider=aws,region= ",
+                "requires a non-empty region",
+            ),
+        ] {
+            let error = parse_org_private_endpoint_remove(value).unwrap_err();
+            assert!(error.to_string().contains(required), "{error}");
         }
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -702,6 +702,33 @@ async fn organization_role_create_rejects_invalid_nested_config_before_http() {
 }
 
 #[tokio::test]
+async fn organization_update_rejects_incomplete_endpoint_removals_before_http() {
+    let mock = MockServer::start().await;
+
+    for value in [
+        "pe-1,region=us-east-1",
+        "pe-1,cloud-provider=aws",
+        "pe-1,description=old",
+        "pe-1,cloud-provider=,region=us-east-1",
+        "pe-1,cloud-provider=aws,region= ",
+    ] {
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &["org", "update", "org-1", "--remove-private-endpoint", value],
+        );
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("requires"),
+            "unexpected stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn org_quota_list_preserves_sparse_json_and_supports_oauth() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))


### PR DESCRIPTION
## Summary

- require `cloud-provider` and `region` in every `cloud org update --remove-private-endpoint` value
- reject absent, empty, and whitespace-only identity fields during clap parsing, before credentials or HTTP work
- remove the generated provider and region defaults from the internal parser and document the required fields

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/al/ch/ai/clickhousectl/target cargo test -p clickhousectl cloud::organizations::tests` (33 passed)
- `CARGO_TARGET_DIR=/Users/al/ch/ai/clickhousectl/target cargo test -p clickhousectl --test cli_request_shape_test organization_update_rejects_incomplete_endpoint_removals_before_http -- --exact` (1 passed)

Closes #679
