### PR TITLE
fix(cli): expose and validate canonical closed-set values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1259,6 +1259,8 @@ generate-backup-bucket-json | clickhousectl cloud backup bucket create <service-
 
 ### ClickPipes
 
+Every ClickPipe `--auth` flag lists its accepted canonical modes in `--help`.
+
 Manage ClickPipes for ingesting data into ClickHouse Cloud from external sources. See the [ClickPipes documentation](https://clickhouse.com/docs/integrations/clickpipes).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2569,6 +2569,9 @@ Usage errors and cancelled actions use distinct exit codes.
 | `3`  | Cancelled (user aborted)                                 |
 | `4`  | Auth required (no credentials, 401/403, OAuth-only writes) |
 
+Flags with a fixed value set show their choices in `--help`. An unsupported
+choice exits with code `2` before a Cloud request or Skills download begins.
+
 ## Skills
 
 Install the official ClickHouse Agent Skills from [ClickHouse/agent-skills](https://github.com/ClickHouse/agent-skills).

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -49,9 +49,7 @@ CONTEXT FOR AGENTS:
   are still prompted.
   Agent selection without one of those three flags needs a TTY and errors out without one.
   Scope: prompted on a TTY, else the current project directory; --global forces your home directory.
-  The universal `.agents/skills` target is always installed, alongside any selected agent.
-  --agent values: claude, cursor, opencode, codex, agent, roo, trae, windsurf, zencoder, neovate,
-  pochi, adal, openclaw, cline, command-code, kiro-cli, agents")]
+  The universal `.agents/skills` target is always installed, alongside any selected agent.")]
     Skills(SkillsArgs),
 
     /// Update clickhousectl to the latest version
@@ -98,7 +96,12 @@ pub enum TelemetryCommands {
 #[derive(Args, Debug)]
 pub struct SkillsArgs {
     /// Install into specific agents (repeatable, comma-separated)
-    #[arg(long = "agent", value_name = "AGENT", value_delimiter = ',')]
+    #[arg(
+        long = "agent",
+        value_name = "AGENT",
+        value_delimiter = ',',
+        value_parser = clap::builder::PossibleValuesParser::new(crate::skills::supported_agent_keys())
+    )]
     pub agents: Vec<String>,
 
     /// Install into every supported agent in the selected scope without prompting
@@ -182,6 +185,27 @@ mod tests {
         assert!(!args.detected_only);
         assert!(args.global);
         assert_eq!(args.agents, vec!["claude", "codex", "agents"]);
+    }
+
+    #[test]
+    fn skills_agent_accepts_every_supported_agent_and_rejects_unknown_values() {
+        let supported = crate::skills::supported_agent_keys().collect::<Vec<_>>();
+        let joined = supported.join(",");
+        let cli = Cli::try_parse_from(["clickhousectl", "skills", "--agent", &joined]).unwrap();
+        let Commands::Skills(args) = cli.command else {
+            panic!("expected skills command");
+        };
+        assert_eq!(args.agents, supported);
+
+        let error = Cli::try_parse_from(["clickhousectl", "skills", "--agent", "unknown"])
+            .err()
+            .expect("unknown agent must be rejected by clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+        assert_eq!(error.exit_code(), 2);
+        let message = error.to_string();
+        for agent in crate::skills::supported_agent_keys() {
+            assert!(message.contains(agent), "missing `{agent}`: {message}");
+        }
     }
 
     #[cfg(feature = "telemetry")]

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -4,13 +4,15 @@ use crate::cloud::output::{eprint_line, or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, parse_ip_access_entries, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::FailureStage;
-use clap::Subcommand;
+use clap::{Subcommand, builder::PossibleValuesParser};
 #[cfg(test)]
 use clickhouse_cloud_api::models::IpAccessListEntry;
 use clickhouse_cloud_api::models::{
     ApiKeyPatchRequest, ApiKeyPatchRequestState, ApiKeyPostRequest, ApiKeyPostRequestState,
 };
 use tabled::{Table, Tabled, settings::Style};
+
+const API_KEY_STATES: &[&str] = &["enabled", "disabled"];
 
 #[derive(Subcommand)]
 pub enum KeyCommands {
@@ -35,8 +37,8 @@ pub enum KeyCommands {
         #[arg(long, value_parser = parse_datetime)]
         expires_at: Option<String>,
 
-        /// Key state (enabled or disabled)
-        #[arg(long)]
+        /// Key state
+        #[arg(long, value_parser = PossibleValuesParser::new(API_KEY_STATES))]
         state: Option<String>,
 
         /// Allowed IP/CIDR, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
@@ -95,8 +97,8 @@ pub enum KeyCommands {
         #[arg(long, conflicts_with = "expires_at")]
         clear_expiry: bool,
 
-        /// Key state (enabled or disabled)
-        #[arg(long)]
+        /// Key state
+        #[arg(long, value_parser = PossibleValuesParser::new(API_KEY_STATES))]
         state: Option<String>,
 
         /// Allowed IP/CIDR, optionally IP_OR_CIDR=DESCRIPTION (repeatable)
@@ -841,6 +843,41 @@ mod tests {
         assert_eq!(hash_key_id_suffix.as_deref(), Some("abcd"));
         assert_eq!(hash_key_secret.as_deref(), Some("secret-hash"));
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn rejects_invalid_api_key_states_as_usage_errors() {
+        for args in [
+            vec![
+                "clickhousectl",
+                "cloud",
+                "key",
+                "create",
+                "--name",
+                "ci-key",
+                "--state",
+                "broken",
+            ],
+            vec![
+                "clickhousectl",
+                "cloud",
+                "key",
+                "update",
+                "key-1",
+                "--state",
+                "broken",
+            ],
+        ] {
+            let error = Cli::try_parse_from(args)
+                .err()
+                .expect("invalid state must be rejected by clap");
+            assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+            assert_eq!(error.exit_code(), 2);
+            let message = error.to_string();
+            for state in API_KEY_STATES {
+                assert!(message.contains(state), "missing `{state}`: {message}");
+            }
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -2,7 +2,7 @@ use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::config::{deserialize_strict_config, read_config_value, read_typed_config};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, resolve_org_id};
-use clap::builder::PossibleValuesParser;
+use clap::builder::{PossibleValue, PossibleValuesParser, TypedValueParser};
 use clap::{ArgGroup, Args, Subcommand};
 use clickhouse_cloud_api::models::{
     ClickPipeBigQueryPipeSettingsReplicationmode, ClickPipeBigQueryPipeTableMappingTableengine,
@@ -207,6 +207,32 @@ fn parse_supported_kafka_auth(value: &str) -> Result<String, String> {
     parse_kafka_authentication(value)
         .map(|_| value.to_string())
         .map_err(|error| error.message)
+}
+
+/// Expose canonical choices while retaining the existing authentication parser.
+#[derive(Clone)]
+struct AuthenticationValueParser {
+    parse: fn(&str) -> Result<String, String>,
+    values: &'static [&'static str],
+}
+
+impl TypedValueParser for AuthenticationValueParser {
+    type Value = String;
+
+    fn parse_ref(
+        &self,
+        command: &clap::Command,
+        argument: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        (self.parse).parse_ref(command, argument, value)
+    }
+
+    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+        Some(Box::new(
+            self.values.iter().copied().map(PossibleValue::new),
+        ))
+    }
 }
 
 #[derive(Subcommand)]
@@ -867,7 +893,7 @@ pub struct ObjectStorageSourceFields {
     ///
     /// Inferred from credential flags when omitted; with no credentials, no
     /// authentication is sent. Workload identity is only valid for GCS.
-    #[arg(long, value_parser = parse_supported_object_storage_auth)]
+    #[arg(long, value_parser = AuthenticationValueParser { parse: parse_supported_object_storage_auth, values: &["IAM_ROLE", "IAM_USER", "CONNECTION_STRING", "SERVICE_ACCOUNT", "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"] })]
     pub auth: Option<String>,
 
     /// Enable continuous ingestion
@@ -997,7 +1023,7 @@ pub struct KafkaSourceFields {
     ///
     /// Inferred from the credential flags when omitted; with no credential flag
     /// at all, no authentication is sent.
-    #[arg(long, value_parser = parse_supported_kafka_auth)]
+    #[arg(long, value_parser = AuthenticationValueParser { parse: parse_supported_kafka_auth, values: ClickPipePostKafkaSourceAuthentication::VALUES })]
     pub auth: Option<String>,
 
     /// Azure Event Hubs connection string
@@ -1687,7 +1713,7 @@ pub struct BigQueryCreateArgs {
     #[arg(
         long,
         default_value = "SERVICE_ACCOUNT",
-        value_parser = parse_supported_bigquery_auth,
+        value_parser = AuthenticationValueParser { parse: parse_supported_bigquery_auth, values: &["SERVICE_ACCOUNT", "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"] },
     )]
     pub auth: String,
 
@@ -1820,7 +1846,7 @@ pub struct PubSubSourceFields {
     #[arg(
         long,
         default_value = "SERVICE_ACCOUNT",
-        value_parser = parse_supported_pubsub_auth,
+        value_parser = AuthenticationValueParser { parse: parse_supported_pubsub_auth, values: &["SERVICE_ACCOUNT", "SERVICE_ACCOUNT_WORKLOAD_IDENTITY"] },
     )]
     pub auth: String,
 
@@ -9186,6 +9212,53 @@ mod tests {
             }
             assert_pubsub_value("--seek-type", value);
         }
+    }
+
+    #[test]
+    fn every_clickpipe_auth_flag_exposes_valid_canonical_choices() {
+        use clap::CommandFactory;
+        fn visit(command: &clap::Command, count: &mut usize) {
+            for argument in command
+                .get_arguments()
+                .filter(|arg| arg.get_long() == Some("auth"))
+            {
+                let parser = argument.get_value_parser();
+                let choices: Vec<_> = parser.possible_values().expect("auth choices").collect();
+                assert!(!choices.is_empty(), "{}", command.get_name());
+                for choice in choices {
+                    let value = choice.get_name();
+                    // Validate every advertised choice through the existing domain parser.
+                    match command.get_name() {
+                        "object-storage" => {
+                            parse_supported_object_storage_auth(value).unwrap();
+                        }
+                        "kafka" => {
+                            parse_supported_kafka_auth(value).unwrap();
+                        }
+                        "pubsub" => {
+                            parse_supported_pubsub_auth(value).unwrap();
+                        }
+                        "bigquery" => {
+                            parse_supported_bigquery_auth(value).unwrap();
+                        }
+                        _ => {}
+                    }
+                }
+                *count += 1;
+            }
+            for child in command.get_subcommands() {
+                visit(child, count);
+            }
+        }
+        let tree = crate::cli::Cli::command();
+        let clickpipe = tree
+            .find_subcommand("cloud")
+            .unwrap()
+            .find_subcommand("clickpipe")
+            .unwrap();
+        let mut count = 0;
+        visit(clickpipe, &mut count);
+        assert_eq!(count, 11);
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -93,8 +93,12 @@ CONTEXT FOR AGENTS:
         /// Instance size (e.g. c6gd.xlarge); validated by the server
         #[arg(long)]
         size: String,
-        /// Cloud provider (aws or gcp)
-        #[arg(long, default_value = "aws")]
+        /// Cloud provider
+        #[arg(
+            long,
+            default_value = "aws",
+            value_parser = clap::builder::PossibleValuesParser::new(PgProvider::VALUES)
+        )]
         provider: String,
         /// Postgres major version
         #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgVersion::VALUES))]
@@ -2996,6 +3000,59 @@ mod tests {
         assert_eq!(provider, "aws");
         assert!(pg_version.is_none());
         assert!(ha_type.is_none());
+    }
+
+    #[test]
+    fn postgres_create_provider_uses_the_api_value_set() {
+        for provider in PgProvider::VALUES {
+            let cmd = parse_postgres(&[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "create",
+                "--name",
+                "pg1",
+                "--region",
+                "us-east-1",
+                "--size",
+                "m7i.2xlarge",
+                "--provider",
+                provider,
+            ]);
+            let PostgresCommands::Create {
+                provider: parsed, ..
+            } = cmd
+            else {
+                panic!("expected create");
+            };
+            assert_eq!(parsed, *provider);
+        }
+
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
+            "--provider",
+            "azure",
+        ])
+        .err()
+        .expect("invalid provider must be rejected by clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+        assert_eq!(error.exit_code(), 2);
+        let message = error.to_string();
+        for provider in PgProvider::VALUES {
+            assert!(
+                message.contains(provider),
+                "missing `{provider}`: {message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/skills.rs
+++ b/crates/clickhousectl/src/skills.rs
@@ -145,6 +145,10 @@ const SUPPORTED_AGENTS: &[AgentSpec] = &[
     },
 ];
 
+pub(crate) fn supported_agent_keys() -> impl Iterator<Item = &'static str> {
+    SUPPORTED_AGENTS.iter().map(|agent| agent.key)
+}
+
 pub async fn install(args: SkillsArgs) -> Result<()> {
     let home = home_dir()?;
     let scope = resolve_scope(&args)?;
@@ -634,11 +638,7 @@ fn find_agent(name: &str) -> Option<&'static AgentSpec> {
 }
 
 fn supported_agent_list() -> String {
-    SUPPORTED_AGENTS
-        .iter()
-        .map(|agent| agent.key)
-        .collect::<Vec<_>>()
-        .join(", ")
+    supported_agent_keys().collect::<Vec<_>>().join(", ")
 }
 
 fn home_dir() -> Result<PathBuf> {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -242,6 +242,42 @@ fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> st
         .expect("failed to spawn clickhousectl")
 }
 
+#[tokio::test]
+async fn fixed_enum_flags_are_usage_errors_before_any_cloud_request() {
+    for args in [
+        vec![
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
+            "--provider",
+            "azure",
+            "--org-id",
+            "org-1",
+        ],
+        vec![
+            "key", "create", "--name", "ci-key", "--state", "broken", "--org-id", "org-1",
+        ],
+        vec![
+            "key", "update", "key-1", "--state", "broken", "--org-id", "org-1",
+        ],
+    ] {
+        let mock = MockServer::start().await;
+        let output = invoke_cli_with_cloud_credentials(&mock, &args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("possible values"), "{args:?}: {stderr}");
+        assert!(
+            mock.received_requests().await.unwrap().is_empty(),
+            "{args:?}"
+        );
+    }
+}
+
 fn invoke_cli_with_cloud_credentials_and_stdin(
     mock: &MockServer,
     cli_args: &[&str],


### PR DESCRIPTION
Managed Postgres providers, API key states and Skills agent names are validated during clap parsing, returning usage exit 2 before networking.

Every ClickPipe `--auth` flag advertises canonical possible values while delegating validation to its existing parser, preserving accepted modes and aliases. Credential inference and requirements are unchanged.

Parser and subprocess tests cover closed-set values and usage errors before HTTP. All eleven ClickPipe auth declarations expose validated canonical choices.

Refs #841 (choice visibility only; keep its remaining auth behavior scope open).

Fixes #684

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
