### PR TITLE
docs(clickpipes): explain verified field-mapping update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,6 +1417,46 @@ The `kafka_read_committed` setting applies only to Kafka pipes.
 }
 ```
 
+For object-storage pipes, sending root `fieldMappings` also requires
+`destination.columns` in the same patch. Send the complete column and mapping
+arrays: every destination column must have a mapping. This changes the ClickPipe
+configuration, not the destination table schema.
+
+For example, replace mappings on an existing object-storage pipe whose destination
+has `station String` and `avg Float64` columns. Inspect your pipe with
+`clickhousectl cloud clickpipe get "$SERVICE_ID" "$PIPE_ID" --json` first and use
+its complete destination column list; only `columns` belongs in the destination
+patch, so leave out `database`, `table`, `managedTable`, and `tableDefinition`.
+
+```bash
+clickhousectl cloud clickpipe update "$SERVICE_ID" "$PIPE_ID" --config-file - <<'JSON'
+{
+  "destination": {
+    "columns": [
+      { "name": "station", "type": "String" },
+      { "name": "avg", "type": "Float64" }
+    ]
+  },
+  "fieldMappings": [
+    { "sourceField": "station", "destinationField": "station" },
+    { "sourceField": "avg", "destinationField": "avg" }
+  ]
+}
+JSON
+
+# Rename while preserving the existing mappings, source, destination and settings.
+printf '%s\n' '{"name":"stations-v2"}' |
+  clickhousectl cloud clickpipe update "$SERVICE_ID" "$PIPE_ID" --config-file -
+```
+
+Omitting `fieldMappings` preserves saved mappings, including when resending
+`destination.columns`. An explicit `"fieldMappings": []` is different: live
+object-storage verification rejected it without columns (columns required) and
+with columns (every column requires a mapping); the saved mappings remained
+unchanged. No clearing workflow that retains the configured columns was verified.
+These observations concern root object-storage field mappings, not CDC
+`tableMappingsToAdd` or `tableMappingsToRemove` arrays.
+
 A source patch selects at most one of the seven supported arms.
 `validateSamples` is optional. Kafka credentials must match the selected
 authentication: username and password for PLAIN/SCRAM, access key and secret

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -267,6 +267,7 @@ CONTEXT FOR AGENTS:
   The file is a typed PATCH body; omitted top-level fields remain unchanged.
   Source updates support kafka, kinesis, objectStorage, pubsub, postgres, mysql,
   and mongodb. BigQuery sources cannot be updated by this API.
+  For object-storage, fieldMappings (including []) requires destination.columns.
   Use `-` to read the JSON body from stdin.")]
     Update {
         /// Service ID


### PR DESCRIPTION
Document the verified object-storage field-mapping update requirement in README and input help.

Update help states that object-storage `fieldMappings`, including an explicit empty array, requires `destination.columns`. This documents the verified source-specific requirement.

The existing README and live object-storage verification remain the basis for this narrowly scoped help requirement. No universal PATCH validation is introduced.

Refs #845 (object-storage help only; broader enforcement and CDC guidance remain open).

Fixes #763.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
