### PR TITLE
fix(clickpipes): clarify PATCH input diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1460,7 +1460,8 @@ These observations concern root object-storage field mappings, not CDC
 `tableMappingsToAdd` or `tableMappingsToRemove` arrays.
 
 A source patch selects at most one of the seven supported arms.
-`validateSamples` is optional. Kafka credentials must match the selected
+BigQuery sources cannot be updated by this API. `validateSamples` is optional.
+Kafka credentials must match the selected
 authentication: username and password for PLAIN/SCRAM, access key and secret
 for IAM user, or certificate and private key for mutual TLS. Event Hubs
 connection-string credentials use PLAIN. IAM role uses `iamRole` without a

--- a/README.md
+++ b/README.md
@@ -1461,6 +1461,8 @@ These observations concern root object-storage field mappings, not CDC
 
 A source patch selects at most one of the seven supported arms.
 BigQuery sources cannot be updated by this API. `validateSamples` is optional.
+Unknown PATCH fields are rejected before a request is sent; diagnostics use the
+JSON field path and identify `--config-file -` as stdin.
 Kafka credentials must match the selected
 authentication: username and password for PLAIN/SCRAM, access key and secret
 for IAM user, or certificate and private key for mutual TLS. Event Hubs

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -3237,6 +3237,12 @@ fn validate_clickpipe_patch_required_fields(
         return Ok(());
     };
 
+    if source.contains_key("bigquery") {
+        return Err(CloudError::new(format!(
+            "invalid request body in config {config_source}: `source.bigquery` cannot be updated by the ClickPipes API"
+        )));
+    }
+
     if let Some(mysql) = source.get("mysql") {
         require_patch_object_fields(mysql, "source.mysql", &["host", "port"], config_source)?;
         if let Some(mappings) = mysql
@@ -9935,6 +9941,28 @@ mod tests {
         }});
         let request = build_clickpipe_update_request(omitted.clone(), "test").unwrap();
         assert_eq!(serde_json::to_value(request).unwrap(), omitted);
+    }
+
+    #[test]
+    fn clickpipe_update_builder_reports_bigquery_as_an_unsupported_source() {
+        let error = build_clickpipe_update_request(
+            serde_json::json!({"source": {
+                "bigquery": {},
+                "validateSamples": false
+            }}),
+            "test",
+        )
+        .unwrap_err();
+        assert!(error.message.contains("`source.bigquery`"), "{error}");
+        assert!(error.message.contains("cannot be updated"), "{error}");
+        assert!(!error.message.contains(".?."), "{error}");
+
+        let unknown = build_clickpipe_update_request(
+            serde_json::json!({"source": {"kafka": {"unknownOption": true}}}),
+            "test",
+        )
+        .unwrap_err();
+        assert!(unknown.message.contains("unknownOption"), "{unknown}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1,5 +1,7 @@
 use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
-use crate::cloud::config::{deserialize_strict_config, read_config_value, read_typed_config};
+use crate::cloud::config::{
+    config_source_label, deserialize_strict_config, read_config_value, read_typed_config,
+};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, resolve_org_id};
 use clap::builder::{PossibleValue, PossibleValuesParser, TypedValueParser};
@@ -3551,7 +3553,8 @@ async fn clickpipe_update(
     org_id: Option<&str>,
     json: bool,
 ) -> CloudResult<()> {
-    let request = build_clickpipe_update_request(read_config_value(config_file)?, config_file)?;
+    let config_source = config_source_label(config_file);
+    let request = build_clickpipe_update_request(read_config_value(config_file)?, config_source)?;
     let org_id = resolve_org_id(client, org_id).await?;
     let clickpipe = client
         .update_clickpipe(&org_id, service_id, clickpipe_id, &request)

--- a/crates/clickhousectl/src/cloud/config.rs
+++ b/crates/clickhousectl/src/cloud/config.rs
@@ -3,6 +3,15 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::io::Read as _;
 
+/// User-facing label for a file-or-stdin configuration source.
+pub(crate) fn config_source_label(config_file: &str) -> &str {
+    if config_file == "-" {
+        "stdin"
+    } else {
+        config_file
+    }
+}
+
 /// Read a JSON request body from a file or stdin.
 pub(crate) fn read_config_value(config_file: &str) -> CloudResult<Value> {
     let contents = if config_file == "-" {
@@ -21,9 +30,35 @@ pub(crate) fn read_config_value(config_file: &str) -> CloudResult<Value> {
 
     serde_json::from_str(&contents).map_err(|error| {
         CloudError::new(format!(
-            "failed to parse config {config_file} as JSON: {error}"
+            "failed to parse config {} as JSON: {error}",
+            config_source_label(config_file)
         ))
     })
+}
+
+fn display_ignored_path(path: &serde_ignored::Path<'_>) -> String {
+    fn collect(path: &serde_ignored::Path<'_>, parts: &mut Vec<String>) {
+        match path {
+            serde_ignored::Path::Root => {}
+            serde_ignored::Path::Seq { parent, index } => {
+                collect(parent, parts);
+                parts.push(index.to_string());
+            }
+            serde_ignored::Path::Map { parent, key } => {
+                collect(parent, parts);
+                parts.push(key.clone());
+            }
+            // These variants are Rust deserializer traversal details, not
+            // components of the JSON field path.
+            serde_ignored::Path::Some { parent }
+            | serde_ignored::Path::NewtypeStruct { parent }
+            | serde_ignored::Path::NewtypeVariant { parent } => collect(parent, parts),
+        }
+    }
+
+    let mut parts = Vec::new();
+    collect(path, &mut parts);
+    parts.join(".")
 }
 
 /// Strictly deserialize a raw request body into a library request type.
@@ -39,7 +74,7 @@ where
     let mut deserializer = serde_json::Deserializer::from_slice(&encoded);
     let mut ignored = Vec::new();
     let request = serde_ignored::deserialize(&mut deserializer, |path| {
-        ignored.push(path.to_string());
+        ignored.push(display_ignored_path(&path));
     })
     .map_err(|error| {
         CloudError::new(format!("invalid request body in config {source}: {error}"))
@@ -83,6 +118,9 @@ mod tests {
         nested: Option<Nested>,
     }
 
+    #[derive(Debug, Deserialize)]
+    struct Empty {}
+
     #[test]
     fn strict_config_rejects_ignored_nested_fields_including_null() {
         let parsed: Example = deserialize_strict_config(
@@ -103,6 +141,27 @@ mod tests {
             "test",
         )
         .unwrap_err();
-        assert!(error.message.contains("enabeld"), "{error}");
+        assert!(
+            error.message.contains("unknown field `nested.enabeld`"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn ignored_paths_preserve_map_keys_while_hiding_traversal_markers() {
+        for key in ["?", "", "dotted.key"] {
+            let error = deserialize_strict_config::<Empty>(serde_json::json!({key: true}), "test")
+                .unwrap_err();
+            assert!(
+                error.message.contains(&format!("unknown field `{key}`")),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn stdin_has_a_clear_config_source_label() {
+        assert_eq!(config_source_label("-"), "stdin");
+        assert_eq!(config_source_label("patch.json"), "patch.json");
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -22346,6 +22346,50 @@ async fn clickpipe_update_reads_stdin_and_preserves_explicit_empty_values() {
 }
 
 #[tokio::test]
+async fn clickpipe_update_reports_clean_unknown_paths_and_names_stdin() {
+    let patch = serde_json::json!({"source": {"kafka": {"unknownOption": true}}});
+
+    let file_mock = MockServer::start().await;
+    let file_output = invoke_clickpipe_update_file(&file_mock, &patch);
+    assert_eq!(file_output.status.code(), Some(1));
+    let file_stderr = String::from_utf8_lossy(&file_output.stderr);
+    assert!(
+        file_stderr.contains("unknown field `source.kafka.unknownOption`"),
+        "{file_stderr}"
+    );
+    assert!(!file_stderr.contains(".?"), "{file_stderr}");
+    assert!(file_mock.received_requests().await.unwrap().is_empty());
+
+    let stdin_mock = MockServer::start().await;
+    let stdin_output = invoke_cli_with_cloud_credentials_and_stdin(
+        &stdin_mock,
+        &[
+            "clickpipe",
+            "update",
+            "svc-1",
+            "pipe-1",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        &patch.to_string(),
+    );
+    assert_eq!(stdin_output.status.code(), Some(1));
+    let stdin_stderr = String::from_utf8_lossy(&stdin_output.stderr);
+    assert!(
+        stdin_stderr.contains("invalid request body in config stdin"),
+        "{stdin_stderr}"
+    );
+    assert!(
+        stdin_stderr.contains("unknown field `source.kafka.unknownOption`"),
+        "{stdin_stderr}"
+    );
+    assert!(!stdin_stderr.contains(".?"), "{stdin_stderr}");
+    assert!(stdin_mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn clickpipe_update_rejects_mysql_port_zero_from_file_and_stdin_before_http() {
     let patch = serde_json::json!({"source": {
         "mysql": {"host": "mysql.example.com", "port": 0}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -22409,15 +22409,28 @@ async fn clickpipe_update_accepts_database_port_boundaries_and_preserves_omissio
 }
 
 #[tokio::test]
-async fn clickpipe_update_rejects_noop_unknown_nested_fields_and_bigquery_before_http() {
+async fn clickpipe_update_reports_bigquery_as_unsupported_before_http() {
+    let mock = MockServer::start().await;
+    let patch = serde_json::json!({"source": {
+        "bigquery": {},
+        "validateSamples": false
+    }});
+    let output = invoke_clickpipe_update_file(&mock, &patch);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("`source.bigquery`"), "{stderr}");
+    assert!(stderr.contains("cannot be updated"), "{stderr}");
+    assert!(!stderr.contains(".?."), "{stderr}");
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn clickpipe_update_rejects_noop_and_unknown_nested_fields_before_http() {
     for patch in [
         serde_json::json!({}),
         serde_json::json!({"destination": {}}),
         serde_json::json!({"destination": {"colums": []}}),
-        serde_json::json!({"source": {
-            "bigquery": {},
-            "validateSamples": false
-        }}),
         serde_json::json!({"source": {
             "kafka": {
                 "credentials": {"username": "user", "password": "pw", "token": "bad"},


### PR DESCRIPTION
Unsupported BigQuery source updates identify `source.bigquery` and explain the restriction.

Unknown-field diagnostics omit serde traversal artifacts while retaining the real JSON field path, strict rejection and the specific unsupported BigQuery source diagnostic. File-or-stdin PATCH input identifies stdin clearly.

Builder/config and real-binary tests cover file and stdin sources, nested unknown keys, literal map keys and BigQuery diagnostics before HTTP.

Refs #844 item 1 only; remaining batch scope stays open.

Closes #810.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
