### PR TITLE
test(cli): cover fractional slow-query JSON and human output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1194,7 +1194,7 @@ Use `clickhousectl cloud postgres create --help` for the complete option list. S
 
 `postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
 
-`postgres slow-queries list` requires an RFC 3339 start and end time and supports database, user, operation and application filters, sorting, limits and offsets. Copy `queryId`, `dbName`, `dbUser` and `dbOperation` from a list result into `slow-queries get`; add `--app` when the list result has one, and optionally select a recent execution with `--timestamp`. JSON and human output preserve every aggregate and execution field the API returns, including sparse beta responses.
+`postgres slow-queries list` requires an RFC 3339 start and end time and supports database, user, operation and application filters, sorting, limits and offsets. Copy `queryId`, `dbName`, `dbUser` and `dbOperation` from a list result into `slow-queries get`; add `--app` when the list result has one, and optionally select a recent execution with `--timestamp`. JSON and human output preserve every aggregate and execution field the API returns, including sparse beta responses. Duration values are microseconds and may be fractional; call, row and block counts remain integers.
 
 `postgres prometheus service` and `postgres prometheus org` return the beta API's raw Prometheus exposition text for scraping. In `--json` mode, including automatic coding-agent mode, the complete text is emitted as one JSON string; it is not parsed into metric series. These endpoints have no filtered-metrics query parameter. Use `postgres metrics` when you need time-bucketed metric objects over a chosen date range.
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2971,12 +2971,12 @@ async fn postgres_slow_query_list_sends_exact_query_supports_oauth_and_preserves
         "app": "reporting/api",
         "callCount": 42,
         "errorCount": 1,
-        "totalDurationUs": 950000,
-        "avgDurationUs": 22619,
-        "maxDurationUs": 81000,
-        "p50DurationUs": 18000,
-        "p95DurationUs": 70000,
-        "p99DurationUs": 80000,
+        "totalDurationUs": 950000.25,
+        "avgDurationUs": 1190.8419405320817,
+        "maxDurationUs": 81000.75,
+        "p50DurationUs": 18000.25,
+        "p95DurationUs": 70000.5,
+        "p99DurationUs": 80000.125,
         "totalRows": 420,
         "totalSharedBlksRead": 12,
         "totalSharedBlksHit": 900,
@@ -3085,7 +3085,7 @@ async fn postgres_slow_query_list_omits_filters_and_renders_sparse_human_output(
             "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "result": [{ "queryId": "query-1", "callCount": 2 }],
+            "result": [{ "queryId": "query-1", "callCount": 2, "avgDurationUs": 1190.8419405320817, "p95DurationUs": 2000.25 }],
             "status": 200
         })))
         .expect(1)
@@ -3110,6 +3110,11 @@ async fn postgres_slow_query_list_omits_filters_and_renders_sparse_human_output(
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("queryId: query-1"), "{stdout}");
     assert!(stdout.contains("callCount: 2"), "{stdout}");
+    assert!(
+        stdout.contains("avgDurationUs: 1190.8419405320817"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("p95DurationUs: 2000.25"), "{stdout}");
     let requests = mock.received_requests().await.unwrap();
     let query: Vec<_> = requests[0].url.query_pairs().collect();
     assert_eq!(query.len(), 2, "unexpected query parameters: {query:?}");
@@ -3177,13 +3182,17 @@ async fn postgres_slow_query_get_has_distinct_query_and_preserves_recent_executi
             "dbUser": "reader+worker",
             "dbOperation": "SELECT & EXPLAIN",
             "app": "reporting/api",
-            "callCount": 2
+            "callCount": 2,
+            "avgDurationUs": 1190.8419405320817,
+            "p50DurationUs": 1100.25,
+            "p95DurationUs": 1800.5,
+            "p99DurationUs": 1950.125
         },
         "recentExecutions": [{
             "queryId": "query-1",
             "queryText": "SELECT 42",
             "timestamp": "2026-04-16T12:30:00Z",
-            "durationUs": 1234,
+            "durationUs": 1234.56789,
             "rows": 1,
             "errMessage": "optional detail"
         }]
@@ -3272,8 +3281,8 @@ async fn postgres_slow_query_get_omits_optional_query_and_renders_sparse_detail(
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "result": {
-                "aggregate": { "queryId": "query-1" },
-                "recentExecutions": [{ "timestamp": "2026-04-16T12:30:00Z" }]
+                "aggregate": { "queryId": "query-1", "avgDurationUs": 1190.8419405320817, "p99DurationUs": 2000.25 },
+                "recentExecutions": [{ "timestamp": "2026-04-16T12:30:00Z", "durationUs": 1234.56789, "rows": 1 }]
             },
             "status": 200
         })))
@@ -3300,6 +3309,13 @@ async fn postgres_slow_query_get_omits_optional_query_and_renders_sparse_detail(
     );
     assert_success(&output);
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("avgDurationUs: 1190.8419405320817"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("p99DurationUs: 2000.25"), "{stdout}");
+    assert!(stdout.contains("durationUs: 1234.56789"), "{stdout}");
+    assert!(stdout.contains("rows: 1"), "{stdout}");
     for text in [
         "aggregate:",
         "queryId: query-1",


### PR DESCRIPTION
Verify that Postgres `slow-queries list` and `slow-queries get` preserve fractional averages, percentiles and execution durations in both JSON and human output after the library fix. Extend the existing real-binary wire fixtures and document fractional microsecond units in the README. Existing request, authentication and sparse-response assertions remain in place.

This PR stacks on the #758 API-model fix; the CLI handlers already serialize the library models and need no implementation change.

Validation: `cargo fmt --all`; `cargo test -p clickhousectl --test cli_request_shape_test postgres_slow_query` passes all five focused tests, exercising list/detail JSON equality and human duration rendering.

Closes #758.
