### PR TITLE
fix(local): generate fresh names for unnamed Postgres starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,8 @@ Native `psql` arguments require `--`, with all wrapper selectors before it: `loc
 
 `local postgres client` also retains native psql output for interactive sessions, `--query` and `--queries-file`, regardless of `--json` or coding-agent detection. Put psql output options after `--`, for example `local postgres client --query "SELECT 1" -- --csv`.
 
+When `local postgres start` is run without `--name`, the first instance is named `default`. If that instance is already running, each subsequent unnamed start gets a fresh generated name instead of resuming or colliding with existing Postgres state.
+
 `local postgres client --queries-file` accepts relative or absolute host paths, or `-` to read stdin. Plain pipes also work, for example `cat seed.sql | clickhousectl local postgres client`. Both forms work when host `psql` is unavailable: the Docker fallback streams SQL to container `psql`, preserves EOF and returns psql's exit status. When combined, `--query` executes before the file; append native arguments such as `-- -v ON_ERROR_STOP=1` to stop on SQL errors. In Docker mode, file contents are streamed as `psql -f -`; paths used inside SQL (such as `\i` or `\copy`) still refer to the container filesystem.
 
 Postgres `--name` and `--version` select a managed instance and cannot be combined with direct `--host` or `--port` selectors.

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -526,18 +526,23 @@ async fn rollback_failed_fresh_start(
 /// Default user-facing name when `--name` is omitted: `"default"` if no
 /// postgres "default" is running, otherwise a random adjective-noun.
 fn default_pg_name_locked(metadata_lock: &server::MetadataLock) -> Result<String> {
+    default_pg_name_locked_with(metadata_lock, docker::is_container_running_blocking)
+}
+
+fn default_pg_name_locked_with(
+    metadata_lock: &server::MetadataLock,
+    is_container_running: impl Fn(&str) -> bool,
+) -> Result<String> {
     let any_default_running = server::find_pg_instances_locked("default", metadata_lock)?
         .iter()
         .any(|i| {
             i.container_id
                 .as_deref()
-                .map(docker::is_container_running_blocking)
+                .map(&is_container_running)
                 .unwrap_or(false)
         });
     if any_default_running {
-        // Fall back to the existing random-name generator, which checks
-        // metadata file uniqueness across engines.
-        server::resolve_name_locked(None, metadata_lock)
+        server::generate_random_name_locked(metadata_lock)
     } else {
         Ok("default".into())
     }
@@ -1319,6 +1324,43 @@ mod tests {
                 .pop_front()
                 .expect("fake pg_isready result exhausted")
         }
+    }
+
+    #[test]
+    fn unnamed_start_after_running_default_selects_fresh_name() {
+        let directory = tempfile::tempdir().unwrap();
+        let lock = server::MetadataLock::acquire_at(directory.path()).unwrap();
+        assert_eq!(
+            default_pg_name_locked_with(&lock, |_| true).unwrap(),
+            "default"
+        );
+
+        let info = ServerInfo {
+            name: server::pg_instance_key("default", "18"),
+            pid: 0,
+            version: "postgres:18".into(),
+            http_port: 0,
+            tcp_port: 5432,
+            started_at: "1700000000".into(),
+            cwd: "/tmp/project".into(),
+            engine: Engine::Postgres,
+            container_id: Some("running-default".into()),
+        };
+        server::save_server_info_locked(&info, &lock).unwrap();
+
+        assert_eq!(
+            default_pg_name_locked_with(&lock, |_| false).unwrap(),
+            "default"
+        );
+
+        let selected = default_pg_name_locked_with(&lock, |id| id == "running-default").unwrap();
+
+        assert_ne!(selected, "default");
+        assert!(
+            server::find_pg_instances_locked(&selected, &lock)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -114,7 +114,7 @@ pub(crate) struct MetadataLock {
 }
 
 impl MetadataLock {
-    fn acquire_at(dir: &Path) -> Result<Self> {
+    pub(crate) fn acquire_at(dir: &Path) -> Result<Self> {
         std::fs::create_dir_all(dir).map_err(|source| {
             server_lock_error(
                 "create the server metadata lock directory",
@@ -758,7 +758,7 @@ pub(crate) fn resolve_name_locked(name: Option<&str>, lock: &MetadataLock) -> Re
     }
 }
 
-fn generate_random_name_locked(lock: &MetadataLock) -> Result<String> {
+pub(crate) fn generate_random_name_locked(lock: &MetadataLock) -> Result<String> {
     let seed = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -768,15 +768,22 @@ fn generate_random_name_locked(lock: &MetadataLock) -> Result<String> {
     let noun = NOUNS[((mixed / ADJECTIVES.len() as u128) % NOUNS.len() as u128) as usize];
     let tag = format!("{}-{}", adj, noun);
 
-    if is_server_running_locked(&tag, lock)? {
-        for i in 2..100 {
-            let candidate = format!("{}-{}", tag, i);
-            if !is_server_running_locked(&candidate, lock)? {
-                return Ok(candidate);
-            }
+    unique_generated_name_locked(&tag, lock)
+}
+
+fn unique_generated_name_locked(tag: &str, lock: &MetadataLock) -> Result<String> {
+    if load_info_locked(tag, lock)?.is_none() && find_pg_instances_locked(tag, lock)?.is_empty() {
+        return Ok(tag.to_string());
+    }
+    for i in 2_u64.. {
+        let candidate = format!("{}-{}", tag, i);
+        if load_info_locked(&candidate, lock)?.is_none()
+            && find_pg_instances_locked(&candidate, lock)?.is_empty()
+        {
+            return Ok(candidate);
         }
     }
-    Ok(tag)
+    unreachable!("a finite metadata directory cannot exhaust generated names")
 }
 
 /// Wait a moment after spawn and check if the child exited immediately.
@@ -1303,6 +1310,22 @@ mod tests {
         assert_eq!(parsed.engine, Engine::Postgres);
         assert_eq!(parsed.container_id.as_deref(), Some("abc123"));
         assert!(json.contains("\"engine\":\"postgres\""));
+    }
+
+    #[test]
+    fn generated_name_avoids_postgres_metadata_collisions() {
+        let directory = tempfile::tempdir().unwrap();
+        let lock = MetadataLock::acquire_at(directory.path()).unwrap();
+        let mut info = test_info(0, "postgres:18");
+        info.name = pg_instance_key("calm-bird", "18");
+        info.engine = Engine::Postgres;
+        info.container_id = Some("stopped-container".into());
+        save_server_info_locked(&info, &lock).unwrap();
+
+        assert_eq!(
+            unique_generated_name_locked("calm-bird", &lock).unwrap(),
+            "calm-bird-2"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When the default Postgres instance is running, another unnamed start now calls the name generator directly instead of consulting ClickHouse default state. Generated names avoid existing metadata across engines; stopped default instances retain resume behavior.

Regression tests cover absent/stopped/running defaults and metadata collisions. Docker was unavailable, so live container validation was not run.

Validation: focused regressions plus the required formatting, default Clippy/tests, telemetry-disabled check/all-target Clippy, and Python classifier tests on the combined QA stack tip.

Closes #801.

Stack: appended to existing GitHub PR stack #769; leave merging and releasing to Al.
