### PR TITLE
fix(postgres): expose accepted log-sort values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ Use `clickhousectl cloud postgres create --help` for the complete option list. S
 
 `postgres metrics` requires an RFC 3339 start and end time, with the start no later than the end. Whole seconds, fractional seconds, and UTC offsets are normalized to UTC with three fractional digits (for example, `2026-04-16T13:00:00+01:00` becomes `2026-04-16T12:00:00.000Z`). The endpoint supports millisecond precision; finer nonzero fractional digits are rejected before any request instead of rounding or truncating the interval. Its JSON output preserves metric metadata, series labels, and data points; the default output renders the same nested response as a readable tree. `--bucket-size-seconds` must be positive and is omitted from the API request when not supplied.
 
-`postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order`, `--limit` and `--offset` to control pagination.
+`postgres logs` reads an inclusive RFC 3339 time window of at most 30 days. Results default to the API's newest-first order and page size; use `--sort-order asc|desc`, `--limit` and `--offset` to control pagination.
 
 `postgres slow-queries list` requires an RFC 3339 start and end time and supports database, user, operation and application filters, sorting, limits and offsets. Copy `queryId`, `dbName`, `dbUser` and `dbOperation` from a list result into `slow-queries get`; add `--app` when the list result has one, and optionally select a recent execution with `--timestamp`. JSON and human output preserve every aggregate and execution field the API returns, including sparse beta responses. Duration values are microseconds and may be fractional; call, row and block counts remain integers.
 

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -3,6 +3,7 @@ use crate::cloud::client::{
 };
 use crate::cloud::output::{ABSENT, eprint_line, or_absent, print_human, print_line};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
+use clap::builder::TypedValueParser;
 use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
     ApiResponse, PgBouncerConfig, PgConfig, PgConfigDefaultTransactionIsolation,
@@ -18,6 +19,8 @@ use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tabled::{Table, Tabled, settings::Style};
+
+const POSTGRES_LOG_SORT_ORDERS: &[&str] = &["asc", "desc"];
 
 #[derive(Subcommand)]
 pub enum PostgresCommands {
@@ -60,7 +63,12 @@ pub enum PostgresCommands {
         #[arg(long)]
         severity: Option<String>,
         /// Sort order
-        #[arg(long, value_parser = parse_postgres_logs_sort_order)]
+        #[arg(
+            long,
+            value_parser = clap::builder::PossibleValuesParser::new(
+                POSTGRES_LOG_SORT_ORDERS
+            ).try_map(parse_known_postgres_logs_sort_order)
+        )]
         sort_order: Option<PostgresLogsGetListSortorder>,
         /// Maximum number of log entries
         #[arg(long, value_parser = clap::value_parser!(i64).range(1..=2000))]
@@ -1354,6 +1362,12 @@ fn parse_postgres_logs_sort_order(value: &str) -> Result<PostgresLogsGetListSort
     let parsed = serde_json::from_value(serde_json::Value::String(value.to_string()))
         .map_err(|error| format!("invalid sort order '{value}': {error}"))?;
     validate_postgres_logs_sort_order(parsed)
+}
+
+fn parse_known_postgres_logs_sort_order(
+    value: String,
+) -> Result<PostgresLogsGetListSortorder, String> {
+    parse_postgres_logs_sort_order(&value)
 }
 
 fn validate_postgres_logs_sort_order(
@@ -2866,6 +2880,50 @@ mod tests {
     }
 
     #[test]
+    fn postgres_logs_sort_order_exposes_every_supported_value() {
+        use clap::CommandFactory;
+
+        let command = PostgresCli::command();
+        let sort_order = command
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "logs")
+            .and_then(|logs| {
+                logs.get_arguments()
+                    .find(|arg| arg.get_id() == "sort_order")
+            })
+            .expect("logs --sort-order argument");
+        let possible_values: Vec<_> = sort_order
+            .get_possible_values()
+            .into_iter()
+            .map(|value| value.get_name().to_string())
+            .collect();
+        assert_eq!(possible_values, POSTGRES_LOG_SORT_ORDERS);
+
+        for &value in POSTGRES_LOG_SORT_ORDERS {
+            let cmd = parse_postgres(&[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "logs",
+                "pg-1",
+                "--from-date",
+                "2026-08-01T00:00:00Z",
+                "--to-date",
+                "2026-08-02T00:00:00Z",
+                "--sort-order",
+                value,
+            ]);
+            let PostgresCommands::Logs { sort_order, .. } = cmd else {
+                panic!("expected logs");
+            };
+            assert_eq!(
+                sort_order.as_ref().map(ToString::to_string).as_deref(),
+                Some(value)
+            );
+        }
+    }
+
+    #[test]
     fn rejects_invalid_postgres_logs_flag_values() {
         let invalid_datetime = PostgresCli::try_parse_from([
             "clickhousectl",
@@ -2887,7 +2945,7 @@ mod tests {
             (
                 "--sort-order",
                 "newest",
-                clap::error::ErrorKind::ValueValidation,
+                clap::error::ErrorKind::InvalidValue,
             ),
             ("--limit", "0", clap::error::ErrorKind::ValueValidation),
             ("--limit", "2001", clap::error::ErrorKind::ValueValidation),


### PR DESCRIPTION
Postgres logs now exposes `asc` and `desc` through clap possible values and rejects unknown sort orders with usage exit 2 before HTTP. The omitted default and library wire values are preserved.

Structural possible-value tests and valid/invalid parser regressions cover the accepted values and wire representation.

Validation: focused regressions plus the required formatting, default Clippy/tests, telemetry-disabled check/all-target Clippy, and Python classifier tests on the combined QA stack tip.

Closes #808.

Stack: appended to existing GitHub PR stack #769; leave merging and releasing to Al.
