### PR TITLE
fix(cli): align ClickPipe insert-size bounds with production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,6 +1695,10 @@ request contains other settings. Database-source creates use their source-specif
 CDC setting and table-mapping flags instead. With no common setting flag, the
 request omits the whole `settings` block; explicit `0` and `false` remain present.
 
+`--object-storage-max-insert-bytes` accepts 524,288,000–10,737,418,240 bytes (500 MiB–10 GiB), inclusive, on create and `clickpipe settings update`.
+Use `clickpipe settings update` to change this value on an existing pipe.
+The current API validates this value in whole-pipe PATCH but does not apply it.
+
 ```bash
 clickhousectl cloud clickpipe create kafka <service-id> \
   --name mapped-events \

--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,7 @@ clickhousectl cloud clickpipe settings update <service-id> <clickpipe-id> \
   --object-storage-concurrency 8 \
   --object-storage-polling-interval-ms 30000 \
   --object-storage-max-file-count 500 \
-  --object-storage-max-insert-bytes 268435456 \
+  --object-storage-max-insert-bytes 536870912 \
   --object-storage-use-cluster-function true \
   --clickhouse-max-threads 16 --clickhouse-max-insert-threads 4 \
   --clickhouse-max-download-threads 8 \

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -673,8 +673,8 @@ pub struct ClickPipeSettingsValues {
     #[arg(long, value_parser = clap::value_parser!(u32).range(100..=3600000))]
     object_storage_polling_interval_ms: Option<u32>,
 
-    /// Bytes per insert batch (10485760-53687091200)
-    #[arg(long, value_parser = clap::value_parser!(u64).range(10485760..=53687091200))]
+    /// Bytes per insert batch (524288000-10737418240)
+    #[arg(long, value_parser = clap::value_parser!(u64).range(524288000..=10737418240))]
     object_storage_max_insert_bytes: Option<u64>,
 
     /// Max files per insert batch (1-10000)
@@ -6525,6 +6525,66 @@ mod tests {
     }
 
     #[test]
+    fn object_storage_insert_size_boundaries_match_create_and_settings_update() {
+        for size in [
+            524_287_999_u64,
+            524_288_000,
+            10_737_418_240,
+            10_737_418_241,
+            10_485_760,
+            53_687_091_200,
+        ] {
+            let size_arg = size.to_string();
+            for mut args in [
+                vec![
+                    "create",
+                    "object-storage",
+                    "svc-1",
+                    "--name",
+                    "pipe-1",
+                    "--source-url",
+                    "https://example.test/data.csv",
+                    "--format",
+                    "CSVWithNames",
+                    "--database",
+                    "default",
+                    "--table",
+                    "events",
+                ],
+                vec!["settings", "update", "svc-1", "pipe-1"],
+            ] {
+                args.extend(["--object-storage-max-insert-bytes", &size_arg]);
+                let result = Cli::try_parse_from(
+                    ["chctl", "cloud", "clickpipe"]
+                        .into_iter()
+                        .chain(args.iter().copied()),
+                );
+                if [524_288_000, 10_737_418_240].contains(&size) {
+                    assert!(result.is_ok(), "{args:?}");
+                    let settings = match parse_clickpipe(&args) {
+                        ClickPipeCommands::Create {
+                            command: ClickPipeCreateCommands::ObjectStorage(args),
+                        } => args.request.settings,
+                        ClickPipeCommands::Settings {
+                            command: ClickPipeSettingsCommands::Update { settings, .. },
+                        } => settings,
+                        _ => panic!("unexpected command"),
+                    };
+                    assert_eq!(settings.object_storage_max_insert_bytes, Some(size));
+                    let request = build_clickpipe_settings_request(&settings, None);
+                    assert_eq!(request.object_storage_max_insert_bytes, Some(size as i64));
+                } else {
+                    assert_eq!(
+                        result.err().expect("out-of-range size must fail").kind(),
+                        clap::error::ErrorKind::ValueValidation,
+                        "{args:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn parses_settings_commands_flags_and_defaults() {
         let ClickPipeCommands::Settings {
             command:
@@ -6561,7 +6621,7 @@ mod tests {
             "--object-storage-polling-interval-ms",
             "3000",
             "--object-storage-max-insert-bytes",
-            "10485760",
+            "524288000",
             "--object-storage-max-file-count",
             "5",
             "--clickhouse-max-threads",
@@ -6591,7 +6651,7 @@ mod tests {
         assert_eq!(settings.streaming_max_insert_wait_ms, Some(1000));
         assert_eq!(settings.object_storage_concurrency, Some(2));
         assert_eq!(settings.object_storage_polling_interval_ms, Some(3000));
-        assert_eq!(settings.object_storage_max_insert_bytes, Some(10_485_760));
+        assert_eq!(settings.object_storage_max_insert_bytes, Some(524_288_000));
         assert_eq!(settings.object_storage_max_file_count, Some(5));
         assert_eq!(settings.clickhouse_max_threads, Some(6));
         assert_eq!(settings.clickhouse_max_insert_threads, Some(7));
@@ -6793,7 +6853,7 @@ mod tests {
                 settings: ClickPipeSettingsValues {
                     object_storage_concurrency: Some(1),
                     object_storage_polling_interval_ms: Some(100),
-                    object_storage_max_insert_bytes: Some(10_485_760),
+                    object_storage_max_insert_bytes: Some(524_288_000),
                     object_storage_max_file_count: Some(1),
                     object_storage_use_cluster_function: Some(false),
                     ..Default::default()

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -6529,6 +6529,7 @@ mod tests {
         for size in [
             524_287_999_u64,
             524_288_000,
+            536_870_912,
             10_737_418_240,
             10_737_418_241,
             10_485_760,
@@ -6559,7 +6560,7 @@ mod tests {
                         .into_iter()
                         .chain(args.iter().copied()),
                 );
-                if [524_288_000, 10_737_418_240].contains(&size) {
+                if [524_288_000, 536_870_912, 10_737_418_240].contains(&size) {
                     assert!(result.is_ok(), "{args:?}");
                     let settings = match parse_clickpipe(&args) {
                         ClickPipeCommands::Create {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -6124,7 +6124,7 @@ async fn cross_source_create_controls_reach_all_eight_request_shapes() {
         "--object-storage-polling-interval-ms".into(),
         "100".into(),
         "--object-storage-max-insert-bytes".into(),
-        "10485760".into(),
+        "524288000".into(),
         "--object-storage-max-file-count".into(),
         "1".into(),
         "--object-storage-use-cluster-function".into(),
@@ -13854,6 +13854,97 @@ async fn recorded_put_body(mock: &MockServer) -> Value {
         .find(|request| request.method == wiremock::http::Method::PUT)
         .expect("no settings PUT request recorded by mock");
     serde_json::from_slice::<Value>(&put.body).unwrap()
+}
+
+#[tokio::test]
+async fn object_storage_insert_size_bounds_reach_create_and_settings_put() {
+    for size in [524_288_000_u64, 10_737_418_240] {
+        let size_arg = size.to_string();
+        let mock = start_mock_clickpipes_api().await;
+        let body = invoke_cli_capture_body(
+            &mock,
+            &[
+                "clickpipe",
+                "create",
+                "object-storage",
+                "svc-id",
+                "--name",
+                "pipe",
+                "--source-url",
+                "https://example.test/data.csv",
+                "--format",
+                "CSVWithNames",
+                "--database",
+                "default",
+                "--table",
+                "events",
+                "--org-id",
+                "org",
+                "--object-storage-max-insert-bytes",
+                &size_arg,
+            ],
+        )
+        .await;
+        assert_eq!(body["settings"]["object_storage_max_insert_bytes"], size);
+
+        let mock = MockServer::start().await;
+        mount_clickpipe_get(&mock, serde_json::json!({"objectStorage": {"type": "s3"}})).await;
+        let expected = serde_json::json!({"object_storage_max_insert_bytes": size});
+        mount_clickpipe_settings_put(&mock, expected.clone()).await;
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "clickpipe",
+                "settings",
+                "update",
+                "svc-id",
+                "pipe-id",
+                "--org-id",
+                "org",
+                "--object-storage-max-insert-bytes",
+                &size_arg,
+            ],
+        );
+        assert_success(&output);
+        assert_eq!(recorded_put_body(&mock).await, expected);
+    }
+}
+
+#[tokio::test]
+async fn object_storage_insert_size_outside_bounds_fails_before_http() {
+    let mock = MockServer::start().await;
+    for size in [524_287_999_u64, 10_737_418_241, 10_485_760, 53_687_091_200] {
+        let size_arg = size.to_string();
+        for mut args in [
+            vec![
+                "clickpipe",
+                "create",
+                "object-storage",
+                "svc-id",
+                "--name",
+                "pipe",
+                "--source-url",
+                "https://example.test/data.csv",
+                "--format",
+                "CSVWithNames",
+                "--database",
+                "default",
+                "--table",
+                "events",
+            ],
+            vec!["clickpipe", "settings", "update", "svc-id", "pipe-id"],
+        ] {
+            args.extend([
+                "--org-id",
+                "org",
+                "--object-storage-max-insert-bytes",
+                &size_arg,
+            ]);
+            let output = invoke_cli_with_cloud_credentials(&mock, &args);
+            assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+        }
+    }
+    assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
The README settings-update example now uses 536,870,912 bytes, within the deployed range. Parser/request-builder coverage includes that interior value for both create and settings update.

Closes #864.

Align `--object-storage-max-insert-bytes` with the deployed inclusive range of 524,288,000–10,737,418,240 bytes (500 MiB–10 GiB). Create and settings-update commands now reject out-of-range values during parsing, before any API request. Update help, fixtures and README guidance.

Closes #794. Upstream numeric-contract fix: https://github.com/ClickHouse/control-plane/pull/40253. This builds on the preceding API snapshot refresh.

Production validation on 10 September 2026, using a disposable AWS eu-west-1 service:

| Path | Both inclusive limits | One byte outside either limit; old 10 MiB/50 GiB limits |
| --- | --- | --- |
| Create POST | HTTP 200; settings GET confirmed each value | HTTP 400 with the corrected range |
| Settings PUT | HTTP 200; settings GET confirmed each value | HTTP 400; stored value unchanged |
| Whole-pipe PATCH with a changed name | HTTP 200, but settings were not applied | HTTP 400 with the corrected range |

**Remaining upstream behavior is tracked separately in #824:** settings-only PATCH returned HTTP 400 `no fields to update`. Adding a changed name returned HTTP 200, but changing insert bytes from 524,288,000 to 10,737,418,240 left it at 524,288,000 across GETs at 0/10/20/30 seconds. This is a remaining upstream PATCH behavior defect, independent of the now-consistent numeric bounds. Nullable settings were not changed or revalidated; that open contract question is also carried forward in #824. The README points users to `clickpipe settings update` for existing-pipe settings changes.

All test pipes were deleted, and the disposable service (including its uniquely named test tables) was deleted. Final service inventory matched the two pre-existing services.

Validation:
- Clap coverage for both boundaries, adjacent invalid values and both formerly advertised boundaries on create and settings update.
- Real CLI subprocess + wiremock tests verify native integer POST/PUT bodies and exit code 2 with no HTTP requests for invalid inputs.
- `cargo fmt --all`, default Clippy and CLI tests, and telemetry-disabled check/Clippy pass.

Final combined revision `82b374816a917cbac3a68194659beaaa5c7c9087` passed formatting, default CLI Clippy/tests, telemetry-disabled check/all-target Clippy, API/analyzer all-target Clippy/tests, and Python/classifier checks (1,822 CLI, 639 library/doc, and 91 Python tests). Required Cloud checks on the final PR heads remain pending; historical runs are not substituted.
