### PR TITLE
docs(local): clarify running-only global server listing

### DIFF
--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -289,6 +289,7 @@ CONTEXT FOR AGENTS:
   Requires Docker installed and running.
   Each instance is keyed on (name, major version); pass --version when one name has two majors.
   There is no `postgres list` — `local server list` shows ClickHouse and Postgres together.
+  `local server list --global` only discovers running ClickHouse servers, excluding Postgres.
   Typical flow: `postgres start` -> `postgres client` -> `postgres dotenv --local` -> `postgres stop`")]
     Postgres {
         #[command(subcommand)]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -368,7 +368,7 @@ CONTEXT FOR AGENTS:
 
     /// List all server instances (running and stopped)
     List {
-        /// List ClickHouse servers in all projects; the default is project-scoped
+        /// List running ClickHouse servers across all projects
         #[arg(long)]
         global: bool,
     },


### PR DESCRIPTION
Global server-list help explains that it lists running ClickHouse processes across projects.

The local Postgres parent help now explains that `server list --global` discovers only running ClickHouse servers.

The existing running-only global ClickHouse listing remains unchanged; no global Postgres discovery is introduced.

Refs #860 (global-list Postgres scope only).

Closes #805.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
