### PR TITLE
fix(api): preserve fractional Postgres slow-query durations

### DIFF
--- a/crates/clickhouse-cloud-api/AGENTS.md
+++ b/crates/clickhouse-cloud-api/AGENTS.md
@@ -79,7 +79,8 @@ reachability from return types across the client module tree, so a newly wired o
 - `models_carry_no_serde_default` — via the analyzer's `model_fields_with_serde_default()`.
 - `scim_models_are_outside_the_response_tree` — the 40 `Scim*` schemas have no spec path and no `Client` method,
   so they are legitimately strict; the test fails if one becomes response-reachable.
-- `integer_schema_fields_are_not_typed_as_float` — integer schemas do not use floating-point Rust fields.
+- `integer_schema_fields_are_not_typed_as_float` — integer schemas do not use floating-point Rust fields, except
+  verified response-only runtime divergences in `fractional_response_exemptions`.
 
 Scope enforcement to the response tree, never to "every model type": operation-unreferenced and request-only
 schemas resolve in request position, so making them all-`Option` reports genuine `FieldOptionalityMismatch` drift.
@@ -160,6 +161,9 @@ Rust type names but spec/wire field and enum values:
 - `non_openapi_client_methods` — intentional `Client` helpers with no operation, keyed by snake-case method name.
 - `optionality_exemptions` — fields deliberately optional despite the resolved spec, keyed by
   `(RustStructName, specFieldName)`. Request-position only, so a response-only entry can never hit and surfaces as stale.
+- `fractional_response_exemptions` — verified fractional runtime measurements declared as integers by the spec,
+  keyed by `(RustStructName, specFieldName)`. Only response-only `f64` fields qualify; request fields cannot be
+  exempted. Entries become stale when the field, response reachability, Rust type, or upstream integer type changes.
 - `extra_field_exemptions` — deliberate code-only fields, keyed by `(RustStructName, specFieldName)`.
 - `deprecated_field_exemptions` — spec-deprecated fields deliberately excluded from hiding, same key shape.
 - `extra_enum_value_exemptions` — intentional Rust-only wire values, keyed by `(RustEnumName, wireValue)`.

--- a/crates/clickhouse-cloud-api/README.md
+++ b/crates/clickhouse-cloud-api/README.md
@@ -14,6 +14,8 @@ ClickStack models now include alert channel lists, 30-second alert intervals, qu
 
 The current alert request schemas have no `required` array or optional marker on either `channel` or `channels`, so both fields remain strict in the Rust request models. This mirrors the documented requiredness policy; it does not establish whether the server accepts a channels-only request. Supply the channel list explicitly rather than relying on the empty `Default` value (the API specifies 1–10 channels).
 
+Postgres slow-query aggregate durations (`*DurationUs`) and execution `durationUs` use `Option<f64>` to preserve fractional microseconds returned by the API. Counts remain integral. The analyzer tracks the upstream integer-schema discrepancy with response-only, stale-checked exceptions ([#758](https://github.com/ClickHouse/clickhousectl/issues/758)).
+
 ## Development
 
 ### Structure

--- a/crates/clickhouse-cloud-api/src/models/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/models/postgres.rs
@@ -1081,7 +1081,7 @@ pub struct PostgresQueryExecution {
     #[serde(rename = "dbUser", skip_serializing_if = "Option::is_none")]
     pub db_user: Option<String>,
     #[serde(rename = "durationUs", skip_serializing_if = "Option::is_none")]
-    pub duration_us: Option<i64>,
+    pub duration_us: Option<f64>,
     #[serde(rename = "errElevel", skip_serializing_if = "Option::is_none")]
     pub err_elevel: Option<i64>,
     #[serde(rename = "errMessage", skip_serializing_if = "Option::is_none")]
@@ -1180,7 +1180,7 @@ pub struct PostgresSlowQueryPattern {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app: Option<String>,
     #[serde(rename = "avgDurationUs", skip_serializing_if = "Option::is_none")]
-    pub avg_duration_us: Option<i64>,
+    pub avg_duration_us: Option<f64>,
     #[serde(rename = "callCount", skip_serializing_if = "Option::is_none")]
     pub call_count: Option<i64>,
     #[serde(rename = "dbName", skip_serializing_if = "Option::is_none")]
@@ -1192,13 +1192,13 @@ pub struct PostgresSlowQueryPattern {
     #[serde(rename = "errorCount", skip_serializing_if = "Option::is_none")]
     pub error_count: Option<i64>,
     #[serde(rename = "maxDurationUs", skip_serializing_if = "Option::is_none")]
-    pub max_duration_us: Option<i64>,
+    pub max_duration_us: Option<f64>,
     #[serde(rename = "p50DurationUs", skip_serializing_if = "Option::is_none")]
-    pub p50_duration_us: Option<i64>,
+    pub p50_duration_us: Option<f64>,
     #[serde(rename = "p95DurationUs", skip_serializing_if = "Option::is_none")]
-    pub p95_duration_us: Option<i64>,
+    pub p95_duration_us: Option<f64>,
     #[serde(rename = "p99DurationUs", skip_serializing_if = "Option::is_none")]
-    pub p99_duration_us: Option<i64>,
+    pub p99_duration_us: Option<f64>,
     #[serde(rename = "queryId", skip_serializing_if = "Option::is_none")]
     pub query_id: Option<String>,
     #[serde(rename = "queryText", skip_serializing_if = "Option::is_none")]
@@ -1206,7 +1206,7 @@ pub struct PostgresSlowQueryPattern {
     #[serde(rename = "totalCpuTimeUs", skip_serializing_if = "Option::is_none")]
     pub total_cpu_time_us: Option<i64>,
     #[serde(rename = "totalDurationUs", skip_serializing_if = "Option::is_none")]
-    pub total_duration_us: Option<i64>,
+    pub total_duration_us: Option<f64>,
     #[serde(rename = "totalRows", skip_serializing_if = "Option::is_none")]
     pub total_rows: Option<i64>,
     #[serde(rename = "totalSharedBlksHit", skip_serializing_if = "Option::is_none")]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6611,3 +6611,106 @@ fn udf_request_inline_variants_preserve_determinism_and_memory() {
     check::<UdfVersionCreateRequestV1>("executable", false);
     check::<UdfVersionCreateRequestV2>("executable_pool", false);
 }
+
+#[test]
+fn postgres_slow_query_durations_preserve_fractions_and_integral_counts() {
+    let aggregate = serde_json::json!({
+        "avgDurationUs": 1190.8419405320817,
+        "maxDurationUs": 2000.75,
+        "p50DurationUs": 1100.25,
+        "p95DurationUs": 1800.5,
+        "p99DurationUs": 1950.125,
+        "totalDurationUs": 3572.525821596245,
+        "callCount": 3, "errorCount": 0, "totalRows": 9007199254740993_i64,
+        "totalSharedBlksHit": 10, "totalSharedBlksRead": 2,
+        "totalCpuTimeUs": 2000, "totalWalBytes": 128
+    });
+    let list: Vec<PostgresSlowQueryPattern> =
+        serde_json::from_value(serde_json::json!([aggregate])).unwrap();
+    assert_eq!(list[0].avg_duration_us, Some(1190.8419405320817));
+    assert_eq!(list[0].total_rows, Some(9007199254740993));
+    assert_eq!(
+        serde_json::to_value(&list).unwrap(),
+        serde_json::json!([aggregate])
+    );
+
+    let detail = serde_json::json!({
+        "aggregate": aggregate,
+        "recentExecutions": [{"durationUs": 1234.56789, "rows": 9007199254740993_i64,
+            "cpuSysTimeUs": 12, "jitFunctions": 2, "sharedBlksHit": 3, "walBytes": 128}]
+    });
+    let parsed: PostgresSlowQueryPatternDetail = serde_json::from_value(detail.clone()).unwrap();
+    assert_eq!(
+        parsed.recent_executions.as_ref().unwrap()[0].duration_us,
+        Some(1234.56789)
+    );
+    assert_eq!(serde_json::to_value(parsed).unwrap(), detail);
+
+    // Existing integer-valued measurements remain accepted as durations.
+    let integer: PostgresQueryExecution =
+        serde_json::from_value(serde_json::json!({"durationUs": 1234})).unwrap();
+    assert_eq!(integer.duration_us, Some(1234.0));
+    let integer: PostgresSlowQueryPattern = serde_json::from_value(serde_json::json!({
+        "avgDurationUs": 1, "maxDurationUs": 2, "p50DurationUs": 1,
+        "p95DurationUs": 2, "p99DurationUs": 2, "totalDurationUs": 3
+    }))
+    .unwrap();
+    assert_eq!(integer.avg_duration_us, Some(1.0));
+    for field in [
+        "callCount",
+        "errorCount",
+        "totalRows",
+        "totalSharedBlksHit",
+        "totalSharedBlksRead",
+        "totalWalBytes",
+    ] {
+        assert!(
+            serde_json::from_value::<PostgresSlowQueryPattern>(serde_json::json!({field: 1.5}))
+                .is_err(),
+            "{field} must remain integral"
+        );
+    }
+    for field in ["rows", "jitFunctions", "sharedBlksHit", "walBytes"] {
+        assert!(
+            serde_json::from_value::<PostgresQueryExecution>(serde_json::json!({field: 1.5}))
+                .is_err(),
+            "{field} must remain integral"
+        );
+    }
+}
+
+#[test]
+fn postgres_slow_query_durations_allow_missing_and_null() {
+    for aggregate in [
+        serde_json::json!({}),
+        serde_json::json!({
+            "avgDurationUs": null, "maxDurationUs": null, "p50DurationUs": null,
+            "p95DurationUs": null, "p99DurationUs": null, "totalDurationUs": null
+        }),
+    ] {
+        let parsed: PostgresSlowQueryPattern = serde_json::from_value(aggregate.clone()).unwrap();
+        assert_eq!(parsed, PostgresSlowQueryPattern::default());
+        assert_eq!(serde_json::to_value(parsed).unwrap(), serde_json::json!({}));
+        let detail: PostgresSlowQueryPatternDetail = serde_json::from_value(serde_json::json!({
+            "aggregate": aggregate, "recentExecutions": [{}, {"durationUs": null}]
+        }))
+        .unwrap();
+        assert_eq!(detail.aggregate, Some(PostgresSlowQueryPattern::default()));
+        assert_eq!(
+            detail.recent_executions,
+            Some(vec![PostgresQueryExecution::default(); 2])
+        );
+        assert_eq!(
+            serde_json::to_value(detail).unwrap(),
+            serde_json::json!({"aggregate": {}, "recentExecutions": [{}, {}]})
+        );
+    }
+    for value in [
+        serde_json::json!({}),
+        serde_json::json!({"aggregate": null, "recentExecutions": null}),
+    ] {
+        let parsed: PostgresSlowQueryPatternDetail = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed, PostgresSlowQueryPatternDetail::default());
+        assert_eq!(serde_json::to_value(parsed).unwrap(), serde_json::json!({}));
+    }
+}

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -20,9 +20,71 @@ pub(crate) fn compare(
     compare_additional_properties(rust, spec, &mut report);
     compare_beta_and_deprecation(rust, spec, config, &mut report);
     compare_enums(rust, spec, config, &mut report);
+    let fractional = integer_float_fields(rust, spec);
+    stale_pairs(
+        "fractional_response",
+        &config.fractional_response_exemptions,
+        &fractional.response_only,
+        &mut report,
+    );
     compare_snapshot(spec, snapshot, &mut report);
     report.finish();
     report
+}
+
+/// Returns all integer/f64 mismatches and the response-only subset eligible for
+/// a verified runtime divergence. Shared by the public policy inventory and the
+/// stale-exemption check so a corrected schema cannot silently retain an entry.
+pub(crate) struct IntegerFloatFields {
+    pub all: BTreeSet<(String, String)>,
+    pub response_only: BTreeSet<(String, String)>,
+}
+
+pub(crate) fn integer_float_fields(
+    rust: &RustInventory,
+    spec: &OpenApiInventory,
+) -> IntegerFloatFields {
+    let response_types = rust.response_reachable_types();
+    let mut offenders = BTreeSet::new();
+    let mut response_fields = BTreeSet::new();
+    let mut request_fields = BTreeSet::new();
+    for ((schema_name, property_name), property) in &spec.properties {
+        if property.schema_type.as_deref() != Some("integer") {
+            continue;
+        }
+        for (rust_name, direction) in field_check_targets(rust, spec, schema_name) {
+            if direction == Direction::Response && !response_types.contains(&rust_name) {
+                continue;
+            }
+            let Some(field) = rust
+                .structs
+                .get(&rust_name)
+                .and_then(|info| info.fields.get(property_name))
+            else {
+                continue;
+            };
+            if rust.terminal_type(&field.rust_type).as_deref() == Some("f64") {
+                let key = (rust_name, property_name.clone());
+                offenders.insert(key.clone());
+                match direction {
+                    Direction::Response => {
+                        response_fields.insert(key);
+                    }
+                    Direction::Request => {
+                        request_fields.insert(key);
+                    }
+                }
+            }
+        }
+    }
+    let eligible = response_fields
+        .difference(&request_fields)
+        .cloned()
+        .collect();
+    IntegerFloatFields {
+        all: offenders,
+        response_only: eligible,
+    }
 }
 
 fn compare_operations(

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -8,6 +8,9 @@ pub struct AnalyzerConfig {
     /// suppressed entirely in response position, so a response-only entry can
     /// never be hit and would surface as a stale exemption.
     pub optionality_exemptions: BTreeSet<(String, String)>,
+    /// Response-only integer properties whose verified runtime values require f64.
+    /// Entries become stale when the spec, Rust type, or response reachability changes.
+    pub fractional_response_exemptions: BTreeSet<(String, String)>,
     pub extra_field_exemptions: BTreeSet<(String, String)>,
     pub deprecated_field_exemptions: BTreeSet<(String, String)>,
     pub extra_enum_value_exemptions: BTreeSet<(String, String)>,
@@ -36,6 +39,7 @@ pub fn clickhouse_cloud_config() -> AnalyzerConfig {
     AnalyzerConfig {
         non_openapi_client_methods: strings(&["run_query", "run_query_bearer"]),
         optionality_exemptions: pairs(OPTIONALITY_EXEMPTIONS),
+        fractional_response_exemptions: pairs(FRACTIONAL_RESPONSE_EXEMPTIONS),
         extra_field_exemptions: BTreeSet::new(),
         deprecated_field_exemptions: BTreeSet::new(),
         extra_enum_value_exemptions: BTreeSet::new(),
@@ -48,6 +52,21 @@ pub fn clickhouse_cloud_config() -> AnalyzerConfig {
         acknowledged_unsupported_enum_pointers: strings(ACKNOWLEDGED_UNSUPPORTED_ENUM_POINTERS),
     }
 }
+
+// Live slow-query list/detail responses contain fractional microsecond durations,
+// including avgDurationUs = 1190.8419405320817. The public spec still declares
+// integers (verified 2026-09-08); rounding would destroy valid response data.
+// https://github.com/ClickHouse/clickhousectl/issues/758
+// Only duration measurements are widened; counts and CPU/JIT counters stay i64.
+const FRACTIONAL_RESPONSE_EXEMPTIONS: &[(&str, &str)] = &[
+    ("PostgresSlowQueryPattern", "avgDurationUs"),
+    ("PostgresSlowQueryPattern", "maxDurationUs"),
+    ("PostgresSlowQueryPattern", "p50DurationUs"),
+    ("PostgresSlowQueryPattern", "p95DurationUs"),
+    ("PostgresSlowQueryPattern", "p99DurationUs"),
+    ("PostgresSlowQueryPattern", "totalDurationUs"),
+    ("PostgresQueryExecution", "durationUs"),
+];
 
 const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // The spec allows protobufSchema only for Protobuf without schemaRegistry;

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -125,6 +125,8 @@ pub fn response_tree(rust_source_root: &Path) -> Result<ResponseTree, AnalyzeErr
 /// The analyzer resolves request/response split variants with the same mapping
 /// used by drift analysis. Response targets are additionally constrained to the
 /// Rust response tree, so unused schemas do not expand the policy surface.
+/// Verified response-only runtime divergences in `fractional_response_exemptions`
+/// are excluded; drift analysis reports stale entries using this same inventory.
 pub fn integer_model_fields_typed_as_float(
     spec_json: &str,
     rust_source_root: &Path,
@@ -133,31 +135,15 @@ pub fn integer_model_fields_typed_as_float(
     let spec = serde_json::from_str(spec_json).map_err(AnalyzeError::SpecJson)?;
     let spec = OpenApiInventory::build(&spec, config).map_err(AnalyzeError::SpecInventory)?;
     let rust = load_rust_inventory(rust_source_root)?;
-    let response_types = rust.response_reachable_types();
-    let mut offenders = BTreeSet::new();
-
-    for ((schema_name, property_name), property) in &spec.properties {
-        if property.schema_type.as_deref() != Some("integer") {
-            continue;
-        }
-        for (rust_name, direction) in compare::field_check_targets(&rust, &spec, schema_name) {
-            if direction == compare::Direction::Response && !response_types.contains(&rust_name) {
-                continue;
-            }
-            let Some(field) = rust
-                .structs
-                .get(&rust_name)
-                .and_then(|info| info.fields.get(property_name))
-            else {
-                continue;
-            };
-            if rust.terminal_type(&field.rust_type).as_deref() == Some("f64") {
-                offenders.insert((rust_name, property_name.clone()));
-            }
-        }
+    let mut fields = compare::integer_float_fields(&rust, &spec);
+    for key in config
+        .fractional_response_exemptions
+        .intersection(&fields.response_only)
+    {
+        fields.all.remove(key);
     }
 
-    Ok(offenders)
+    Ok(fields.all)
 }
 
 /// Lists every public model struct field in the model module tree that carries a
@@ -340,5 +326,122 @@ mod tests {
                 ("WidgetResponse".to_string(), "nullableCount".to_string()),
             ])
         );
+    }
+    #[test]
+    fn fractional_response_exemptions_are_narrow_and_report_staleness() {
+        let spec = serde_json::json!({
+            "paths": {"/widgets": {"get": {
+                "operationId": "getWidget",
+                "responses": {"200": {"content": {"application/json": {
+                    "schema": {"$ref": "#/components/schemas/Widget"}
+                }}}}
+            }}},
+            "components": {"schemas": {"Widget": {
+                "type": "object", "properties": {
+                    "duration": {"type": "integer"}, "count": {"type": "integer"}
+                }
+            }}}
+        });
+        let client = "pub struct Client; impl Client { pub async fn get_widget(&self) -> Result<Widget, Error> { unimplemented!() } }";
+        let models = "pub struct Widget { pub duration: Option<f64>, pub count: Option<f64> }";
+        let key = ("Widget".to_string(), "duration".to_string());
+        let config = AnalyzerConfig {
+            fractional_response_exemptions: BTreeSet::from([key.clone()]),
+            ..AnalyzerConfig::default()
+        };
+        for scenario in [
+            "active",
+            "number",
+            "field_removed",
+            "integer_rust",
+            "rust_field_removed",
+            "unwired",
+            "request",
+            "shared_request",
+        ] {
+            let mut spec = spec.clone();
+            let mut client = client;
+            let mut models = models;
+            match scenario {
+                "number" => {
+                    spec["components"]["schemas"]["Widget"]["properties"]["duration"]["type"] =
+                        serde_json::json!("number")
+                }
+                "field_removed" => {
+                    spec["components"]["schemas"]["Widget"]["properties"]
+                        .as_object_mut()
+                        .unwrap()
+                        .remove("duration");
+                }
+                "integer_rust" => {
+                    models =
+                        "pub struct Widget { pub duration: Option<i64>, pub count: Option<f64> }"
+                }
+                "rust_field_removed" => models = "pub struct Widget { pub count: Option<f64> }",
+                "unwired" => client = "pub struct Client;",
+                "shared_request" => {
+                    spec["paths"]["/widgets"]["post"] = serde_json::json!({
+                        "operationId": "createWidget",
+                        "requestBody": {"content": {"application/json": {
+                            "schema": {"$ref": "#/components/schemas/Widget"}
+                        }}}, "responses": {}
+                    });
+                }
+                "request" => {
+                    spec["paths"] = serde_json::json!({});
+                }
+                _ => {}
+            }
+            let source = source_tree(client, models);
+            let spec = spec.to_string();
+            let offenders =
+                integer_model_fields_typed_as_float(&spec, source.path(), &config).unwrap();
+            if scenario == "active" {
+                assert_eq!(
+                    offenders,
+                    BTreeSet::from([("Widget".to_string(), "count".to_string())])
+                );
+            }
+            if matches!(scenario, "request" | "shared_request") {
+                assert!(offenders.contains(&key));
+            }
+            let report = analyze(
+                AnalysisInput {
+                    spec_json: &spec,
+                    snapshot_json: &spec,
+                    rust_source_root: source.path(),
+                },
+                &config,
+            )
+            .unwrap();
+            let stale: Vec<_> = report
+                .findings
+                .iter()
+                .filter(|finding| finding.kind == report::FindingKind::StaleExemption)
+                .collect();
+            assert_eq!(
+                stale.len(),
+                usize::from(scenario != "active"),
+                "{scenario}: {report:?}"
+            );
+            if let Some(finding) = stale.first() {
+                assert_eq!(finding.details["exemption_kind"], "fractional_response");
+                assert_eq!(finding.details["left"], "Widget");
+                assert_eq!(finding.details["right"], "duration");
+            }
+            let repeated = analyze(
+                AnalysisInput {
+                    spec_json: &spec,
+                    snapshot_json: &spec,
+                    rust_source_root: source.path(),
+                },
+                &config,
+            )
+            .unwrap();
+            assert_eq!(
+                serde_json::to_string(&report).unwrap(),
+                serde_json::to_string(&repeated).unwrap()
+            );
+        }
     }
 }


### PR DESCRIPTION
Postgres slow-query list and detail responses fail to deserialize when the API returns fractional microseconds, such as `avgDurationUs: 1190.8419405320817`. Represent the six aggregate `*DurationUs` measurements and execution `durationUs` as `Option<f64>` so callers retain these values. Call, error, row, block, byte and other integral counters keep their existing types; missing/null durations remain absent.

The public OpenAPI fetched on 2026-09-08 still declares these durations as integers. Leave that snapshot untouched and document seven exact response-only runtime exceptions, backed by the live evidence in #758. The analyzer shares its integer/float inventory with exception validation and reports stale entries when the upstream type, Rust field/type, or response reachability changes. Request-side fields cannot use these exceptions.

Validation:
- `cargo fmt --all`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer` (offline suites; explicitly ignored live suites remain ignored)
- Python script suite: 91 tests pass (per-process `commit.gpgsign=false` for temporary Git fixtures).
- Model fixtures cover fractional list/detail aggregates and executions, integer inputs, missing/null responses and counts above 2^53.
- Analyzer fixtures cover narrow matching and stale entries after schema/field/type/reachability changes, including request-only and shared request/response types. Existing integer policy and snapshot coverage tests pass.
- Analysis against the freshly fetched public spec has only the pre-existing unrelated `organization_prometheus_discovery_get` beta marker finding; no duration exception is stale.

Refs #758. CLI JSON/human regression coverage is a separate stacked PR.
