### PR TITLE
docs(cloud): explain scaling-schedule file shape

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -772,7 +772,7 @@ pub enum ScalingScheduleCommands {
     /// Create or replace the scaling schedule
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  --file is a JSON ScalingSchedulePostRequest; '-' reads it from stdin.
+  --file is a JSON object with an entries array; '-' reads it from stdin.
   Set replaces every existing entry. Get, edit only entries, then set to preserve other entries.
   Hours and weekdays are UTC. baseConfig is response-only and must not be sent.")]
     Set {

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -774,7 +774,8 @@ pub enum ScalingScheduleCommands {
 CONTEXT FOR AGENTS:
   --file is a JSON object with an entries array; '-' reads it from stdin.
   Set replaces every existing entry. Get, edit only entries, then set to preserve other entries.
-  Hours and weekdays are UTC. baseConfig is response-only and must not be sent.")]
+  Hours and weekdays are UTC.
+  Omit response-only baseConfig and each entry's id and isActiveNow when setting a schedule.")]
     Set {
         /// Service ID
         service_id: String,


### PR DESCRIPTION
Scaling-schedule set help describes the JSON entries-array request, stdin input and whole-list replacement.

Scaling-schedule input help identifies entry `id` and `isActiveNow` as response-only alongside `baseConfig`, within the agent-context line budget.

Schedule file shape and response-only fields are documented within the existing structural help limits.

Refs #848 (schedule help only).

Closes #807.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
