### PR TITLE
fix(org): support consistent organization selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,12 +696,12 @@ Reading a service, Postgres service or organization â€” or deleting a service â€
 
 ```bash
 clickhousectl cloud org list              # List organizations
-clickhousectl cloud org get <org-id>      # Get organization details
+clickhousectl cloud org get --org-id <org-id>      # Get organization details
 clickhousectl cloud org quota list --org-id <org-id>
 clickhousectl cloud org quota get services-per-organization --org-id <org-id>
 clickhousectl cloud org balance --org-id <org-id>  # Active trial and prepaid credits
-clickhousectl cloud org update <org-id> --name "Renamed Org"
-clickhousectl cloud org update <org-id> \
+clickhousectl cloud org update --org-id <org-id> --name "Renamed Org"
+clickhousectl cloud org update --org-id <org-id> \
   --remove-private-endpoint pe-1,cloud-provider=aws,region=us-east-1 \
   --enable-core-dumps false
 # Create BYOC infrastructure (repeat --availability-zone-suffix as needed)
@@ -710,7 +710,7 @@ clickhousectl cloud org byoc create --org-id <org-id> \
   --availability-zone-suffix a --availability-zone-suffix b \
   --vpc-cidr-range 10.0.0.0/16 --display-name production
 # Find the infrastructure ID and state in the organization's byocConfig
-clickhousectl cloud org get <org-id>
+clickhousectl cloud org get --org-id <org-id>
 clickhousectl cloud org byoc update <infrastructure-id> \
   --display-name renamed --org-id <org-id>
 clickhousectl cloud org byoc delete <infrastructure-id> --org-id <org-id>
@@ -720,11 +720,14 @@ clickhousectl cloud org usage \
   --from-date 2024-01-01 \
   --to-date 2024-01-31 \
   --filter tag:Environment=Production   # max 31-day window (to-date inclusive), costs in CHC
-# Org quota, balance, prometheus, and usage commands auto-detect the org when --org-id is omitted.
-# Org list takes no ID; org get/update take a positional <org-id>.
+# Org get, update, quota, balance, prometheus, and usage auto-detect the org without --org-id.
+# Org list takes no ID.
 # It is auto-detected only when your credentials reach exactly one organization.
 # Organization quota and balance commands are beta and read-only, so they support OAuth.
 ```
+
+`org get` and `org update` still accept the legacy positional organization ID.
+Prefer `--org-id` in new commands; supplying both forms is a usage error (exit 2).
 
 BYOC create, update, and delete require API key authentication. Update requires
 `--display-name`, so it cannot send an empty/no-op patch. The API has no separate

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -21,8 +21,13 @@ pub enum OrgCommands {
 
     /// Get organization details
     Get {
-        /// Organization ID
-        org_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+
+        /// Organization ID (deprecated positional form; use --org-id)
+        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
+        legacy_org_id: Option<String>,
     },
 
     /// View organization quotas (Beta)
@@ -61,8 +66,13 @@ CONTEXT FOR AGENTS:
   Only the flags you pass change; everything else is left as-is.
   This can only remove private endpoints; add them with `cloud service update --add-private-endpoint-id`.")]
     Update {
-        /// Organization ID
-        org_id: String,
+        /// Organization ID (auto-detected only if you have one org)
+        #[arg(long)]
+        org_id: Option<String>,
+
+        /// Organization ID (deprecated positional form; use --org-id)
+        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
+        legacy_org_id: Option<String>,
 
         /// New organization name
         #[arg(long)]
@@ -220,7 +230,7 @@ pub enum ByocCommands {
     /// Create BYOC infrastructure
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Wait for `cloud org get <org-id>` to show state `infra-ready` before creating a service.
+  Wait for `cloud org get --org-id <org-id>` to show state `infra-ready` before creating a service.
   Discover profiles with `cloud service profile list --region <region> --byoc-id <id>`.")]
     Create {
         /// Cloud region ID
@@ -427,13 +437,21 @@ impl InvitationCommands {
 pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> CloudResult<()> {
     match command {
         OrgCommands::List => org_list(client, json).await,
-        OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
+        OrgCommands::Get {
+            org_id,
+            legacy_org_id,
+        } => {
+            let org_id =
+                resolve_org_id(client, org_id.as_deref().or(legacy_org_id.as_deref())).await?;
+            org_get(client, &org_id, json).await
+        }
         OrgCommands::Quota { command } => run_quota(client, command, json).await,
         OrgCommands::Balance { org_id } => org_balance(client, org_id.as_deref(), json).await,
         OrgCommands::Byoc { command } => run_byoc(client, command, json).await,
         OrgCommands::Role { command } => run_role(client, command, json).await,
         OrgCommands::Update {
             org_id,
+            legacy_org_id,
             name,
             remove_private_endpoint,
             enable_core_dumps,
@@ -443,7 +461,13 @@ pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> 
                 remove_private_endpoints: remove_private_endpoint,
                 enable_core_dumps,
             };
-            org_update(client, &org_id, options, json).await
+            org_update(
+                client,
+                org_id.as_deref().or(legacy_org_id.as_deref()),
+                options,
+                json,
+            )
+            .await
         }
         OrgCommands::Prometheus {
             command,
@@ -1023,12 +1047,13 @@ async fn org_balance(client: &CloudClient, org_id: Option<&str>, json: bool) -> 
 
 async fn org_update(
     client: &CloudClient,
-    org_id: &str,
+    org_id: Option<&str>,
     options: OrgUpdateOptions,
     json: bool,
 ) -> CloudResult<()> {
     let request = build_org_update_request(&options)?;
-    let organization = client.update_organization(org_id, &request).await?;
+    let org_id = resolve_org_id(client, org_id).await?;
+    let organization = client.update_organization(&org_id, &request).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&organization)?);
@@ -1871,6 +1896,78 @@ mod tests {
     }
 
     #[test]
+    fn org_get_and_update_hide_only_the_legacy_selector() {
+        use clap::CommandFactory;
+        let cli = Cli::command();
+        let org = cli
+            .find_subcommand("cloud")
+            .unwrap()
+            .find_subcommand("org")
+            .unwrap();
+        for name in ["get", "update"] {
+            let command = org.find_subcommand(name).unwrap();
+            let legacy = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == "legacy_org_id")
+                .unwrap();
+            let flag = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == "org_id")
+                .unwrap();
+            assert!(legacy.is_hide_set());
+            assert!(!legacy.is_required_set());
+            assert_eq!(flag.get_long(), Some("org-id"));
+            assert!(!flag.is_hide_set());
+            assert!(!flag.is_required_set());
+        }
+    }
+
+    #[test]
+    fn org_get_and_update_accept_optional_and_legacy_selectors() {
+        for subcommand in ["get", "update"] {
+            for selector in [vec![], vec!["--org-id", "org-1"], vec!["org-1"]] {
+                let mut args = vec!["clickhousectl", "cloud", "org", subcommand];
+                args.extend(&selector);
+                let CloudCommands::Org { command } = parse_cloud_command(&args) else {
+                    panic!("expected org command");
+                };
+                assert_eq!(command.is_write(), subcommand == "update");
+                let (org_id, legacy_org_id) = match command {
+                    OrgCommands::Get {
+                        org_id,
+                        legacy_org_id,
+                    }
+                    | OrgCommands::Update {
+                        org_id,
+                        legacy_org_id,
+                        ..
+                    } => (org_id, legacy_org_id),
+                    _ => panic!("expected get or update"),
+                };
+                assert_eq!(org_id.as_deref(), (selector.len() == 2).then_some("org-1"));
+                assert_eq!(
+                    legacy_org_id.as_deref(),
+                    (selector.len() == 1).then_some("org-1")
+                );
+            }
+            for positional in ["org-1", "org-2"] {
+                let err = Cli::try_parse_from([
+                    "clickhousectl",
+                    "cloud",
+                    "org",
+                    subcommand,
+                    positional,
+                    "--org-id",
+                    "org-1",
+                ])
+                .err()
+                .expect("conflicting selectors must fail");
+                assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+            }
+        }
+    }
+
+    #[test]
     fn parses_organization_body_command_defaults() {
         let CloudCommands::Org { command } =
             parse_cloud_command(&["clickhousectl", "cloud", "org", "update", "org-1"])
@@ -1879,6 +1976,7 @@ mod tests {
         };
         let OrgCommands::Update {
             org_id,
+            legacy_org_id,
             name,
             remove_private_endpoint,
             enable_core_dumps,
@@ -1886,7 +1984,8 @@ mod tests {
         else {
             panic!("expected org update");
         };
-        assert_eq!(org_id, "org-1");
+        assert!(org_id.is_none());
+        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
         assert!(name.is_none());
         assert!(remove_private_endpoint.is_empty());
         assert!(enable_core_dumps.is_none());
@@ -1954,6 +2053,7 @@ mod tests {
         };
         let OrgCommands::Update {
             org_id,
+            legacy_org_id,
             name,
             remove_private_endpoint,
             enable_core_dumps,
@@ -1961,7 +2061,8 @@ mod tests {
         else {
             panic!("expected org update");
         };
-        assert_eq!(org_id, "org-1");
+        assert!(org_id.is_none());
+        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
         assert_eq!(name.as_deref(), Some("Updated Org"));
         assert_eq!(
             remove_private_endpoint,

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -22534,3 +22534,159 @@ async fn service_settings_set_names_unreadable_files_before_organization_discove
     }
     assert!(mock.received_requests().await.unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn org_get_and_update_select_explicit_legacy_or_detected_organization() {
+    for subcommand in ["get", "update"] {
+        for selector in [
+            vec![],
+            vec!["--org-id", "00000000-0000-0000-0000-000000000001"],
+            vec!["00000000-0000-0000-0000-000000000001"],
+        ] {
+            let mock = MockServer::start().await;
+            let home = tempfile::tempdir().unwrap();
+            Mock::given(method("GET"))
+                .and(path("/v1/organizations"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Only org"}]
+                })))
+                .expect(if selector.is_empty() { 1 } else { 0 })
+                .mount(&mock)
+                .await;
+            let result = serde_json::json!({"id": "00000000-0000-0000-0000-000000000001", "name": "Selected org"});
+            let mut target = Mock::given(method(if subcommand == "get" { "GET" } else { "PATCH" }))
+                .and(path(
+                    "/v1/organizations/00000000-0000-0000-0000-000000000001",
+                ))
+                .and(header(
+                    "authorization",
+                    "Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ=",
+                ));
+            if subcommand == "update" {
+                target = target.and(body_json(serde_json::json!({"name": "Selected org"})));
+            }
+            target
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": result})),
+                )
+                .expect(1)
+                .mount(&mock)
+                .await;
+            let mut cmd = Command::new(clickhousectl_binary());
+            clear_inherited_env(&mut cmd);
+            cmd.current_dir(home.path())
+                .env("HOME", home.path())
+                .env("DO_NOT_TRACK", "1")
+                .args([
+                    "cloud",
+                    "--url",
+                    &mock.uri(),
+                    "--api-key",
+                    "test-key",
+                    "--api-secret",
+                    "test-secret",
+                    "--json",
+                    "org",
+                    subcommand,
+                ])
+                .args(&selector);
+            if subcommand == "update" {
+                cmd.args(["--name", "Selected org"]);
+            }
+            let output = cmd.output().unwrap();
+            assert_success(&output);
+            assert_eq!(
+                serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+                result
+            );
+            assert_eq!(
+                mock.received_requests().await.unwrap().len(),
+                if selector.is_empty() { 2 } else { 1 }
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn org_get_and_update_reject_conflicting_selectors_before_http() {
+    let mock = MockServer::start().await;
+    let home = tempfile::tempdir().unwrap();
+    for subcommand in ["get", "update"] {
+        for positional in [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+        ] {
+            let mut cmd = Command::new(clickhousectl_binary());
+            clear_inherited_env(&mut cmd);
+            let output = cmd
+                .current_dir(home.path())
+                .env("HOME", home.path())
+                .env("DO_NOT_TRACK", "1")
+                .args([
+                    "cloud",
+                    "--url",
+                    &mock.uri(),
+                    "--api-key",
+                    "test-key",
+                    "--api-secret",
+                    "test-secret",
+                    "org",
+                    subcommand,
+                    positional,
+                    "--org-id",
+                    "00000000-0000-0000-0000-000000000001",
+                ])
+                .output()
+                .unwrap();
+            assert_eq!(output.status.code(), Some(2), "{output:?}");
+        }
+    }
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn org_get_and_update_require_one_organization_for_autodetection() {
+    for subcommand in ["get", "update"] {
+        for organizations in [
+            serde_json::json!([]),
+            serde_json::json!([
+                {"id": "00000000-0000-0000-0000-000000000001", "name": "First"}, {"id": "00000000-0000-0000-0000-000000000002", "name": "Second"}
+            ]),
+        ] {
+            let mock = MockServer::start().await;
+            let home = tempfile::tempdir().unwrap();
+            Mock::given(method("GET"))
+                .and(path("/v1/organizations"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({"result": organizations})),
+                )
+                .expect(1)
+                .mount(&mock)
+                .await;
+            let mut cmd = Command::new(clickhousectl_binary());
+            clear_inherited_env(&mut cmd);
+            let output = cmd
+                .current_dir(home.path())
+                .env("HOME", home.path())
+                .env("DO_NOT_TRACK", "1")
+                .args([
+                    "cloud",
+                    "--url",
+                    &mock.uri(),
+                    "--api-key",
+                    "test-key",
+                    "--api-secret",
+                    "test-secret",
+                    "org",
+                    subcommand,
+                ])
+                .output()
+                .unwrap();
+            assert_eq!(output.status.code(), Some(1), "{output:?}");
+            let requests = mock.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 1);
+            assert_eq!(requests[0].url.path(), "/v1/organizations");
+        }
+    }
+}


### PR DESCRIPTION
Organization get/update previously required a positional ID while sibling commands accepted optional `--org-id`. Both now accept `--org-id` and use the existing single-organization autodetection when omitted. The legacy positional remains accepted but hidden; providing both selectors fails with usage exit 2 before HTTP, even if the IDs match.

README examples and migration guidance use the flag form. Update request validation still happens before organization discovery.

Validation: organization unit tests (32 passed); three subprocess/wiremock tests covering both explicit selectors, successful autodetection, zero/multiple organizations, matching/differing selector conflicts, authentication, and exact update bodies; `cargo fmt --all`. Full stacked checks are run before publishing.

Closes #686.
