### PR TITLE
fix(cloud): preserve explicit empty values in human output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ For `postgres config patch --file`, put that map under `pgBouncerConfig` alongsi
 
 PgBouncer parameter names are open-ended; values must be quoted strings, including numbers. Invalid value types fail locally before any API request. `config replace` replaces the complete Postgres and PgBouncer configuration: obtain the current document with `config get --json`, edit it, and retain both sections and every setting you want to keep.
 
-Human detail output shows explicit empty configuration sections as `pgConfig: {}` and `pgBouncerConfig: {}`. JSON retains the original objects.
+Human detail output preserves explicit empty values: configuration sections show as `pgConfig: {}` and `pgBouncerConfig: {}`, empty lists as `[]`, and empty strings as `""`. JSON retains the original values.
 
 `pgConfig` uses the closed set of GUC names supported by the Cloud API. Unknown names and `null` values are rejected locally on `--set` and every PgConfig file path, and the enum-valued settings accept only `default_transaction_isolation` (`read committed`, `repeatable read`, `serializable`), `ssl_min_protocol_version` (`TLSv1` through `TLSv1.3`), and `wal_compression` (`off`, `on`, `lz4`, `zstd`). Files for `config patch` and `config replace` must contain both `pgConfig` and `pgBouncerConfig`; use an explicit `{}` when a section is intentionally empty rather than omitting it.
 

--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,8 @@ For `postgres config patch --file`, put that map under `pgBouncerConfig` alongsi
 
 PgBouncer parameter names are open-ended; values must be quoted strings, including numbers. Invalid value types fail locally before any API request. `config replace` replaces the complete Postgres and PgBouncer configuration: obtain the current document with `config get --json`, edit it, and retain both sections and every setting you want to keep.
 
+Human detail output shows explicit empty configuration sections as `pgConfig: {}` and `pgBouncerConfig: {}`. JSON retains the original objects.
+
 `pgConfig` uses the closed set of GUC names supported by the Cloud API. Unknown names and `null` values are rejected locally on `--set` and every PgConfig file path, and the enum-valued settings accept only `default_transaction_isolation` (`read committed`, `repeatable read`, `serializable`), `ssl_min_protocol_version` (`TLSv1` through `TLSv1.3`), and `wal_compression` (`off`, `on`, `lz4`, `zstd`). Files for `config patch` and `config replace` must contain both `pgConfig` and `pgBouncerConfig`; use an explicit `{}` when a section is intentionally empty rather than omitting it.
 
 Use `clickhousectl cloud postgres create --help` for the complete option list. Save any initial password and connection string in the create response because later `postgres get` responses do not return credentials. If both are omitted, run `clickhousectl cloud postgres reset-password <postgres-id> --generate`.

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -175,7 +175,8 @@ pub fn print_error(detail: &CloudErrorDetail) {
 /// - String values are unquoted.
 /// - Arrays of scalars render inline (`key: [a, b, c]`); arrays of objects
 ///   render as `-` bullet blocks.
-/// - Empty objects render as `{}`; nulls and empty strings/arrays are omitted.
+/// - Present empty objects, strings, and arrays remain visible as `{}`, `""`,
+///   and `[]`; nulls are omitted.
 pub fn print_human<T: Serialize>(value: &T) -> Result<(), serde_json::Error> {
     let value = serde_json::to_value(value)?;
     let mut lines = Vec::new();
@@ -191,13 +192,7 @@ fn pad(indent: usize) -> String {
 }
 
 fn is_empty(value: &Value) -> bool {
-    match value {
-        Value::Null => true,
-        Value::String(s) => s.is_empty(),
-        Value::Array(a) => a.is_empty(),
-        Value::Object(_) => false,
-        _ => false,
-    }
+    matches!(value, Value::Null)
 }
 
 fn is_scalar(value: &Value) -> bool {
@@ -209,6 +204,7 @@ fn scalar_string(value: &Value) -> Option<String> {
         // The single place a string scalar becomes human text, so summarizing
         // PEM here covers object fields, nested objects and arrays of strings
         // alike.
+        Value::String(s) if s.is_empty() => Some("\"\"".to_string()),
         Value::String(s) => Some(pem_summary(s).unwrap_or_else(|| s.clone())),
         Value::Number(n) => Some(n.to_string()),
         Value::Bool(b) => Some(b.to_string()),
@@ -408,6 +404,7 @@ fn pem_summary(value: &str) -> Option<String> {
 fn render(lines: &mut Vec<String>, indent: usize, value: &Value) {
     match value {
         Value::Object(map) if map.is_empty() => lines.push(format!("{}{{}}", pad(indent))),
+        Value::Array(items) if items.is_empty() => lines.push(format!("{}[]", pad(indent))),
         Value::Object(map) => render_object(lines, indent, map),
         Value::Array(items) => render_array(lines, indent, items),
         scalar => {
@@ -511,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn omits_null_and_empty_values() {
+    fn omits_null_but_renders_present_empty_values() {
         let v = json!({
             "name": "svc",
             "note": null,
@@ -521,16 +518,19 @@ mod tests {
             "count": 0,
             "flag": false
         });
-        // Missing scalar values are dropped; explicit objects, 0 and false stay.
+        // Missing fields serialize as absent; null is omitted while explicit
+        // empty values, 0 and false remain distinguishable.
         assert_eq!(
             render_to_string(&v),
-            "name: svc\nmeta: {}\ncount: 0\nflag: false"
+            "name: svc\nempty: \"\"\ntags: []\nmeta: {}\ncount: 0\nflag: false"
         );
     }
 
     #[test]
     fn renders_explicit_empty_objects_at_every_depth() {
         assert_eq!(render_to_string(&json!({})), "{}");
+        assert_eq!(render_to_string(&json!([])), "[]");
+        assert_eq!(render_to_string(&json!("")), "\"\"");
         assert_eq!(
             render_to_string(&json!({"pgConfig": {}, "pgBouncerConfig": {}})),
             "pgConfig: {}\npgBouncerConfig: {}"

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -175,7 +175,7 @@ pub fn print_error(detail: &CloudErrorDetail) {
 /// - String values are unquoted.
 /// - Arrays of scalars render inline (`key: [a, b, c]`); arrays of objects
 ///   render as `-` bullet blocks.
-/// - Null values and empty strings/arrays/objects are omitted.
+/// - Empty objects render as `{}`; nulls and empty strings/arrays are omitted.
 pub fn print_human<T: Serialize>(value: &T) -> Result<(), serde_json::Error> {
     let value = serde_json::to_value(value)?;
     let mut lines = Vec::new();
@@ -195,7 +195,7 @@ fn is_empty(value: &Value) -> bool {
         Value::Null => true,
         Value::String(s) => s.is_empty(),
         Value::Array(a) => a.is_empty(),
-        Value::Object(o) => o.is_empty(),
+        Value::Object(_) => false,
         _ => false,
     }
 }
@@ -407,6 +407,7 @@ fn pem_summary(value: &str) -> Option<String> {
 /// anchor a caller can retrofit a `-` bullet onto.
 fn render(lines: &mut Vec<String>, indent: usize, value: &Value) {
     match value {
+        Value::Object(map) if map.is_empty() => lines.push(format!("{}{{}}", pad(indent))),
         Value::Object(map) => render_object(lines, indent, map),
         Value::Array(items) => render_array(lines, indent, items),
         scalar => {
@@ -423,6 +424,9 @@ fn render_object(lines: &mut Vec<String>, indent: usize, map: &Map<String, Value
             continue;
         }
         match value {
+            Value::Object(inner) if inner.is_empty() => {
+                lines.push(format!("{}{}: {{}}", pad(indent), key));
+            }
             Value::Object(inner) => {
                 let start = lines.len();
                 lines.push(format!("{}{}:", pad(indent), key));
@@ -517,8 +521,22 @@ mod tests {
             "count": 0,
             "flag": false
         });
-        // null/empty-string/empty-array/empty-object are dropped; 0 and false stay.
-        assert_eq!(render_to_string(&v), "name: svc\ncount: 0\nflag: false");
+        // Missing scalar values are dropped; explicit objects, 0 and false stay.
+        assert_eq!(
+            render_to_string(&v),
+            "name: svc\nmeta: {}\ncount: 0\nflag: false"
+        );
+    }
+
+    #[test]
+    fn renders_explicit_empty_objects_at_every_depth() {
+        assert_eq!(render_to_string(&json!({})), "{}");
+        assert_eq!(
+            render_to_string(&json!({"pgConfig": {}, "pgBouncerConfig": {}})),
+            "pgConfig: {}\npgBouncerConfig: {}"
+        );
+        assert_eq!(render_to_string(&json!({"items": [{}]})), "items:\n  - {}");
+        assert_eq!(render_to_string(&json!({"absent": {"value": null}})), "");
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -15224,7 +15224,7 @@ async fn clickpipe_context_get_renders_full_and_sparse_responses() {
         &["clickpipe", "context", "get", "svc-id", "--org-id", "org"],
     );
     assert_success(&output);
-    assert!(output.stdout.is_empty());
+    assert_eq!(output.stdout, b"{}\n");
 
     let not_ready = MockServer::start().await;
     mount_clickpipe_context(
@@ -17673,6 +17673,33 @@ async fn postgres_config_get_honors_human_explicit_json_and_agent_output() {
         assert_eq!(request.url.query(), None);
         assert!(request.body.is_empty());
     }
+}
+
+#[tokio::test]
+async fn postgres_config_get_shows_empty_sections_in_human_output() {
+    let mock = MockServer::start().await;
+    let config = serde_json::json!({"pgConfig": {}, "pgBouncerConfig": {}});
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/postgres/pg-1/config"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": config
+        })))
+        .expect(2)
+        .mount(&mock)
+        .await;
+    let args = ["postgres", "config", "get", "pg-1", "--org-id", "org-1"];
+    let human = invoke_cli_with_cloud_credentials_human(&mock, &args);
+    assert_success(&human);
+    assert_eq!(
+        String::from_utf8(human.stdout).unwrap(),
+        "pgBouncerConfig: {}\npgConfig: {}\n"
+    );
+    let json = invoke_cli_with_cloud_credentials(&mock, &args);
+    assert_success(&json);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&json.stdout).unwrap(),
+        config
+    );
 }
 
 #[tokio::test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3451,6 +3451,44 @@ async fn postgres_slow_query_get_omits_optional_query_and_renders_sparse_detail(
     );
 }
 
+#[tokio::test]
+async fn postgres_slow_query_get_renders_an_explicit_empty_execution_list() {
+    let mock = MockServer::start().await;
+    let result = serde_json::json!({"recentExecutions": []});
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/slowQueryPatterns/query-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials_human(
+        &mock,
+        &[
+            "postgres",
+            "slow-queries",
+            "get",
+            "pg-1",
+            "query-1",
+            "--db-name",
+            "app",
+            "--db-user",
+            "reader",
+            "--db-operation",
+            "SELECT",
+            "--org-id",
+            "org-1",
+        ],
+    );
+    assert_success(&output);
+    assert_eq!(output.stdout, b"recentExecutions: []\n");
+}
+
 // ── Postgres Prometheus metrics (issue #584) ──────────────────────────────
 
 #[tokio::test]
@@ -17096,6 +17134,26 @@ async fn clickpipe_get_human_output_summarizes_the_ca_certificate() {
 }
 
 #[tokio::test]
+async fn clickpipe_get_human_output_shows_present_empty_fields() {
+    let mock = MockServer::start().await;
+    mount_clickpipe_get(
+        &mock,
+        serde_json::json!({"kafka": {"brokers": "", "consumerGroup": ""}}),
+    )
+    .await;
+
+    let output = invoke_cli_human(
+        &mock,
+        &["clickpipe", "get", "svc-id", "pipe-id", "--org-id", "org"],
+    );
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("brokers: \"\""), "{stdout}");
+    assert!(stdout.contains("consumerGroup: \"\""), "{stdout}");
+}
+
+#[tokio::test]
 async fn clickpipe_get_json_output_keeps_the_full_ca_certificate() {
     let mock = MockServer::start().await;
     mount_clickpipe_get(&mock, postgres_source_with_certificate()).await;
@@ -22805,6 +22863,7 @@ async fn service_settings_get_preserves_json_types_and_renders_human_values() {
         ("max_query_size", serde_json::json!(262146), "262146"),
         ("compatibility", serde_json::json!("26.2"), "26.2"),
         ("future_bool", serde_json::json!(false), "false"),
+        ("empty_value", serde_json::json!(""), "\"\""),
     ] {
         let setting = serde_json::json!({"name": name, "value": value});
         Mock::given(method("GET"))


### PR DESCRIPTION
Empty Postgres config sections remain visible as `{}` in human mode.

The shared human renderer now displays present empty objects as `{}`, arrays as `[]`, and strings as `""`. Empty slow-query execution lists, ClickPipe fields and API-supplied setting strings remain visible; missing fields and PEM summaries retain their behavior, and JSON values remain unchanged.

Renderer and real-binary tests cover empty values, sparse output, Postgres config, slow-query details, ClickPipe fields and setting JSON/human output.

Refs #850, #844 item 6, #837 empty slow-query detail, and #849 empty setting string; remaining batch scope stays open.

Closes #806.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
