### PR TITLE
fix(clickpipes): validate typed update source ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,9 @@ credentials object, and workload identity uses neither field. Authentication,
 credentials, CA certificate, and reverse private endpoints can each be omitted
 when changing an unrelated Kafka field.
 
+MySQL and Postgres source ports must be in the range 1–65535. Omitting a
+Postgres port from a partial source update preserves the configured port.
+
 ```json
 {
   "source": {

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -3422,6 +3422,7 @@ fn validate_clickpipe_patch_source(
     }
 
     if let Some(source) = &patch.postgres {
+        validate_clickpipe_patch_port(source.port, "source.postgres.port", config_source)?;
         if let Some(mappings) = &source.table_mappings_to_add {
             for mapping in mappings {
                 if let PostgresAddEngine::Unknown(value) = &mapping.table_engine {
@@ -3443,6 +3444,7 @@ fn validate_clickpipe_patch_source(
     }
 
     if let Some(source) = &patch.mysql {
+        validate_clickpipe_patch_port(source.port, "source.mysql.port", config_source)?;
         if let Some(MySqlAuth::Unknown(value)) = &source.authentication {
             return Err(CloudError::new(format!(
                 "invalid request body in config {config_source}: unknown `source.mysql.authentication` value `{value}`"
@@ -3494,6 +3496,19 @@ fn validate_clickpipe_patch_source(
         }
     }
 
+    Ok(())
+}
+
+fn validate_clickpipe_patch_port(
+    port: Option<i64>,
+    path: &str,
+    config_source: &str,
+) -> CloudResult<()> {
+    if port.is_some_and(|port| !(1..=u16::MAX.into()).contains(&port)) {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: `{path}` must be in the range 1..=65535"
+        )));
+    }
     Ok(())
 }
 
@@ -9888,6 +9903,38 @@ mod tests {
                 "omitted PATCH fields must remain absent"
             );
         }
+    }
+
+    #[test]
+    fn clickpipe_update_builder_validates_typed_database_source_ports() {
+        for provider in ["mysql", "postgres"] {
+            for port in [1, 65535] {
+                let patch = serde_json::json!({"source": {
+                    (provider): {"host": "db.example.com", "port": port}
+                }});
+                let request = build_clickpipe_update_request(patch.clone(), "test").unwrap();
+                assert_eq!(serde_json::to_value(request).unwrap(), patch);
+            }
+
+            for port in [-1, 0, 65536] {
+                let patch = serde_json::json!({"source": {
+                    (provider): {"host": "db.example.com", "port": port}
+                }});
+                let error = build_clickpipe_update_request(patch, "test").unwrap_err();
+                assert!(
+                    error.message.contains(&format!(
+                        "source.{provider}.port` must be in the range 1..=65535"
+                    )),
+                    "{error}"
+                );
+            }
+        }
+
+        let omitted = serde_json::json!({"source": {
+            "postgres": {"host": "db.example.com"}
+        }});
+        let request = build_clickpipe_update_request(omitted.clone(), "test").unwrap();
+        assert_eq!(serde_json::to_value(request).unwrap(), omitted);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -22346,6 +22346,69 @@ async fn clickpipe_update_reads_stdin_and_preserves_explicit_empty_values() {
 }
 
 #[tokio::test]
+async fn clickpipe_update_rejects_mysql_port_zero_from_file_and_stdin_before_http() {
+    let patch = serde_json::json!({"source": {
+        "mysql": {"host": "mysql.example.com", "port": 0}
+    }});
+
+    let file_mock = MockServer::start().await;
+    let file_output = invoke_clickpipe_update_file(&file_mock, &patch);
+    assert_eq!(file_output.status.code(), Some(1));
+    let file_stderr = String::from_utf8_lossy(&file_output.stderr);
+    assert!(
+        file_stderr.contains("source.mysql.port` must be in the range 1..=65535"),
+        "{file_stderr}"
+    );
+    assert!(file_mock.received_requests().await.unwrap().is_empty());
+
+    let stdin_mock = MockServer::start().await;
+    let stdin_output = invoke_cli_with_cloud_credentials_and_stdin(
+        &stdin_mock,
+        &[
+            "clickpipe",
+            "update",
+            "svc-1",
+            "pipe-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        &patch.to_string(),
+    );
+    assert_eq!(stdin_output.status.code(), Some(1));
+    let stdin_stderr = String::from_utf8_lossy(&stdin_output.stderr);
+    assert!(
+        stdin_stderr.contains("source.mysql.port` must be in the range 1..=65535"),
+        "{stdin_stderr}"
+    );
+    assert!(stdin_mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn clickpipe_update_accepts_database_port_boundaries_and_preserves_omission() {
+    for provider in ["mysql", "postgres"] {
+        for port in [1, 65535] {
+            let patch = serde_json::json!({"source": {
+                (provider): {"host": "db.example.com", "port": port}
+            }});
+            let mock = MockServer::start().await;
+            mount_clickpipe_update(&mock, patch.clone()).await;
+            let output = invoke_clickpipe_update_file(&mock, &patch);
+            assert_success(&output);
+        }
+    }
+
+    let omitted = serde_json::json!({"source": {
+        "postgres": {"host": "db.example.com"}
+    }});
+    let mock = MockServer::start().await;
+    mount_clickpipe_update(&mock, omitted.clone()).await;
+    let output = invoke_clickpipe_update_file(&mock, &omitted);
+    assert_success(&output);
+}
+
+#[tokio::test]
 async fn clickpipe_update_rejects_noop_unknown_nested_fields_and_bigquery_before_http() {
     for patch in [
         serde_json::json!({}),


### PR DESCRIPTION
Follow-up to #776 under existing issue #685. MySQL update JSON containing port 0 now fails before HTTP for files and stdin. The typed-source audit also adds the same 1–65535 check for supplied Postgres update ports. Omitted fields retain PATCH semantics.

Builder and real-binary WireMock tests cover invalid inputs, valid boundaries, no-request rejection and exact request omission.

Validation: focused regressions plus the required formatting, default Clippy/tests, telemetry-disabled check/all-target Clippy, and Python classifier tests on the combined QA stack tip.

Refs #685 and #776.

Stack: appended to existing GitHub PR stack #769; leave merging and releasing to Al.
