### PR TITLE
fix(clickpipes): validate scaling ranges before HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,10 @@ clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
 clickhousectl cloud clickpipe reverse-private-endpoint list <service-id>
 ```
 
+`clickpipe scale` accepts replicas 1–40, CPU 125–2000 millicores, and memory
+0.5–8 GB. Out-of-range and non-finite values fail with usage exit 2 before any
+API request.
+
 CDC scaling CPU accepts 1000-32000 millicores in increments of 1000, and
 memory accepts 4-128 GiB in increments of 4. Memory must be four times the CPU
 core count when both are changed together; omitted update flags preserve their

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -86,7 +86,7 @@ fn parse_cdc_memory_gb(value: &str) -> Result<f64, String> {
     Ok(value)
 }
 
-fn parse_create_memory_gb(value: &str) -> Result<f64, String> {
+fn parse_streaming_memory_gb(value: &str) -> Result<f64, String> {
     let value = value
         .parse::<f64>()
         .map_err(|_| "must be a number from 0.5 to 8".to_string())?;
@@ -348,15 +348,15 @@ CONTEXT FOR AGENTS:
         clickpipe_id: String,
 
         /// Number of replicas (1-40)
-        #[arg(long)]
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=40))]
         replicas: Option<u32>,
 
         /// CPU millicores per replica (125-2000, streaming pipes)
-        #[arg(long)]
+        #[arg(long, value_parser = clap::value_parser!(u32).range(125..=2000))]
         cpu_millicores: Option<u32>,
 
         /// Memory GB per replica (0.5-8, streaming pipes)
-        #[arg(long)]
+        #[arg(long, value_parser = parse_streaming_memory_gb)]
         memory_gb: Option<f64>,
 
         /// Organization ID (auto-detected only if you have one org)
@@ -814,7 +814,7 @@ pub struct ClickPipeCreateRequestArgs {
     pub cpu_millicores: Option<u32>,
 
     /// Initial memory GB per replica (0.5-8)
-    #[arg(long, value_parser = parse_create_memory_gb)]
+    #[arg(long, value_parser = parse_streaming_memory_gb)]
     pub memory_gb: Option<f64>,
 
     /// Field mapping JSON with sourceField and destinationField (repeatable)
@@ -6277,6 +6277,69 @@ mod tests {
         assert_eq!(cpu_millicores, Some(500));
         assert_eq!(memory_gb, Some(1.5));
         assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn scale_accepts_inclusive_boundaries() {
+        for (replicas, cpu, memory) in [("1", "125", "0.5"), ("40", "2000", "8")] {
+            let ClickPipeCommands::Scale {
+                replicas: parsed_replicas,
+                cpu_millicores,
+                memory_gb,
+                ..
+            } = parse_clickpipe(&[
+                "scale",
+                "svc-1",
+                "pipe-1",
+                "--replicas",
+                replicas,
+                "--cpu-millicores",
+                cpu,
+                "--memory-gb",
+                memory,
+            ])
+            else {
+                panic!("expected scale");
+            };
+            assert_eq!(parsed_replicas, Some(replicas.parse().unwrap()));
+            assert_eq!(cpu_millicores, Some(cpu.parse().unwrap()));
+            assert_eq!(memory_gb, Some(memory.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn scale_rejects_out_of_range_and_non_finite_values() {
+        for (flag, values) in [
+            ("replicas", &["0", "41", "-1"][..]),
+            ("cpu-millicores", &["0", "124", "2001", "-1"][..]),
+            (
+                "memory-gb",
+                &[
+                    "0",
+                    "0.49",
+                    "8.01",
+                    "9",
+                    "-1",
+                    "NaN",
+                    "inf",
+                    "+inf",
+                    "-inf",
+                    "infinity",
+                    "-infinity",
+                ][..],
+            ),
+        ] {
+            for value in values {
+                let argument = format!("--{flag}={value}");
+                let error = clickpipe_parse_error(&["scale", "svc-1", "pipe-1", &argument]);
+                assert_eq!(
+                    error.kind(),
+                    clap::error::ErrorKind::ValueValidation,
+                    "{argument}"
+                );
+                assert_eq!(error.exit_code(), 2, "{argument}");
+            }
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -347,7 +347,7 @@ CONTEXT FOR AGENTS:
         /// ClickPipe ID
         clickpipe_id: String,
 
-        /// Number of replicas (1-40)
+        /// Number of replicas (1-40, streaming pipes)
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..=40))]
         replicas: Option<u32>,
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -15850,6 +15850,92 @@ async fn clickpipe_scale_with_a_single_flag_sends_the_request() {
     assert_eq!(body["replicas"], 4);
 }
 
+#[tokio::test]
+async fn clickpipe_scale_invalid_values_make_no_request() {
+    let mock = MockServer::start().await;
+    for argument in [
+        "--replicas=0",
+        "--replicas=41",
+        "--cpu-millicores=0",
+        "--cpu-millicores=124",
+        "--cpu-millicores=2001",
+        "--memory-gb=0",
+        "--memory-gb=0.49",
+        "--memory-gb=8.01",
+        "--memory-gb=9",
+        "--memory-gb=NaN",
+        "--memory-gb=inf",
+        "--memory-gb=+inf",
+        "--memory-gb=-inf",
+    ] {
+        // Omit --org-id so the check also catches accidental organization discovery.
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &["clickpipe", "scale", "svc-1", "pipe-1", argument],
+        );
+        assert_eq!(output.status.code(), Some(2), "{argument}: {output:?}");
+    }
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "invalid scale values must be rejected before any API request"
+    );
+}
+
+#[tokio::test]
+async fn clickpipe_scale_boundaries_preserve_wire_values() {
+    for (replicas, cpu, memory, body) in [
+        (
+            "1",
+            "125",
+            "0.5",
+            serde_json::json!({
+                "replicas": 1, "replicaCpuMillicores": 125, "replicaMemoryGb": 0.5
+            }),
+        ),
+        (
+            "40",
+            "2000",
+            "8",
+            serde_json::json!({
+                "replicas": 40, "replicaCpuMillicores": 2000, "replicaMemoryGb": 8.0
+            }),
+        ),
+    ] {
+        let mock = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/scaling",
+            ))
+            .and(body_json(&body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {"id": "11111111-2222-3333-4444-555555555555", "scaling": body},
+                "status": 200,
+                "requestId": "stub-clickpipe-scale",
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "clickpipe",
+                "scale",
+                "svc-1",
+                "pipe-1",
+                "--org-id",
+                "org-1",
+                "--replicas",
+                replicas,
+                "--cpu-millicores",
+                cpu,
+                "--memory-gb",
+                memory,
+            ],
+        );
+        assert_success(&output);
+    }
+}
+
 // ── service-wide ClickPipes CDC scaling (issue #586) ───────────────────────
 
 const CDC_SCALING_PATH: &str = "/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling";


### PR DESCRIPTION
Streaming ClickPipe scale flags reject invalid replicas, CPU and memory ranges during parsing before HTTP.

`clickpipe scale --replicas` now states the streaming-pipe constraint alongside the CPU and memory flags.

The existing scaling parser and request-builder tests retain their boundary and omission coverage.

Refs #846 (scale help only).

Closes #762

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
