### PR TITLE
fix(local): ensure runtime ignores during init and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,8 @@ All project-local server data lives inside `.clickhouse/` in your project direct
         └── data/           # ClickHouse data files for "dev" server
 ```
 
+`local init` creates `.clickhouse/.gitignore` whenever it is missing, including when an earlier local command already created `.clickhouse/`. Repeated initialization preserves an existing ignore file and any custom entries in it.
+
 Each named server has its own data directory, so servers are fully isolated from each other. Data persists between restarts — stop and start a server by name to pick up where you left off. Use `clickhousectl local server remove <name>` to permanently delete a server's data.
 
 ## Cloud authentication and account creation

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ All project-local server data lives inside `.clickhouse/` in your project direct
         └── data/           # ClickHouse data files for "dev" server
 ```
 
-`local init` creates `.clickhouse/.gitignore` whenever it is missing, including when an earlier local command already created `.clickhouse/`. Repeated initialization preserves an existing ignore file and any custom entries in it.
+`local init` and starting a local ClickHouse or Postgres server create `.clickhouse/.gitignore` whenever it is missing, including when an earlier local command already created `.clickhouse/`. Repeated initialization and startup preserve an existing ignore file and any custom entries in it. `local init --json` reports only paths created by that run: `[]` for a no-op and `[".clickhouse/.gitignore"]` when it repairs only the ignore file.
 
 Each named server has its own data directory, so servers are fully isolated from each other. Data persists between restarts — stop and start a server by name to pick up where you left off. Use `clickhousectl local server remove <name>` to permanently delete a server's data.
 

--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use std::io::Write;
 use std::path::PathBuf;
 
 pub fn local_dir() -> PathBuf {
@@ -25,31 +26,55 @@ pub fn postgres_project_dir() -> PathBuf {
         .join("postgres")
 }
 
-pub fn is_initialized() -> bool {
-    local_dir().exists()
-}
-
 /// Which project-local paths `init()` created during this invocation. The
 /// caller renders this in both the human-readable and `--json` output, so
 /// `init()` itself prints nothing.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct InitResult {
     pub clickhouse_dir_created: bool,
+    pub runtime_gitignore_created: bool,
     pub clickhouse_scaffold_created: bool,
     pub postgres_scaffold_created: bool,
 }
 
-pub fn init() -> Result<InitResult> {
-    let dir = local_dir();
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeIgnoreResult {
+    pub directory_created: bool,
+    pub gitignore_created: bool,
+}
 
-    let clickhouse_dir_created = !is_initialized();
-    if clickhouse_dir_created {
-        std::fs::create_dir_all(&dir)?;
-    }
+/// Ensure project-local runtime state is ignored without replacing a custom
+/// ignore file. The create-new write also preserves a file created by a
+/// concurrent process, and every other I/O failure reaches the caller.
+pub fn ensure_runtime_gitignore() -> Result<RuntimeIgnoreResult> {
+    let dir = local_dir();
+    let directory_created = !dir.exists();
+    std::fs::create_dir_all(&dir)?;
+
     let gitignore = dir.join(".gitignore");
-    if !gitignore.exists() {
-        std::fs::write(dir.join(".gitignore"), "*\n")?;
-    }
+    let gitignore_created = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&gitignore)
+    {
+        Ok(mut file) => {
+            file.write_all(b"*\n")?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && gitignore.is_file() => {
+            false
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    Ok(RuntimeIgnoreResult {
+        directory_created,
+        gitignore_created,
+    })
+}
+
+pub fn init() -> Result<InitResult> {
+    let runtime_ignore = ensure_runtime_gitignore()?;
 
     let clickhouse_scaffold_created = create_project_scaffold(
         project_dir(),
@@ -61,7 +86,8 @@ pub fn init() -> Result<InitResult> {
     )?;
 
     Ok(InitResult {
-        clickhouse_dir_created,
+        clickhouse_dir_created: runtime_ignore.directory_created,
+        runtime_gitignore_created: runtime_ignore.gitignore_created,
         clickhouse_scaffold_created,
         postgres_scaffold_created,
     })

--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -42,13 +42,14 @@ pub struct InitResult {
 pub fn init() -> Result<InitResult> {
     let dir = local_dir();
 
-    let clickhouse_dir_created = if is_initialized() {
-        false
-    } else {
+    let clickhouse_dir_created = !is_initialized();
+    if clickhouse_dir_created {
         std::fs::create_dir_all(&dir)?;
+    }
+    let gitignore = dir.join(".gitignore");
+    if !gitignore.exists() {
         std::fs::write(dir.join(".gitignore"), "*\n")?;
-        true
-    };
+    }
 
     let clickhouse_scaffold_created = create_project_scaffold(
         project_dir(),

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -37,7 +37,12 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
         LocalCommands::Which => which(json),
         LocalCommands::Init => {
             let result = init::init()?;
-            let mut paths = vec![".clickhouse/".to_string()];
+            let mut paths = Vec::new();
+            if result.clickhouse_dir_created {
+                paths.push(".clickhouse/".to_string());
+            } else if result.runtime_gitignore_created {
+                paths.push(".clickhouse/.gitignore".to_string());
+            }
             if result.clickhouse_scaffold_created {
                 paths.push("clickhouse/".to_string());
             }
@@ -566,6 +571,7 @@ async fn start_server(
     if name.is_some() && server::is_server_running_locked(&server_name, &metadata_lock)? {
         return Err(Error::ServerAlreadyRunning(server_name));
     }
+    init::ensure_runtime_gitignore()?;
 
     // Show running server count
     let running = server::advisory_running_server_count_locked(&metadata_lock);

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -816,28 +816,33 @@ impl fmt::Display for RemoveOutput {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct InitOutput {
-    /// Every project-local path this invocation created or manages, e.g.
-    /// `.clickhouse/`, and (when newly created) `clickhouse/` and `postgres/`.
+    /// Every project-local path this invocation created, e.g. `.clickhouse/`,
+    /// `.clickhouse/.gitignore`, `clickhouse/`, or `postgres/`.
     pub paths: Vec<String>,
     /// Human-output detail only: the project dir already existed before this
-    /// run. JSON consumers can tell from `paths`, so it is not serialized.
+    /// run. This affects human wording only, so it is not serialized.
     #[serde(skip)]
     pub already_initialized: bool,
 }
 
 impl fmt::Display for InitOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let dir = self
+        if !self.already_initialized {
+            write!(f, "Initialized ClickHouse project in .clickhouse/")?;
+        } else if self
             .paths
-            .first()
-            .map(String::as_str)
-            .unwrap_or(".clickhouse/");
-        if self.already_initialized {
-            write!(f, "Already initialized at {dir}")?;
+            .iter()
+            .any(|path| path == ".clickhouse/.gitignore")
+        {
+            write!(f, "Restored runtime ignore at .clickhouse/.gitignore")?;
         } else {
-            write!(f, "Initialized ClickHouse project in {dir}")?;
+            write!(f, "Already initialized at .clickhouse/")?;
         }
-        for path in self.paths.iter().skip(1) {
+        for path in self
+            .paths
+            .iter()
+            .filter(|path| !path.starts_with(".clickhouse/"))
+        {
             write!(f, "\nCreated project scaffold in {path}")?;
         }
         Ok(())
@@ -2070,15 +2075,15 @@ mod tests {
     }
 
     #[test]
-    fn init_json_idempotent_run_only_reports_clickhouse_dir() {
+    fn init_json_idempotent_run_reports_no_created_paths() {
         let output = InitOutput {
-            paths: vec![".clickhouse/".to_string()],
+            paths: vec![],
             already_initialized: true,
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
-        assert_eq!(json["paths"], serde_json::json!([".clickhouse/"]));
+        assert_eq!(json["paths"], serde_json::json!([]));
     }
 
     #[test]
@@ -2405,10 +2410,34 @@ mod tests {
     #[test]
     fn init_display_idempotent() {
         let output = InitOutput {
-            paths: vec![".clickhouse/".to_string()],
+            paths: vec![],
             already_initialized: true,
         };
         assert_eq!(output.to_string(), "Already initialized at .clickhouse/");
+    }
+
+    #[test]
+    fn init_display_reports_runtime_ignore_repair() {
+        let output = InitOutput {
+            paths: vec![".clickhouse/.gitignore".to_string()],
+            already_initialized: true,
+        };
+        assert_eq!(
+            output.to_string(),
+            "Restored runtime ignore at .clickhouse/.gitignore"
+        );
+    }
+
+    #[test]
+    fn init_display_reports_scaffold_repair_without_runtime_path() {
+        let output = InitOutput {
+            paths: vec!["postgres/".to_string()],
+            already_initialized: true,
+        };
+        assert_eq!(
+            output.to_string(),
+            "Already initialized at .clickhouse/\nCreated project scaffold in postgres/"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -288,6 +288,7 @@ async fn start(
             drop(metadata_lock);
             continue;
         }
+        crate::init::ensure_runtime_gitignore()?;
 
         // Resume path: an instance for this exact (name, major) already exists.
         if let Some(prior) = prior {

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -193,16 +193,11 @@ pub fn pg_data_dir(name: &str, major: &str) -> PathBuf {
         .join("data")
 }
 
-/// Ensure project-local servers dir + .gitignore exist. Idempotent.
+/// Ensure the project-local server and ignore paths exist. Idempotent.
 fn ensure_servers_dir() -> Result<()> {
     let dir = servers_dir();
-    if !dir.exists() {
-        std::fs::create_dir_all(&dir)?;
-        let gitignore = init::local_dir().join(".gitignore");
-        if !gitignore.exists() {
-            let _ = std::fs::write(gitignore, "*\n");
-        }
-    }
+    std::fs::create_dir_all(&dir)?;
+    init::ensure_runtime_gitignore()?;
     Ok(())
 }
 

--- a/crates/clickhousectl/tests/local_init_json_test.rs
+++ b/crates/clickhousectl/tests/local_init_json_test.rs
@@ -106,3 +106,65 @@ fn init_human_output_second_run_reports_already_initialized() {
         "Already initialized at .clickhouse/\n"
     );
 }
+
+#[test]
+fn init_after_server_list_creates_runtime_gitignore() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    let list = run(project.path(), home.path(), &["local", "server", "list"]);
+    assert!(
+        list.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&list.stderr)
+    );
+    assert!(
+        project
+            .path()
+            .join(".clickhouse/servers/.metadata.lock")
+            .is_file()
+    );
+
+    let init = run(project.path(), home.path(), &["local", "init"]);
+    assert!(
+        init.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.path().join(".clickhouse/.gitignore")).unwrap(),
+        "*\n"
+    );
+
+    let git_init = Command::new("git")
+        .arg("init")
+        .current_dir(project.path())
+        .output()
+        .expect("initialize temporary Git repository");
+    assert!(git_init.status.success());
+    let status = Command::new("git")
+        .args(["status", "--short", "--untracked-files=all"])
+        .current_dir(project.path())
+        .output()
+        .expect("inspect temporary Git repository");
+    assert!(status.status.success());
+    assert!(!String::from_utf8_lossy(&status.stdout).contains(".metadata.lock"));
+}
+
+#[test]
+fn init_preserves_existing_runtime_gitignore() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let runtime_dir = project.path().join(".clickhouse");
+    std::fs::create_dir(&runtime_dir).unwrap();
+    std::fs::write(runtime_dir.join(".gitignore"), "custom-entry\n").unwrap();
+
+    let first = run(project.path(), home.path(), &["local", "init"]);
+    assert!(first.status.success());
+    let second = run(project.path(), home.path(), &["local", "init"]);
+    assert!(second.status.success());
+    assert_eq!(
+        std::fs::read_to_string(runtime_dir.join(".gitignore")).unwrap(),
+        "custom-entry\n"
+    );
+}

--- a/crates/clickhousectl/tests/local_init_json_test.rs
+++ b/crates/clickhousectl/tests/local_init_json_test.rs
@@ -2,6 +2,7 @@
 //! full set of paths the command created, and the human output must report
 //! each created path exactly once (issue #609).
 
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -48,7 +49,7 @@ fn init_json_reports_clickhouse_dir_and_both_scaffolds_on_first_run() {
 }
 
 #[test]
-fn init_json_on_second_run_reports_only_the_clickhouse_dir() {
+fn init_json_on_second_run_reports_no_created_paths() {
     let project = tempfile::tempdir().expect("create project");
     let home = tempfile::tempdir().expect("create home");
 
@@ -56,7 +57,25 @@ fn init_json_on_second_run_reports_only_the_clickhouse_dir() {
     let output = run(project.path(), home.path(), &["local", "init", "--json"]);
     let json = stdout_json(&output);
 
-    assert_eq!(json["paths"], serde_json::json!([".clickhouse/"]));
+    assert_eq!(json["paths"], serde_json::json!([]));
+}
+
+#[test]
+fn init_json_reports_runtime_gitignore_repair() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    run(project.path(), home.path(), &["local", "init", "--json"]);
+    std::fs::remove_file(project.path().join(".clickhouse/.gitignore"))
+        .expect("remove runtime gitignore");
+    let output = run(project.path(), home.path(), &["local", "init", "--json"]);
+    let json = stdout_json(&output);
+
+    assert_eq!(json["paths"], serde_json::json!([".clickhouse/.gitignore"]));
+    assert_eq!(
+        std::fs::read_to_string(project.path().join(".clickhouse/.gitignore")).unwrap(),
+        "*\n"
+    );
 }
 
 #[test]
@@ -104,6 +123,23 @@ fn init_human_output_second_run_reports_already_initialized() {
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
         "Already initialized at .clickhouse/\n"
+    );
+}
+
+#[test]
+fn init_human_output_reports_a_scaffold_only_repair() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    run(project.path(), home.path(), &["local", "init"]);
+    std::fs::remove_dir_all(project.path().join("postgres/views"))
+        .expect("remove one scaffold directory");
+    let output = run(project.path(), home.path(), &["local", "init"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Already initialized at .clickhouse/\nCreated project scaffold in postgres/\n"
     );
 }
 
@@ -167,4 +203,30 @@ fn init_preserves_existing_runtime_gitignore() {
         std::fs::read_to_string(runtime_dir.join(".gitignore")).unwrap(),
         "custom-entry\n"
     );
+}
+
+#[test]
+fn init_propagates_runtime_gitignore_write_failure() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let runtime_dir = project.path().join(".clickhouse");
+    std::fs::create_dir(&runtime_dir).unwrap();
+    std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = run(project.path(), home.path(), &["local", "init", "--json"]);
+
+    std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!runtime_dir.join(".gitignore").exists());
+}
+
+#[test]
+fn init_rejects_a_runtime_gitignore_directory() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    std::fs::create_dir_all(project.path().join(".clickhouse/.gitignore")).unwrap();
+
+    let output = run(project.path(), home.path(), &["local", "init", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
 }

--- a/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
@@ -303,6 +303,10 @@ fn exhausted_auto_port_range_does_not_block_resume() {
     let body: Value = serde_json::from_slice(&output.stdout).expect("parse start JSON");
     assert_eq!(body["port"], stored_port);
     assert_eq!(body["container_id"], "existing-container");
+    assert_eq!(
+        std::fs::read_to_string(project.path().join(".clickhouse/.gitignore")).unwrap(),
+        "*\n"
+    );
 }
 
 #[test]

--- a/crates/clickhousectl/tests/local_server_start_args_test.rs
+++ b/crates/clickhousectl/tests/local_server_start_args_test.rs
@@ -102,6 +102,10 @@ fn positional_name_keeps_following_version_and_passthrough_separate() {
             .join(".clickhouse/servers/existing.json")
             .exists()
     );
+    assert_eq!(
+        std::fs::read_to_string(project.path().join(".clickhouse/.gitignore")).unwrap(),
+        "*\n"
+    );
     assert!(
         !project
             .path()


### PR DESCRIPTION
A previous list operation or metadata lock may create `.clickhouse/` before initialization; the ignore file is repaired in that case.

Init and ClickHouse/Postgres startup share idempotent runtime-ignore creation even when metadata locking created the directory first. Custom ignore files are preserved and write errors propagate. No-op init reports no created paths; gitignore-only repair reports the created ignore file.

Subprocess tests cover init no-op/repair paths, custom ignore contents, write failures, and both ClickHouse and Postgres bootstrap paths.

Closes #855. Refs #860 (init JSON paths only).

Closes #802.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.

Real Postgres 18 Docker validation on that final revision passed startup-ignore creation/custom preservation, plain pipe/EOF, native `-- -c`, exit 3 on SQL errors, missing-file diagnostics, redirected terminal input and a genuine PTY query followed by Ctrl-D/exit 0. The disposable container, volume and project were removed.
