### PR TITLE
test(cli): enforce structural help conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2783,6 +2783,12 @@ All three list commands expose `--cursor` and `--limit` (1–100) and retain pag
 
 The UDF API request models preserve `deterministic` and nullable `memoryLimitMib` in both executable variants, including version creation. The OpenAPI analyzer checks inline union payload fields and request requiredness; its report format is version 5.
 
+## CLI help checks
+
+`cargo test -p clickhousectl --bin clickhousectl cli::tests::` checks clap's full command tree,
+command and argument descriptions, help structure, agent context limits, and shared flag consistency.
+Run it with `--no-default-features` as well to check the tree without telemetry.
+
 ## Cloud integration testing
 
 Maintainer operation, exact-SHA overrides, stacked-PR policy, and the required

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -127,6 +127,136 @@ pub struct UpdateArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
+    use std::collections::BTreeMap;
+
+    fn visit_commands(
+        command: &clap::Command,
+        path: &str,
+        visit: &mut impl FnMut(&clap::Command, &str),
+    ) {
+        visit(command, path);
+        for child in command.get_subcommands() {
+            visit_commands(child, &format!("{path} {}", child.get_name()), visit);
+        }
+    }
+
+    #[test]
+    fn whole_command_tree_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn whole_command_tree_has_descriptions() {
+        let mut failures = Vec::new();
+        visit_commands(&Cli::command(), "clickhousectl", &mut |command, path| {
+            if command
+                .get_about()
+                .is_none_or(|about| about.to_string().trim().is_empty())
+            {
+                failures.push(format!("{path}: missing command description"));
+            }
+            for arg in command.get_arguments() {
+                if arg
+                    .get_help()
+                    .is_none_or(|help| help.to_string().trim().is_empty())
+                {
+                    failures.push(format!("{path}: missing description for {}", arg.get_id()));
+                }
+            }
+        });
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    #[test]
+    fn whole_command_tree_follows_help_structure() {
+        let mut failures = Vec::new();
+        visit_commands(&Cli::command(), "clickhousectl", &mut |command, path| {
+            if command
+                .get_about()
+                .is_some_and(|about| about.to_string().lines().count() != 1)
+            {
+                failures.push(format!("{path}: about must be one line"));
+            }
+            if command.get_long_about().is_some() {
+                failures.push(format!("{path}: long_about is not allowed"));
+            }
+            if command.get_before_help().is_some() || command.get_before_long_help().is_some() {
+                failures.push(format!("{path}: before_help is not allowed"));
+            }
+            if command.get_after_long_help().is_some() {
+                failures.push(format!("{path}: use after_help for agent context"));
+            }
+            if command
+                .get_subcommand_help_heading()
+                .is_some_and(|heading| heading != "Commands")
+            {
+                failures.push(format!("{path}: use the standard Commands heading"));
+            }
+            for arg in command.get_arguments() {
+                if arg
+                    .get_help_heading()
+                    .is_some_and(|heading| !["Arguments", "Options"].contains(&heading))
+                {
+                    failures.push(format!(
+                        "{path}: {} has a custom help heading",
+                        arg.get_id()
+                    ));
+                }
+            }
+            if let Some(after_help) = command.get_after_help() {
+                let text = after_help.to_string();
+                let mut lines = text.lines().filter(|line| !line.trim().is_empty());
+                if lines.next() != Some("CONTEXT FOR AGENTS:") {
+                    failures.push(format!(
+                        "{path}: after_help must start with CONTEXT FOR AGENTS:"
+                    ));
+                }
+                let content: Vec<_> = lines.collect();
+                if content.is_empty() || content.len() > 8 {
+                    failures.push(format!(
+                        "{path}: agent context has {} content lines (expected 1–8)",
+                        content.len()
+                    ));
+                }
+                for line in content {
+                    if line.chars().count() > 120 {
+                        failures.push(format!(
+                            "{path}: context line exceeds 120 characters: {line}"
+                        ));
+                    }
+                }
+            }
+        });
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    #[test]
+    fn shared_flags_have_identical_help_at_every_declaration() {
+        let shared = ["api-key", "api-secret", "url", "org-id", "json", "debug"];
+        let mut declarations = BTreeMap::new();
+        let mut failures = Vec::new();
+        // Inspect declarations before build() propagates global flags to descendants.
+        visit_commands(&Cli::command(), "clickhousectl", &mut |command, path| {
+            for arg in command.get_arguments() {
+                let Some(flag) = arg.get_long().filter(|flag| shared.contains(flag)) else {
+                    continue;
+                };
+                let help = (
+                    arg.get_help().map(ToString::to_string),
+                    arg.get_long_help().map(ToString::to_string),
+                );
+                if let Some((previous_path, previous_help)) = declarations.get(flag) {
+                    if previous_help != &help {
+                        failures.push(format!("--{flag}: {path} differs from {previous_path}: {help:?} != {previous_help:?}"));
+                    }
+                } else {
+                    declarations.insert(flag.to_owned(), (path.to_owned(), help));
+                }
+            }
+        });
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
 
     #[test]
     fn unknown_command_exits_with_a_usage_error() {

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -220,6 +220,11 @@ mod tests {
                     ));
                 }
                 for line in content {
+                    if !line.starts_with("  ") {
+                        failures.push(format!(
+                            "{path}: context content must be indented by at least two spaces"
+                        ));
+                    }
                     if line.chars().count() > 120 {
                         failures.push(format!(
                             "{path}: context line exceeds 120 characters: {line}"

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -26,11 +26,11 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         interactive: bool,
 
-        /// API key to save (requires --api-secret)
+        /// Cloud API key (requires --api-secret for auth login)
         #[arg(long)]
         api_key: Option<String>,
 
-        /// API secret to save (requires --api-key)
+        /// Cloud API secret (requires --api-key for auth login)
         #[arg(long)]
         api_secret: Option<String>,
     },

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -25,11 +25,11 @@ use clap::{Args, Subcommand};
 
 #[derive(Args)]
 pub struct CloudArgs {
-    /// Cloud API key; overrides stored and environment credentials
+    /// Cloud API key (requires --api-secret for auth login)
     #[arg(long, global = true)]
     pub api_key: Option<String>,
 
-    /// Cloud API secret; overrides stored and environment credentials
+    /// Cloud API secret (requires --api-key for auth login)
     #[arg(long, global = true)]
     pub api_secret: Option<String>,
 
@@ -522,24 +522,5 @@ mod tests {
             ],
             true,
         );
-    }
-
-    #[test]
-    fn every_cloud_subcommand_has_a_help_about() {
-        use clap::CommandFactory;
-
-        let mut command = Cli::command();
-        let cloud = command
-            .find_subcommand_mut("cloud")
-            .expect("cloud subcommand");
-
-        for sub in cloud.get_subcommands() {
-            let about = sub.get_about().map(|a| a.to_string()).unwrap_or_default();
-            assert!(
-                !about.trim().is_empty(),
-                "cloud subcommand `{}` has no about text",
-                sub.get_name()
-            );
-        }
     }
 }

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -590,11 +590,12 @@ pub enum QueryEndpointCommands {
     },
 
     /// Create or update the Query API endpoint
-    #[command(after_help = "CONTEXT FOR AGENTS:\n\
-        Existing API keys are preserved unless --replace-open-api-keys is set.\n\
-        Roles replace the endpoint-wide role list for every authorized key.\n\
-        First creation requires --allowed-origins; use '*' explicitly for all.\n\
-        Avoid concurrent changes to the same endpoint.")]
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Existing API keys are preserved unless --replace-open-api-keys is set.
+  Roles replace the endpoint-wide role list for every authorized key.
+  First creation requires --allowed-origins; use '*' explicitly for all.
+  Avoid concurrent changes to the same endpoint.")]
     Create {
         /// Service ID
         service_id: String,
@@ -719,9 +720,10 @@ pub enum ServiceSettingsCommands {
     /// Set one or more ClickHouse settings
     #[command(
         group(ArgGroup::new("settings_input").required(true).args(["setting", "settings_file"])),
-        after_help = "CONTEXT FOR AGENTS:\n\
-  Discover supported names and types with `settings schema <service-id>`.\n\
-  --setting values are JSON literals; quote string values inside the argument.\n\
+        after_help = "\
+CONTEXT FOR AGENTS:
+  Discover supported names and types with `settings schema <service-id>`.
+  --setting values are JSON literals; quote string values inside the argument.
   --settings-file reads a JSON settings map; `-` reads stdin. Only named settings change."
     )]
     Set {


### PR DESCRIPTION
Whole-tree clap tests enforce descriptions, context limits and consistent shared-flag help.

Settings-set and query-endpoint-create agent context now retains indentation. The whole-tree structural check rejects unindented context content without pinning help wording.

Whole-tree tests validate clap structure, shared flags and the agent-context line budget and indentation, without pinning wording.

Refs #848 (CONTEXT indentation only).

Closes #689.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
