### PR TITLE
fix(api): reconcile Prometheus and Kinesis OpenAPI drift

### DIFF
--- a/crates/clickhouse-cloud-api/README.md
+++ b/crates/clickhouse-cloud-api/README.md
@@ -16,6 +16,8 @@ The current alert request schemas have no `required` array or optional marker on
 
 Postgres slow-query aggregate durations (`*DurationUs`) and execution `durationUs` use `Option<f64>` to preserve fractional microseconds returned by the API. Counts remain integral. The analyzer tracks the upstream integer-schema discrepancy with response-only, stale-checked exceptions ([#758](https://github.com/ClickHouse/clickhousectl/issues/758)).
 
+Kinesis source format enums now include `Protobuf`. Set `ClickPipePostKinesisSource.protobuf_schema` to the base64-encoded `.proto` source or serialized `FileDescriptorSet` for that format; omit it for other formats. Organization Prometheus discovery has graduated from beta and is no longer listed in `BETA_OPERATIONS`.
+
 ## Development
 
 ### Structure

--- a/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
+++ b/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
@@ -5,7 +5,7 @@
     "version": "1.0",
     "contact": {
       "name": "ClickHouse Support",
-      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1107336",
+      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1107552",
       "email": "support@clickhouse.com"
     }
   },
@@ -459,7 +459,7 @@
     "/v1/organizations/{organizationId}/prometheus/discovery": {
       "get": {
         "summary": "List Prometheus scrape targets",
-        "description": "**This endpoint is in beta.** API contract is stable, and no breaking changes are expected in the future. <br /><br /> Returns one Prometheus scrape target per service in the organization, in the [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) (`http_sd`) format. Only services the API key is authorized to view are included; services that are being deleted or have been deleted are omitted.\n\nPoint an [`http_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) job at this endpoint to discover and scrape all services in the organization automatically. Prometheus refreshes the target list on every discovery poll, so newly created and deleted services are picked up without configuration changes.\n\nDiscovered targets scrape with `filtered_metrics=true` by default; pass `?filtered_metrics=false` to this endpoint to discover unfiltered targets. See the [Prometheus integration guide](https://clickhouse.com/docs/integrations/prometheus) for more on the exported metrics.",
+        "description": "Returns one Prometheus scrape target per service in the organization, in the [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) (`http_sd`) format. Only services the API key is authorized to view are included; services that are being deleted or have been deleted are omitted.\n\nPoint an [`http_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) job at this endpoint to discover and scrape all services in the organization automatically. Prometheus refreshes the target list on every discovery poll, so newly created and deleted services are picked up without configuration changes.\n\nDiscovered targets scrape with `filtered_metrics=true` by default; pass `?filtered_metrics=false` to this endpoint to discover unfiltered targets. See the [Prometheus integration guide](https://clickhouse.com/docs/integrations/prometheus) for more on the exported metrics.",
         "operationId": "organizationPrometheusDiscoveryGet",
         "parameters": [
           {
@@ -552,12 +552,6 @@
         },
         "tags": [
           "Prometheus"
-        ],
-        "x-badges": [
-          {
-            "name": "Beta",
-            "position": "after"
-          }
         ]
       }
     },
@@ -21355,7 +21349,8 @@
             "enum": [
               "JSONEachRow",
               "Avro",
-              "AvroConfluent"
+              "AvroConfluent",
+              "Protobuf"
             ]
           },
           "streamName": {
@@ -21418,7 +21413,8 @@
             "enum": [
               "JSONEachRow",
               "Avro",
-              "AvroConfluent"
+              "AvroConfluent",
+              "Protobuf"
             ]
           },
           "streamName": {
@@ -21480,6 +21476,14 @@
                 "type": "null"
               }
             ]
+          },
+          "protobufSchema": {
+            "description": "Base64-encoded .proto source or serialized FileDescriptorSet. Required with Protobuf format and not supported with other formats.",
+            "type": "string",
+            "example": "c3ludGF4ID0gInByb3RvMyI7IG1lc3NhZ2UgRXZlbnQge30=",
+            "maxLength": 1048576,
+            "minLength": 1,
+            "writeOnly": true
           }
         }
       },

--- a/crates/clickhouse-cloud-api/src/meta.rs
+++ b/crates/clickhouse-cloud-api/src/meta.rs
@@ -57,7 +57,6 @@ pub const BETA_OPERATIONS: &[&str] = &[
     "click_stack_update_webhook",
     "click_stack_validate_dashboard",
     "credit_balances_get",
-    "organization_prometheus_discovery_get",
     "organization_quota_get",
     "organization_quotas_get_list",
     "postgres_instance_config_get",
@@ -202,6 +201,7 @@ mod tests {
         assert!(is_beta_operation("scaling_schedule_get"));
         assert!(is_beta_operation("postgres_service_get_list"));
         assert!(!is_beta_operation("services_list"));
+        assert!(!is_beta_operation("organization_prometheus_discovery_get"));
         assert!(!is_beta_operation("not_a_real_op"));
     }
 

--- a/crates/clickhouse-cloud-api/src/models/clickpipes.rs
+++ b/crates/clickhouse-cloud-api/src/models/clickpipes.rs
@@ -303,6 +303,7 @@ pub enum ClickPipeKinesisSourceFormat {
     JSONEachRow,
     Avro,
     AvroConfluent,
+    Protobuf,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -314,6 +315,7 @@ impl std::fmt::Display for ClickPipeKinesisSourceFormat {
             Self::JSONEachRow => write!(f, "JSONEachRow"),
             Self::Avro => write!(f, "Avro"),
             Self::AvroConfluent => write!(f, "AvroConfluent"),
+            Self::Protobuf => write!(f, "Protobuf"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -1291,6 +1293,7 @@ pub enum ClickPipePostKinesisSourceFormat {
     JSONEachRow,
     Avro,
     AvroConfluent,
+    Protobuf,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -1302,6 +1305,7 @@ impl std::fmt::Display for ClickPipePostKinesisSourceFormat {
             Self::JSONEachRow => write!(f, "JSONEachRow"),
             Self::Avro => write!(f, "Avro"),
             Self::AvroConfluent => write!(f, "AvroConfluent"),
+            Self::Protobuf => write!(f, "Protobuf"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -3125,6 +3129,9 @@ pub struct ClickPipePostKinesisSource {
     pub timestamp: Option<i64>,
     #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none")]
     pub use_enhanced_fan_out: Option<bool>,
+    /// Base64-encoded .proto or FileDescriptorSet; required only for Protobuf.
+    #[serde(rename = "protobufSchema", skip_serializing_if = "Option::is_none")]
+    pub protobuf_schema: Option<String>,
 }
 
 /// `ClickPipeSchemaDiscoveryField` from the ClickHouse Cloud API.

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -6790,3 +6790,39 @@ fn service_clickhouse_setting_missing_and_null_values_remain_absent() {
         );
     }
 }
+
+#[test]
+fn kinesis_protobuf_schema_round_trips_and_other_formats_omit_it() {
+    let json_source = ClickPipePostKinesisSource::default();
+    let wire = serde_json::to_value(&json_source).unwrap();
+    assert!(wire.get("protobufSchema").is_none());
+    assert_eq!(
+        serde_json::from_value::<ClickPipePostKinesisSource>(wire).unwrap(),
+        json_source
+    );
+
+    let protobuf = ClickPipePostKinesisSource {
+        format: ClickPipePostKinesisSourceFormat::Protobuf,
+        protobuf_schema: Some("c3ludGF4".into()),
+        ..Default::default()
+    };
+    let wire = serde_json::to_value(&protobuf).unwrap();
+    assert_eq!(wire["format"], "Protobuf");
+    assert_eq!(wire["protobufSchema"], "c3ludGF4");
+    assert_eq!(
+        serde_json::from_value::<ClickPipePostKinesisSource>(wire).unwrap(),
+        protobuf
+    );
+    assert_eq!(protobuf.format.to_string(), "Protobuf");
+
+    let response: ClickPipeKinesisSource =
+        serde_json::from_value(serde_json::json!({"format": "Protobuf"})).unwrap();
+    assert_eq!(
+        response.format,
+        Some(ClickPipeKinesisSourceFormat::Protobuf)
+    );
+    assert_eq!(response.format.unwrap().to_string(), "Protobuf");
+    assert!(
+        matches!(serde_json::from_str::<ClickPipeKinesisSourceFormat>("\"FutureFormat\"").unwrap(), ClickPipeKinesisSourceFormat::Unknown(value) if value == "FutureFormat")
+    );
+}

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -72,6 +72,9 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // The spec allows protobufSchema only for Protobuf without schemaRegistry;
     // requiring it would reject JSON/Avro and schema-registry Kafka requests.
     ("ClickPipePostKafkaSource", "protobufSchema"),
+    // Kinesis likewise requires protobufSchema only for Protobuf and forbids it
+    // for other formats; the legacy requiredness heuristic misses that condition.
+    ("ClickPipePostKinesisSource", "protobufSchema"),
     // The legacy service-create schema marks almost every property required,
     // but the API requires only name/provider/region and rejects many defaults.
     ("ServicePostRequest", "autoscalingMode"),

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -2761,6 +2761,7 @@ fn build_kinesis_source(
     };
 
     Ok(ClickPipePostKinesisSource {
+        protobuf_schema: None,
         format: parse_enum(&args.format)?,
         stream_name: args.stream_name.clone(),
         region: args.region.clone(),


### PR DESCRIPTION
The live OpenAPI spec now treats organization Prometheus discovery as stable and adds Kinesis Protobuf formats plus a create-time `protobufSchema` field. Refresh the snapshot from the unmodified public document, regenerate beta metadata, and add the missing typed Kinesis request/response formats and optional schema field.

The schema field is required only for Protobuf and forbidden for other formats in the upstream description. A narrow optionality exemption preserves that conditional contract, matching the existing Kafka policy. The CLI request literal initializes the new field to `None` so this prerequisite builds independently; CLI Kinesis formats remain unchanged. Library documentation and focused metadata/serde coverage accompany the change.

Validation: live drift dry run and same-document analyzer report zero actionable findings; the five existing unsupported enum acknowledgements are unchanged. Library/analyzer tests and all-target Clippy passed, as did all 91 Python tests. CLI default Clippy, no-default-feature check/Clippy, and focused Kinesis tests are also checked. The snapshot is byte-identical to the freshly fetched public response.

Fixes #766.
