### PR TITLE
fix(clickpipes): reject source port zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2220,6 +2220,10 @@ checked before the request is sent.
 
 Use `clickhousectl cloud clickpipe create <source> --help` for the full list of options per source type.
 
+PostgreSQL and MySQL source `--port` values must be between 1 and 65535
+(defaults: 5432 and 3306, respectively). Values outside this range are usage
+errors (exit code 2) before any request is made.
+
 #### MySQL ClickPipe authentication
 
 `clickpipe create mysql` authenticates with either a username and password

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1439,8 +1439,12 @@ pub struct MySqlCreateArgs {
     #[arg(long)]
     pub host: String,
 
-    /// MySQL port
-    #[arg(long, default_value = "3306")]
+    /// MySQL port (1-65535)
+    #[arg(
+        long,
+        default_value = "3306",
+        value_parser = clap::value_parser!(u16).range(1..=65535)
+    )]
     pub port: u16,
 
     /// Username (required with --auth basic; invalid with --auth IAM_ROLE)
@@ -8616,6 +8620,39 @@ mod tests {
             let mut args = mysql_create_cli_args();
             args.extend([flag, invalid]);
             assert_rejected(&args);
+        }
+    }
+
+    #[test]
+    fn mysql_port_accepts_default_and_boundaries_and_rejects_out_of_range_values() {
+        for (port, expected) in [(None, 3306), (Some("1"), 1), (Some("65535"), 65535)] {
+            let mut args = mysql_create_cli_args();
+            args.extend(["--username", "user", "--password", "password"]);
+            if let Some(port) = port {
+                args.extend(["--port", port]);
+            }
+            let ClickPipeCommands::Create {
+                command: ClickPipeCreateCommands::MySQL(parsed),
+            } = parse_clickpipe(&args)
+            else {
+                panic!("expected mysql create");
+            };
+            assert_eq!(parsed.port, expected);
+        }
+
+        for port in ["0", "65536"] {
+            let mut args = mysql_create_cli_args();
+            args.extend([
+                "--username",
+                "user",
+                "--password",
+                "password",
+                "--port",
+                port,
+            ]);
+            let error = clickpipe_parse_error(&args);
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+            assert_eq!(error.exit_code(), 2);
         }
     }
 


### PR DESCRIPTION
`cloud clickpipe create mysql --port 0` now fails during clap parsing with usage exit code 2. The MySQL source uses the same 1–65535 port range as PostgreSQL; its default remains 3306. Auditing the other ClickPipe source flags found no other standalone port flag missing validation.

Adds parser coverage for the default, both valid boundaries, zero, and overflow, and documents the source port range in README.

Validation: `cargo fmt --all`; `cargo test -p clickhousectl --bin clickhousectl cloud::clickpipes::tests`.

Closes #685.

Typed update JSON follow-up: #813 addresses the QA comment on #685 by validating MySQL and Postgres update ports before HTTP, including file/stdin input and partial-update omission coverage. It is appended to the same PR stack (#769); this PR continues to cover the create-flag path.
