### PR TITLE
fix(local): require separator before native client arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ clickhousectl local client --host remote-host --version 26.8.1.1760  # Use an in
 clickhousectl local client -- --format Pretty        # Extra clickhouse-client args after --
 ```
 
+`local client` and `local postgres client` now require `--` before native arguments. Put wrapper options such as `--name`, `--host`, `--port`, and `--query` before it; unknown options there produce a usage error (exit 2). Existing commands that passed native options without the separator must add it, for example `local client --name dev -- --format CSV`. Everything after `--` is passed literally to the native client, including options that share wrapper names.
+
 `--name` selects the connection and local client binary from managed server metadata, so named mode does not need a global default. It cannot be combined with direct `--host` or `--port` selectors, and named mode does not accept `--version`.
 
 Without `--host` or `--port`, managed client lookup uses `.clickhouse/servers` from the canonical current directory only. It does not search parent directories. If lookup fails, return to the project root that owns the server, inspect that project's servers with `local server list`, or use direct mode.
@@ -556,6 +558,7 @@ clickhousectl local postgres client --name dev --queries-file schema.sql  # Run 
 clickhousectl local postgres client --name dev --version 17               # Disambiguate two majors
 clickhousectl local postgres client --host remote-host       # Direct mode; port defaults to 5432
 clickhousectl local postgres client --port 55432             # Direct mode; connects locally
+clickhousectl local postgres client --name dev -- -X -v ON_ERROR_STOP=1 # Native psql options
 
 # Write POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE into .env.local
 clickhousectl local postgres dotenv --name dev --local
@@ -568,6 +571,8 @@ clickhousectl local postgres stop-all                     # Stop all Postgres in
 clickhousectl local postgres remove                       # Remove "default"
 clickhousectl local postgres remove dev
 ```
+
+Native `psql` arguments require `--`, with all wrapper selectors before it: `local postgres client --host remote-host -- -X`. Without the separator, unknown options are usage errors (exit 2); after it, even `--host` and `--port` are forwarded literally.
 
 `local postgres client --queries-file` accepts relative or absolute host paths, or `-` to read stdin. Plain pipes also work, for example `cat seed.sql | clickhousectl local postgres client`. Both forms work when host `psql` is unavailable: the Docker fallback streams SQL to container `psql`, preserves EOF and returns psql's exit status. When combined, `--query` executes before the file; append native arguments such as `-- -v ON_ERROR_STOP=1` to stop on SQL errors. In Docker mode, file contents are streamed as `psql -f -`; paths used inside SQL (such as `\i` or `\copy`) still refer to the container filesystem.
 
@@ -2686,7 +2691,7 @@ There is no install ID, no device ID, and no fingerprinting of any kind. The pay
 `clickhousectl local server stop analytics-prod` records `positionals: ["name"]` — that a server was named, not which one. Three exclusions keep that honest:
 
 - only arguments you actually passed count, so a value clap filled in from a default (or from the environment), and a name the CLI generated for you, are absent — which is what makes "you named it" and "we picked one" distinguishable
-- arguments forwarded to another program are never recorded: everything after `--` for `local server start`, and the trailing arguments of `local client` and `local postgres client`, belong to `clickhouse-server`, `clickhouse-client`, and `psql`
+- arguments forwarded to another program are never recorded: everything after `--` for `local server start`, `local client`, and `local postgres client` belongs to `clickhouse-server`, `clickhouse-client`, and `psql`
 - when a command fails to parse, the unmatched token is still never recorded — only the slot it would have filled
 
 A failed *runtime* invocation may also carry up to six failure-classification fields, so that "exit code 1" stops being the only thing we know about a broken command. Each one is a closed vocabulary defined in the source, and nothing else can ever appear in it:

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -226,7 +226,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Default mode looks up a server started by `clickhousectl local server start`; the name defaults
   to \"default\".
-  Extra clickhouse-client arguments go after `--`.
+  Put wrapper options before `--`; all arguments after it go to clickhouse-client.
   Next: `clickhousectl local server list` to see running servers."
     )]
     Client {
@@ -261,8 +261,8 @@ CONTEXT FOR AGENTS:
         #[arg(long, num_args = 1.., conflicts_with = "query")]
         queries_file: Vec<String>,
 
-        /// Additional arguments to pass to clickhouse-client
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        /// Native clickhouse-client arguments (require --)
+        #[arg(last = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
@@ -557,7 +557,7 @@ CONTEXT FOR AGENTS:
   psql inside the container via `docker exec`.
   Direct mode (--host/--port) requires `psql` on PATH and connects as user/database \"postgres\"
   with no password; it does not read managed credentials.
-  Extra psql arguments go after `--`.")]
+  Put wrapper options before `--`; all arguments after it go to psql.")]
     Client {
         /// Managed instance to connect to (default: "default")
         #[arg(long, short, conflicts_with_all = ["host", "port"])]
@@ -587,8 +587,8 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         queries_file: Option<String>,
 
-        /// Additional arguments to pass to psql
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        /// Native psql arguments (require --)
+        #[arg(last = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
@@ -990,6 +990,91 @@ mod tests {
                 error.to_string().contains("--queries-file <QUERIES_FILE>"),
                 "{error}"
             );
+        }
+    }
+
+    #[test]
+    fn both_clients_require_boundary_before_native_arguments() {
+        for client in [&["client"][..], &["postgres", "client"][..]] {
+            for native in ["--unknown", "--format", "-X", "dbname"] {
+                for selectors in [
+                    &["--name", "dev"][..],
+                    &["--host", "remote", "--port", "9000"][..],
+                    &["--query", "SELECT 1"][..],
+                ] {
+                    for native_first in [true, false] {
+                        let tail: Vec<&str> = if native_first {
+                            [native]
+                                .into_iter()
+                                .chain(selectors.iter().copied())
+                                .collect()
+                        } else {
+                            selectors.iter().copied().chain([native]).collect()
+                        };
+                        let argv: Vec<&str> = client.iter().copied().chain(tail).collect();
+                        assert_eq!(
+                            local_parse_error(&argv).kind(),
+                            clap::error::ErrorKind::UnknownArgument,
+                            "argv: {argv:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn both_clients_preserve_all_native_arguments_after_boundary() {
+        let native = [
+            "--format=CSV",
+            "-X",
+            "--name",
+            "native-name",
+            "--host",
+            "native-host",
+            "--port",
+            "0",
+            "--version",
+            "native-version",
+            "--query",
+            "SELECT 'a b'",
+            "--json",
+            "--help",
+            "",
+            "--",
+            "-",
+        ];
+        for client in [&["client"][..], &["postgres", "client"][..]] {
+            let argv: Vec<&str> = client
+                .iter()
+                .copied()
+                .chain(["--host", "wrapper-host", "--port", "12345", "--"])
+                .chain(native)
+                .collect();
+            let (name, host, port, args) = match local_command(&argv) {
+                LocalCommands::Client {
+                    name,
+                    host,
+                    port,
+                    args,
+                    ..
+                }
+                | LocalCommands::Postgres {
+                    command:
+                        PostgresCommands::Client {
+                            name,
+                            host,
+                            port,
+                            args,
+                            ..
+                        },
+                } => (name, host, port, args),
+                _ => panic!("expected client"),
+            };
+            assert!(name.is_none());
+            assert_eq!(host.as_deref(), Some("wrapper-host"));
+            assert_eq!(port, Some(12345));
+            assert_eq!(args, native);
         }
     }
 

--- a/crates/clickhousectl/tests/local_client_selectors_test.rs
+++ b/crates/clickhousectl/tests/local_client_selectors_test.rs
@@ -650,3 +650,129 @@ fn postgres_client_uses_the_same_validation_and_direct_mode_defaults() {
         ],
     );
 }
+
+#[test]
+fn both_clients_reject_native_arguments_without_boundary_before_child_execution() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_A);
+    let bin = home.path().join("bin");
+    write_arg_printer(&bin.join("psql"));
+
+    for client in [
+        &["local", "client"][..],
+        &["local", "postgres", "client"][..],
+    ] {
+        for native in ["--format=CSV", "--unknown", "-X", "dbname"] {
+            for selectors in [
+                &["--name", "dev"][..],
+                &["--host", "wrapper-host", "--port", "12345"][..],
+            ] {
+                for native_first in [true, false] {
+                    let tail: Vec<&str> = if native_first {
+                        [native]
+                            .into_iter()
+                            .chain(selectors.iter().copied())
+                            .collect()
+                    } else {
+                        selectors.iter().copied().chain([native]).collect()
+                    };
+                    let argv: Vec<&str> = client.iter().copied().chain(tail).collect();
+                    let output = run(project.path(), home.path(), Some(&bin), &argv);
+                    assert_eq!(output.status.code(), Some(2), "argv: {argv:?}; {output:?}");
+                    assert!(output.stdout.is_empty(), "fake child ran: {output:?}");
+                    assert!(!project.path().join(".clickhouse").exists());
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn both_clients_forward_native_argv_literally_after_wrapper_arguments() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let bin = home.path().join("bin");
+    // NUL framing distinguishes empty arguments, embedded newlines and spaces.
+    let script = "#!/bin/sh\nprintf '%s\\0' \"$@\"\n";
+    write_executable(
+        &home
+            .path()
+            .join(".clickhouse/versions")
+            .join(VERSION_A)
+            .join("clickhouse"),
+        script,
+    );
+    write_executable(&bin.join("psql"), script);
+    let native = [
+        "--format=CSV",
+        "-X",
+        "--name",
+        "native-name",
+        "--host",
+        "native-host",
+        "--port",
+        "0",
+        "--version",
+        "native-version",
+        "--query",
+        "SELECT 'a b'\n",
+        "--json",
+        "--help",
+        "",
+        "--",
+        "-",
+    ];
+    for (client, wrapper) in [
+        (
+            &["local", "client"][..],
+            &[
+                "client",
+                "--host",
+                "wrapper-host",
+                "--port",
+                "12345",
+                "--query",
+                "SELECT 1",
+            ][..],
+        ),
+        (
+            &["local", "postgres", "client"][..],
+            &[
+                "-h",
+                "wrapper-host",
+                "-p",
+                "12345",
+                "-U",
+                "postgres",
+                "-d",
+                "postgres",
+                "-c",
+                "SELECT 1",
+            ][..],
+        ),
+    ] {
+        let argv: Vec<&str> = client
+            .iter()
+            .copied()
+            .chain([
+                "--host",
+                "wrapper-host",
+                "--port",
+                "12345",
+                "--query",
+                "SELECT 1",
+                "--",
+            ])
+            .chain(native)
+            .collect();
+        let output = run(project.path(), home.path(), Some(&bin), &argv);
+        assert!(output.status.success(), "argv: {argv:?}; {output:?}");
+        let actual: Vec<&str> = std::str::from_utf8(&output.stdout)
+            .expect("native argv is UTF-8")
+            .split_terminator('\0')
+            .collect();
+        let expected: Vec<&str> = wrapper.iter().copied().chain(native).collect();
+        assert_eq!(actual, expected, "argv: {argv:?}");
+    }
+}


### PR DESCRIPTION
Require `--` before native arguments to both `local client` and `local postgres client`. Previously an unknown option could start passthrough and consume later wrapper selectors such as `--name` or `--host`; it now produces usage exit 2 before resolving a connection or starting a child. Arguments after the separator retain their order and literal values, including flags that share wrapper names.

README documents the compatibility change and both help screens expose the separator. Coverage includes unknown native arguments before and after wrapper selectors, and real-binary/fake-child checks for preserved empty arguments, spaces, newlines, and native flags.

Validation:
- `cargo fmt --all`
- Local clap tests: 45 passed.
- Telemetry unit tests: 64 passed.
- Local client selector subprocess tests: 15 passed.
- Postgres client input tests: 6 passed; 1 real-Docker test ignored. Mock Unix-socket tests passed with sandbox escalation.
- Both client help screens inspected; `git diff --check` clean.

Closes #253. Implements the client boundary scope accepted in #757.
