### PR TITLE
test(local): isolate ports and make readiness checks robust

### DIFF
--- a/crates/clickhousectl/tests/local_postgres_readiness_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_readiness_test.rs
@@ -6,7 +6,7 @@ use std::io::{ErrorKind, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -528,7 +528,48 @@ fn run_start_command(
     } else {
         command.env("DO_NOT_TRACK", "1");
     }
-    command.output().expect("run clickhousectl")
+    // Bound hangs after acquiring the fixture lock, independently of the
+    // readiness deadline under test. Capturing on another thread also drains
+    // both pipes while the child runs.
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run clickhousectl");
+    let pid = child.id();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let capture = |mut pipe: Box<dyn Read + Send>| {
+        thread::spawn(move || {
+            let mut bytes = Vec::new();
+            pipe.read_to_end(&mut bytes).expect("capture child output");
+            bytes
+        })
+    };
+    let stdout = capture(Box::new(stdout));
+    let stderr = capture(Box::new(stderr));
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = child.try_wait().expect("poll clickhousectl") {
+            return Output {
+                status,
+                stdout: stdout.join().expect("join stdout reader"),
+                stderr: stderr.join().expect("join stderr reader"),
+            };
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill hung clickhousectl");
+            child.wait().expect("reap hung clickhousectl");
+            let stdout = stdout.join().expect("join stdout reader");
+            let stderr = stderr.join().expect("join stderr reader");
+            panic!(
+                "clickhousectl {pid} hung after 30 seconds; stdout: {}; stderr: {}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr),
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 fn readiness_requests(requests: &[DockerRequest]) -> Vec<&DockerRequest> {
@@ -753,7 +794,6 @@ fn resumed_start_also_waits_for_postgres_readiness() {
 
 #[test]
 fn wall_clock_timeout_fails_and_rolls_back_fresh_data() {
-    let started = std::time::Instant::now();
     let (output, requests, project) = run_start(
         DockerScenario {
             existing: false,
@@ -773,14 +813,26 @@ fn wall_clock_timeout_fails_and_rolls_back_fresh_data() {
     );
 
     assert_eq!(output.status.code(), Some(1));
-    assert!(started.elapsed() < Duration::from_secs(4));
     let error: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
     assert_eq!(error["error"]["code"], "startup_timeout");
     assert_eq!(
         error["error"]["message"],
         "Postgres server 'default' did not become ready within 1 seconds"
     );
-    assert!(readiness_requests(&requests).len() >= 2);
+    // The fake daemon always reports a running container and never reports
+    // readiness. The timeout must therefore trigger rollback, regardless of
+    // how many polls the scheduler permits before the deadline.
+    let start = request_index(&requests, "POST", "/containers/pg-id/start");
+    let inspect = request_index(&requests, "GET", "/containers/pg-id/json");
+    let remove = request_index(&requests, "DELETE", "/containers/pg-id?");
+    assert!(start < inspect && inspect < remove);
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "DELETE")
+            .count(),
+        1,
+    );
     assert!(
         !project
             .path()

--- a/crates/clickhousectl/tests/local_structured_errors_test.rs
+++ b/crates/clickhousectl/tests/local_structured_errors_test.rs
@@ -96,14 +96,6 @@ fn install_fake_clickhouse(home: &Path, script: &str) {
         .expect("make fake ClickHouse executable");
 }
 
-fn unused_port() -> u16 {
-    std::net::TcpListener::bind(("127.0.0.1", 0))
-        .expect("bind temporary port")
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
 #[test]
 fn explicit_json_and_agent_mode_emit_the_same_exact_server_error() {
     let project = tempfile::tempdir().expect("create project");
@@ -237,10 +229,10 @@ fn version_port_and_startup_failures_have_typed_safe_shapes() {
             Some("clickhousectl local server start --help"),
         ),
     );
+    // Keep the occupied port reserved through its assertion. For the fake
+    // child below, let the CLI choose ports: it never binds a socket, so
+    // handing it bind-then-drop ephemeral ports only introduces a race.
     drop(occupied);
-
-    let http_port = unused_port().to_string();
-    let tcp_port = unused_port().to_string();
     let startup = run(
         project.path(),
         home.path(),
@@ -251,10 +243,6 @@ fn version_port_and_startup_failures_have_typed_safe_shapes() {
             "start",
             "--version",
             VERSION,
-            "--http-port",
-            &http_port,
-            "--tcp-port",
-            &tcp_port,
             "--no-wait",
         ],
     );
@@ -493,8 +481,6 @@ fn foreground_child_exit_is_not_wrapped_as_a_local_error() {
     let project = tempfile::tempdir().expect("create project");
     let home = tempfile::tempdir().expect("create home");
     install_fake_clickhouse(home.path(), "#!/bin/sh\nexit 7\n");
-    let http_port = unused_port().to_string();
-    let tcp_port = unused_port().to_string();
 
     let output = run(
         project.path(),
@@ -506,10 +492,6 @@ fn foreground_child_exit_is_not_wrapped_as_a_local_error() {
             "start",
             "--version",
             VERSION,
-            "--http-port",
-            &http_port,
-            "--tcp-port",
-            &tcp_port,
             "--foreground",
         ],
     );


### PR DESCRIPTION
The local structured-error fixtures selected ephemeral ports and released them before launching the CLI, allowing another test process to claim them. Fake ClickHouse children now use automatic port selection; the occupied-port case retains its listener through the assertion.

The Postgres readiness test measured time spent waiting for the shared fixture lock as part of its four-second deadline. It now checks the timeout error and the fake Docker start/inspect/removal sequence, including exactly one rollback and removal of fresh data and metadata. A separate 30-second watchdog starts after the fixture lock is acquired and kills/reaps a hung child while preserving captured diagnostics.

Temporary project and home directories, plus the existing `/crates/clickhousectl/.clickhouse/` ignore entry, already cover the reported state leakage. No production behavior changes.

Validation:
- `cargo fmt --all`
- Both focused integration binaries: 22 tests passed.
- Three concurrent copies of each focused binary: all six runs passed (66 tests).
- Focused Clippy with `-D warnings` passed.
- `git diff --check` and nested fixture `git check-ignore` passed.

Closes #687.
