### PR TITLE
docs(cli): remove graduated Prometheus beta labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ Each `cloud org update --remove-private-endpoint` value must include both
 `cloud-provider` and `region`; incomplete endpoint identities are rejected before
 any request is sent.
 
-`cloud org prometheus discovery` returns the beta HTTP service-discovery target groups used by Prometheus `http_sd_configs`; `--json` preserves the complete target and label array. The command defaults discovered scrape targets to filtered metrics. The command without `discovery` still calls the deprecated organization metrics endpoint and emits raw Prometheus exposition text for compatibility.
+`cloud org prometheus discovery` returns the HTTP service-discovery target groups used by Prometheus `http_sd_configs`; `--json` preserves the complete target and label array. The command defaults discovered scrape targets to filtered metrics. The command without `discovery` still calls the deprecated organization metrics endpoint and emits raw Prometheus exposition text for compatibility.
 
 ### Services
 

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -295,7 +295,7 @@ impl ByocCommands {
 
 #[derive(Subcommand)]
 pub enum PrometheusCommands {
-    /// List Prometheus scrape targets (Beta)
+    /// List Prometheus scrape targets
     Discovery,
 }
 


### PR DESCRIPTION
Organization Prometheus discovery has graduated from beta in the public API. Remove the obsolete Beta label from `cloud org prometheus discovery` help and its README description, matching the regenerated API metadata in the prerequisite.

Validation: focused Prometheus command parsing tests pass. Formatting and both CLI Clippy configurations are checked with the API prerequisite. No help wording is pinned in tests.

Depends on the #766 API drift prerequisite (`fix/050-766-prometheus-beta`). Related to #766.
