### PR TITLE
fix(postgres): normalize metrics timestamps without precision loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ PgBouncer parameter names are open-ended; values must be quoted strings, includi
 
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.
 
-`postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
+`postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Whole seconds, fractional seconds, and UTC offsets are normalized to UTC with three fractional digits (for example, `2026-04-16T13:00:00+01:00` becomes `2026-04-16T12:00:00.000Z`). The endpoint supports millisecond precision; finer nonzero fractional digits are rejected before any request instead of rounding or truncating the interval. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
 
 `postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -204,11 +204,11 @@ CONTEXT FOR AGENTS:
     Metrics {
         /// Postgres service ID (from `cloud postgres list`)
         postgres_id: String,
-        /// Start time (ISO 8601 / RFC 3339)
-        #[arg(long, value_parser = parse_datetime)]
+        /// Start time (RFC 3339, at most millisecond precision)
+        #[arg(long, value_parser = parse_metrics_datetime)]
         from_date: String,
-        /// End time (ISO 8601 / RFC 3339)
-        #[arg(long, value_parser = parse_datetime)]
+        /// End time (RFC 3339, at most millisecond precision)
+        #[arg(long, value_parser = parse_metrics_datetime)]
         to_date: String,
         /// Time bucket size in seconds
         #[arg(long, value_parser = clap::value_parser!(i64).range(1..))]
@@ -1994,6 +1994,27 @@ pub async fn postgres_state_change(
     Ok(())
 }
 
+// The metrics endpoint accepts UTC timestamps with exactly three fractional digits.
+// Check the original fraction: chrono discards digits beyond nanosecond precision.
+fn parse_metrics_datetime(value: &str) -> Result<String, String> {
+    let timestamp = chrono::DateTime::parse_from_rfc3339(value)
+        .map_err(|_| format!("invalid datetime '{value}': expected ISO 8601 / RFC 3339"))?;
+    if value.split_once('.').is_some_and(|(_, fraction)| {
+        fraction
+            .bytes()
+            .take_while(u8::is_ascii_digit)
+            .skip(3)
+            .any(|digit| digit != b'0')
+    }) {
+        return Err(format!(
+            "invalid datetime '{value}': Postgres metrics supports at most millisecond precision"
+        ));
+    }
+    Ok(timestamp
+        .with_timezone(&chrono::Utc)
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+}
+
 fn validate_datetime_range(from_date: &str, to_date: &str) -> CloudResult<()> {
     let from = chrono::DateTime::parse_from_rfc3339(from_date)
         .map_err(|_| CloudError::new("invalid --from-date: expected ISO 8601 / RFC 3339"))?;
@@ -3578,8 +3599,8 @@ mod tests {
             panic!("expected metrics");
         };
         assert_eq!(postgres_id, "pg-1");
-        assert_eq!(from_date, "2026-04-16T12:00:00+01:00");
-        assert_eq!(to_date, "2026-04-16T13:00:00+01:00");
+        assert_eq!(from_date, "2026-04-16T11:00:00.000Z");
+        assert_eq!(to_date, "2026-04-16T12:00:00.000Z");
         assert_eq!(bucket_size_seconds, Some(60));
         assert_eq!(org_id.as_deref(), Some("org-1"));
     }
@@ -3628,6 +3649,9 @@ mod tests {
         for (flag, value) in [
             ("--from-date", "yesterday"),
             ("--to-date", "tomorrow"),
+            ("--from-date", "2026-04-16T12:00:00.123456Z"),
+            ("--to-date", "2026-04-16T13:00:00.123456789Z"),
+            ("--from-date", "2026-04-16T12:00:00.0000000001Z"),
             ("--bucket-size-seconds", "0"),
         ] {
             let mut args = vec![
@@ -3651,6 +3675,31 @@ mod tests {
                 .err()
                 .expect("expected parse error");
             assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+    }
+
+    #[test]
+    fn postgres_metrics_normalizes_without_changing_the_instant() {
+        for (input, expected) in [
+            ("2026-04-16T12:00:00Z", "2026-04-16T12:00:00.000Z"),
+            ("2026-04-16T12:00:00.000Z", "2026-04-16T12:00:00.000Z"),
+            ("2026-04-16T12:00:00+00:00", "2026-04-16T12:00:00.000Z"),
+            ("2026-04-16T12:00:00.1Z", "2026-04-16T12:00:00.100Z"),
+            ("2026-04-16T12:00:00.12Z", "2026-04-16T12:00:00.120Z"),
+            ("2026-04-16T00:00:00.123+05:30", "2026-04-15T18:30:00.123Z"),
+            ("2026-04-16T23:00:00.999-02:30", "2026-04-17T01:30:00.999Z"),
+            (
+                "2026-04-16T12:00:00.1230000000Z",
+                "2026-04-16T12:00:00.123Z",
+            ),
+        ] {
+            let normalized = parse_metrics_datetime(input).unwrap();
+            assert_eq!(normalized, expected, "{input}");
+            assert_eq!(
+                chrono::DateTime::parse_from_rfc3339(input).unwrap(),
+                chrono::DateTime::parse_from_rfc3339(&normalized).unwrap(),
+                "normalization changed {input}"
+            );
         }
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2608,8 +2608,8 @@ async fn postgres_metrics_sends_exact_query_supports_oauth_and_preserves_json() 
         .and(path(format!(
             "/v1/organizations/org-1/postgres/{postgres_id}/metrics"
         )))
-        .and(query_param("from_date", "2026-04-16T12:00:00+01:00"))
-        .and(query_param("to_date", "2026-04-16T13:00:00+01:00"))
+        .and(query_param("from_date", "2026-04-16T11:00:00.000Z"))
+        .and(query_param("to_date", "2026-04-16T12:00:00.000Z"))
         .and(query_param("bucket_size_seconds", "60"))
         .and(header("authorization", "Bearer test-bearer-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -2668,11 +2668,11 @@ async fn postgres_metrics_sends_exact_query_supports_oauth_and_preserves_json() 
         [
             (
                 "from_date".to_string(),
-                "2026-04-16T12:00:00+01:00".to_string()
+                "2026-04-16T11:00:00.000Z".to_string()
             ),
             (
                 "to_date".to_string(),
-                "2026-04-16T13:00:00+01:00".to_string()
+                "2026-04-16T12:00:00.000Z".to_string()
             ),
             ("bucket_size_seconds".to_string(), "60".to_string()),
         ]
@@ -2680,12 +2680,92 @@ async fn postgres_metrics_sends_exact_query_supports_oauth_and_preserves_json() 
 }
 
 #[tokio::test]
+async fn postgres_metrics_normalizes_exact_milliseconds_on_the_wire() {
+    let mock = MockServer::start().await;
+    for (from, to, expected_from, expected_to) in [
+        (
+            "2026-04-16T12:00:00Z",
+            "2026-04-16T13:00:00.000Z",
+            "2026-04-16T12:00:00.000Z",
+            "2026-04-16T13:00:00.000Z",
+        ),
+        (
+            "2026-04-16T00:00:00.1+05:30",
+            "2026-04-16T23:00:00.1230000000-02:30",
+            "2026-04-15T18:30:00.100Z",
+            "2026-04-17T01:30:00.123Z",
+        ),
+    ] {
+        Mock::given(method("GET"))
+            .and(path("/v1/organizations/org-1/postgres/pg-1/metrics"))
+            .and(query_param("from_date", expected_from))
+            .and(query_param("to_date", expected_to))
+            .and(query_param("bucket_size_seconds", "300"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {"metrics": []},
+                "status": 200
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "postgres",
+                "metrics",
+                "pg-1",
+                "--from-date",
+                from,
+                "--to-date",
+                to,
+                "--bucket-size-seconds",
+                "300",
+                "--org-id",
+                "org-1",
+            ],
+        );
+        assert_success(&output);
+    }
+}
+
+#[tokio::test]
+async fn postgres_metrics_rejects_malformed_and_submillisecond_dates_before_requests() {
+    let mock = MockServer::start().await;
+    for invalid in [
+        "yesterday",
+        "2026-04-16T12:00:00",
+        "2026-04-16T12:00:00.123456Z",
+        "2026-04-16T12:00:00.123456789Z",
+        "2026-04-16T12:00:00.0000000001Z",
+    ] {
+        for flag in ["--from-date", "--to-date"] {
+            let mut args = [
+                "postgres",
+                "metrics",
+                "pg-1",
+                "--from-date",
+                "2026-04-16T12:00:00Z",
+                "--to-date",
+                "2026-04-16T13:00:00Z",
+                "--org-id",
+                "org-1",
+            ];
+            let position = args.iter().position(|arg| *arg == flag).unwrap();
+            args[position + 1] = invalid;
+            let output = invoke_cli_with_cloud_credentials(&mock, &args);
+            assert_eq!(output.status.code(), Some(2), "{flag} {invalid}");
+        }
+    }
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn postgres_metrics_omits_bucket_and_renders_sparse_human_output() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/metrics"))
-        .and(query_param("from_date", "2026-04-16T12:00:00Z"))
-        .and(query_param("to_date", "2026-04-16T13:00:00Z"))
+        .and(query_param("from_date", "2026-04-16T12:00:00.000Z"))
+        .and(query_param("to_date", "2026-04-16T13:00:00.000Z"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "result": {
                 "metrics": [{


### PR DESCRIPTION
Fixes #761.

Postgres metrics now converts RFC 3339 timestamps to UTC with exactly three fractional digits before sending the request. For example, `2026-04-16T13:00:00+01:00` is sent as `2026-04-16T12:00:00.000Z`, preserving the interval while matching the live endpoint’s parser. Dates with finer nonzero precision fail locally with exit 2 instead of being truncated; extra trailing zero digits remain accepted. Help and README describe the precision limit.

Validation:
- Clap and unit coverage for whole seconds, `.000Z`, positive/negative/zero offsets, date rollover, fractional seconds, and malformed or submillisecond input, including digits beyond chrono’s nanosecond precision.
- Real CLI + wiremock coverage for exact normalized query values, unchanged bucket size, and invalid inputs sending no request.
- Live read-only precision probe on an existing running Postgres service: `.000Z` and `.123Z` returned metrics; whole-second `Z`, `.1Z`, and each tested precision from four through ten fractional digits were rejected by the endpoint. No Cloud resources were created or modified.
- Patched CLI live verification: whole-second `Z`, `+01:00`, `.000Z`, and `.123Z` each returned exit 0 with 11 metric objects for the requested one-hour interval and 300-second buckets.
- `cargo fmt --all`; `cargo clippy -p clickhousectl -- -D warnings`; `cargo test -p clickhousectl postgres_metrics` (5 unit + 5 wiremock tests) passed.
