### PR TITLE
fix(postgres): honor JSON mode for config output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,12 +1143,13 @@ clickhousectl cloud postgres delete <pg-id>
 clickhousectl cloud postgres certs get <pg-id>                   # raw PEM to stdout
 clickhousectl cloud postgres certs get <pg-id> --output ca.pem   # file (mode 0600 on unix)
 
-# Runtime configuration (`config get` always prints JSON; --json changes nothing)
+# Runtime configuration (human-readable by default; JSON with --json or for coding agents)
 clickhousectl cloud postgres config get <pg-id>
+clickhousectl cloud postgres config get <pg-id> --json > complete-config.json
 clickhousectl cloud postgres config patch <pg-id> --set max_connections=500 --set random_page_cost=1.1
 clickhousectl cloud postgres config patch <pg-id> --file patch.json
 
-# Replace the entire configuration only with a complete object obtained from `config get`
+# Replace the entire configuration only with a complete object obtained from `config get --json`
 clickhousectl cloud postgres config replace <pg-id> --file complete-config.json
 
 # Password
@@ -1184,7 +1185,7 @@ For `postgres config patch --file`, put that map under `pgBouncerConfig` alongsi
 {"pgConfig":{},"pgBouncerConfig":{"default_pool_size":"16"}}
 ```
 
-PgBouncer parameter names are open-ended; values must be quoted strings, including numbers. Invalid value types fail locally before any API request. `config replace` replaces the complete Postgres and PgBouncer configuration: obtain the current document with `config get`, edit it, and retain both sections and every setting you want to keep.
+PgBouncer parameter names are open-ended; values must be quoted strings, including numbers. Invalid value types fail locally before any API request. `config replace` replaces the complete Postgres and PgBouncer configuration: obtain the current document with `config get --json`, edit it, and retain both sections and every setting you want to keep.
 
 `pgConfig` uses the closed set of GUC names supported by the Cloud API. Unknown names and `null` values are rejected locally on `--set` and every PgConfig file path, and the enum-valued settings accept only `default_transaction_isolation` (`read committed`, `repeatable read`, `serializable`), `ssl_min_protocol_version` (`TLSv1` through `TLSv1.3`), and `wal_compression` (`off`, `on`, `lz4`, `zstd`). Files for `config patch` and `config replace` must contain both `pgConfig` and `pgBouncerConfig`; use an explicit `{}` when a section is intentionally empty rather than omitting it.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -173,8 +173,7 @@ CONTEXT FOR AGENTS:
         subcommand,
         after_help = "\
 CONTEXT FOR AGENTS:
-  `get` always prints JSON; --json changes nothing.
-  `replace` sends the whole object — start from `config get` output, not a fragment.
+  `replace` sends the whole object — start from `config get --json` output, not a fragment.
   `patch --set` only touches pgConfig; use --file to patch pgBouncerConfig."
     )]
     Config(ConfigCommands),
@@ -347,7 +346,7 @@ pub enum ConfigCommands {
         postgres_id: String,
         /// JSON file with a complete PostgresInstanceConfig object
         ///
-        /// Not a fragment: use a document obtained from `config get`.
+        /// Not a fragment: use a document obtained from `config get --json`.
         #[arg(long)]
         file: PathBuf,
         /// Organization ID (auto-detected only if you have one org)
@@ -1743,7 +1742,7 @@ pub async fn postgres_config_get(
     client: &CloudClient,
     postgres_id: &str,
     org_id: Option<&str>,
-    _json: bool,
+    json: bool,
 ) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
@@ -1752,8 +1751,11 @@ pub async fn postgres_config_get(
         .await
         .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let cfg = unwrap_api(resp)?;
-    // Config is a flat 20+ field object — always emit as JSON (pretty).
-    println!("{}", serde_json::to_string_pretty(&cfg)?);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&cfg)?);
+    } else {
+        print_human(&cfg)?;
+    }
     Ok(())
 }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -17527,6 +17527,75 @@ async fn pgbouncer_invalid_file_values_fail_before_any_api_request() {
 }
 
 #[tokio::test]
+async fn postgres_config_get_honors_human_explicit_json_and_agent_output() {
+    let mock = MockServer::start().await;
+    let config = serde_json::json!({
+        "pgConfig": {"work_mem": "64MB", "max_connections": 500},
+        "pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}
+    });
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/config"))
+        .and(header(
+            "authorization",
+            "Basic ZmFrZS1rZXktZm9yLXRlc3RzOmZha2Utc2VjcmV0LWZvci10ZXN0cw==",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": config
+        })))
+        .expect(3)
+        .mount(&mock)
+        .await;
+
+    let args = ["postgres", "config", "get", "pg-1", "--org-id", "org-1"];
+    let human = invoke_cli_with_cloud_credentials_human(&mock, &args);
+    assert_success(&human);
+    assert!(serde_json::from_slice::<Value>(&human.stdout).is_err());
+    let human = String::from_utf8(human.stdout).unwrap();
+    for line in [
+        "pgConfig:",
+        "  work_mem: 64MB",
+        "  max_connections: 500",
+        "pgBouncerConfig:",
+        "  default_pool_size: 16",
+        "  future_parameter: on",
+    ] {
+        assert!(human.lines().any(|actual| actual == line), "{human}");
+    }
+
+    let explicit = invoke_cli_with_cloud_credentials(&mock, &args);
+    assert_success(&explicit);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&explicit.stdout).unwrap(),
+        config
+    );
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let agent = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("AI_AGENT", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args(["cloud", "--url", &mock.uri()])
+        .args(args)
+        .output()
+        .unwrap();
+    assert_success(&agent);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&agent.stdout).unwrap(),
+        config
+    );
+    for request in mock.received_requests().await.unwrap() {
+        assert_eq!(request.url.query(), None);
+        assert!(request.body.is_empty());
+    }
+}
+
+#[tokio::test]
 async fn pgbouncer_config_get_json_preserves_values_and_tolerates_absent_sections() {
     for result in [
         serde_json::json!({"pgBouncerConfig": {"default_pool_size": "16", "future_parameter": "on"}}),


### PR DESCRIPTION
`cloud postgres config get` previously always printed JSON, ignoring its output mode. It now uses the shared human renderer by default and preserves the configuration JSON when `--json` is passed or a coding agent is detected. Help and README examples use `config get --json` when saving a document for `config replace`.

Validation: `cargo fmt --all`; `cargo test -p clickhousectl --test cli_request_shape_test config_get` (2 passed, using loopback wiremock fixtures). The regression checks human fields, explicit and agent JSON values, authenticated GET requests, and absence of query parameters or bodies. Existing sparse-response JSON coverage passes. Full combined-release checks are tracked in #757.

Closes #683.
