### PR TITLE
feat(cli): expose Query API endpoint management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,37 @@ Querying an **idled** service wakes it automatically in both auth modes — unde
 
 The Query API host is derived from the API base URL per environment (`api.[control-plane.]<domain>` → `queries.<domain>`, e.g. `https://queries.clickhouse.cloud` for production). Set `CLICKHOUSE_CLOUD_QUERY_HOST` to override it.
 
-The Rust [Cloud API library](crates/clickhouse-cloud-api/README.md) also supports beta Query API endpoint management: create, get, list with cursor pagination, update, and delete. These methods manage named SQL endpoints; CLI exposure is separate.
+#### Named Query API endpoints (beta)
+
+`cloud query-api-endpoint` manages named SQL endpoints with their own SQL, default parameters, database roles, API key bindings, and allowed origins. The existing `cloud service query-endpoint` commands manage the service-level binding used by `cloud service query`.
+
+Create an endpoint from a complete JSON definition:
+
+```json
+{
+  "name": "Order count",
+  "sql": "SELECT count() FROM orders WHERE status = {status:String}",
+  "database": "default",
+  "apiKeyIds": ["11111111-1111-4111-8111-111111111111"],
+  "roles": ["sql_console_read_only"],
+  "parameters": {"status": "paid"},
+  "allowedOrigins": ["https://example.com"]
+}
+```
+
+Save this as `endpoint.json` and replace the example key ID with one from `cloud key list`. `roles` contains database role names, not organization role IDs. `name`, `sql`, `database`, `apiKeyIds`, and `roles` are required; `parameters` and `allowedOrigins` are optional.
+
+```bash
+clickhousectl cloud query-api-endpoint create <service-id> --config-file endpoint.json
+clickhousectl cloud query-api-endpoint list <service-id> --limit 10 --json
+clickhousectl cloud query-api-endpoint get <service-id> <endpoint-id>
+clickhousectl cloud query-api-endpoint update <service-id> <endpoint-id> --config-file endpoint.json
+clickhousectl cloud query-api-endpoint delete <service-id> <endpoint-id>
+```
+
+Create and update also accept `--config-file -` to read JSON from stdin. Unknown fields and incomplete definitions are rejected before organization discovery. Update replaces the complete definition: omitted `parameters` and `allowedOrigins` use empty defaults, so include any values you want to retain. A GET response includes response-only fields; construct an update definition from the writable fields shown above.
+
+List returns one page; pass `pagination.nextCursor` from JSON output to `--cursor` to continue. Human output also displays the next cursor when present. `--limit` accepts 1–100. `--org-id` works before or after the subcommand. List/get support OAuth; create/update/delete require API key authentication. User-owned endpoints can be listed and read, but cannot be updated or deleted through these commands.
 
 ### Postgres (beta)
 

--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,16 @@ Create and update also accept `--config-file -` to read JSON from stdin. Unknown
 
 List returns one page; pass `pagination.nextCursor` from JSON output to `--cursor` to continue. Human output also displays the next cursor when present. `--limit` accepts 1–100. `--org-id` works before or after the subcommand. List/get support OAuth; create/update/delete require API key authentication. User-owned endpoints can be listed and read, but cannot be updated or deleted through these commands.
 
+Call the returned `url` with the bound key's `keyId` and `keySecret` (the credentials returned at key creation, distinct from the management `id` used in `apiKeyIds`). Supply every SQL placeholder explicitly: live validation found that stored `parameters` were returned by management GET but were not applied when executing the endpoint.
+
+```bash
+curl --user "$QUERY_KEY_ID:$QUERY_KEY_SECRET" "$ENDPOINT_URL" \
+  --header 'Content-Type: application/json' \
+  --data '{"queryVariables":{"status":"paid"},"format":"JSONEachRow"}'
+```
+
+GET requests use `param_status=paid` and `format=JSONEachRow` query parameters instead. `allowedOrigins` controls browser CORS access; it does not prevent an authenticated non-browser client from executing the endpoint. An empty list grants no cross-origin browser access; `["*"]` allows any origin.
+
 ### Postgres (beta)
 
 Manage ClickHouse Cloud managed Postgres services. All write commands require API key auth.

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -16,6 +16,7 @@ pub(crate) use crate::cloud::clickpipes::{
 };
 pub(crate) use crate::cloud::clickstack::ClickStackCommands;
 pub(crate) use crate::cloud::organizations::{InvitationCommands, MemberCommands, OrgCommands};
+pub(crate) use crate::cloud::query_api_endpoints::QueryApiEndpointArgs;
 #[allow(unused_imports)]
 pub(crate) use crate::cloud::services::{
     PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands, UpgradeWindowCommands,
@@ -129,6 +130,15 @@ CONTEXT FOR AGENTS:
         #[command(subcommand)]
         command: ServiceCommands,
     },
+
+    /// Manage Query API endpoints (Beta)
+    #[command(after_help = "CONTEXT FOR AGENTS:
+  Writes require API key authentication; list/get support OAuth.
+  Service IDs: `cloud service list`; API key IDs: `cloud key list`.
+  Endpoint IDs: `cloud query-api-endpoint list <service-id>`.
+  User-owned endpoints can be read but cannot be updated or deleted.
+  Typical flow: create -> get -> update -> delete.")]
+    QueryApiEndpoint(QueryApiEndpointArgs),
 
     /// Manage service backups and backup buckets
     #[command(after_help = "\
@@ -250,6 +260,7 @@ impl CloudCommands {
             CloudCommands::Invitation { command } => command.is_write(),
             CloudCommands::Key { command } => command.is_write(),
             CloudCommands::Udf(args) => args.is_write(),
+            CloudCommands::QueryApiEndpoint(args) => args.is_write(),
             CloudCommands::Activity { command } => command.is_write(),
             CloudCommands::Postgres { command } => command.is_write(),
             CloudCommands::ClickPipe { command } => command.is_write(),

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -12,6 +12,7 @@ pub mod credentials;
 pub mod organizations;
 pub mod output;
 pub mod postgres;
+pub mod query_api_endpoints;
 pub mod service_query;
 pub mod services;
 mod shared;
@@ -132,6 +133,7 @@ async fn dispatch(client: &CloudClient, command: CloudCommands, json: bool) -> c
         }
         CloudCommands::Key { command } => api_keys::run(client, command, json).await,
         CloudCommands::Udf(args) => udfs::run(client, args, json).await,
+        CloudCommands::QueryApiEndpoint(args) => query_api_endpoints::run(client, args, json).await,
         CloudCommands::Activity { command } => activity::run(client, command, json).await,
         CloudCommands::Backup { command } => backups::run(client, command, json).await,
         CloudCommands::Postgres { command } => postgres::run(client, command, json).await,

--- a/crates/clickhousectl/src/cloud/query_api_endpoints.rs
+++ b/crates/clickhousectl/src/cloud/query_api_endpoints.rs
@@ -1,0 +1,534 @@
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
+use crate::cloud::config::{deserialize_strict_config, read_config_value};
+use crate::cloud::output::{ABSENT, or_absent, print_human};
+use crate::cloud::shared::resolve_org_id;
+use crate::cloud::types::DeleteResponse;
+use clap::{Args, Subcommand};
+use clickhouse_cloud_api::models::{
+    PublicQueryApiEndpoint, PublicQueryApiEndpointRequest, QueryApiEndpointListResponse,
+};
+use serde::Serialize;
+use serde_json::Value;
+use tabled::{Table, Tabled, settings::Style};
+
+#[derive(Args)]
+pub struct QueryApiEndpointArgs {
+    /// Organization ID (auto-detected only if you have one org)
+    #[arg(long, global = true)]
+    org_id: Option<String>,
+    #[command(subcommand)]
+    command: QueryApiEndpointCommands,
+}
+
+#[derive(Subcommand)]
+pub enum QueryApiEndpointCommands {
+    /// List Query API endpoints
+    List {
+        /// Service ID
+        service_id: String,
+        /// Cursor from pagination.nextCursor
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Maximum records per page (1–100)
+        #[arg(long, allow_negative_numbers = true, value_parser = clap::value_parser!(i64).range(1..=100))]
+        limit: Option<i64>,
+    },
+    /// Get Query API endpoint details
+    Get(QueryApiEndpointTarget),
+    /// Create a Query API endpoint
+    Create(QueryApiEndpointCreateArgs),
+    /// Update a Query API endpoint
+    #[command(
+        after_help = "CONTEXT FOR AGENTS:\n  Supply the complete definition; omitted parameters and allowedOrigins reset to empty."
+    )]
+    Update {
+        #[command(flatten)]
+        target: QueryApiEndpointTarget,
+        #[command(flatten)]
+        input: QueryApiEndpointConfigArgs,
+    },
+    /// Delete a Query API endpoint
+    Delete(QueryApiEndpointTarget),
+}
+
+#[derive(Args)]
+pub struct QueryApiEndpointTarget {
+    /// Service ID
+    service_id: String,
+    /// Query API endpoint ID
+    endpoint_id: String,
+}
+
+#[derive(Args)]
+pub struct QueryApiEndpointConfigArgs {
+    /// Complete JSON definition (file path or - for stdin)
+    #[arg(long = "config-file")]
+    config_file: String,
+}
+
+#[derive(Args)]
+pub struct QueryApiEndpointCreateArgs {
+    /// Service ID
+    service_id: String,
+    #[command(flatten)]
+    input: QueryApiEndpointConfigArgs,
+}
+
+impl QueryApiEndpointArgs {
+    pub fn is_write(&self) -> bool {
+        match &self.command {
+            QueryApiEndpointCommands::List { .. } | QueryApiEndpointCommands::Get(_) => false,
+            QueryApiEndpointCommands::Create(_)
+            | QueryApiEndpointCommands::Update { .. }
+            | QueryApiEndpointCommands::Delete(_) => true,
+        }
+    }
+}
+
+pub async fn run(client: &CloudClient, args: QueryApiEndpointArgs, json: bool) -> CloudResult<()> {
+    match args.command {
+        QueryApiEndpointCommands::Create(input) => {
+            let request =
+                build_query_api_endpoint_request(read_config_value(&input.input.config_file)?)?;
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            output(
+                &client
+                    .create_query_api_endpoint(&org, &input.service_id, &request)
+                    .await?,
+                json,
+            )
+        }
+        QueryApiEndpointCommands::Update { target, input } => {
+            let request = build_query_api_endpoint_request(read_config_value(&input.config_file)?)?;
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            output(
+                &client
+                    .update_query_api_endpoint(
+                        &org,
+                        &target.service_id,
+                        &target.endpoint_id,
+                        &request,
+                    )
+                    .await?,
+                json,
+            )
+        }
+        QueryApiEndpointCommands::List {
+            service_id,
+            cursor,
+            limit,
+        } => {
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            let data = client
+                .list_query_api_endpoints(&org, &service_id, cursor.as_deref(), limit)
+                .await?;
+            if json {
+                output(&data, true)
+            } else {
+                print_endpoints(data);
+                Ok(())
+            }
+        }
+        QueryApiEndpointCommands::Get(target) => {
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            output(
+                &client
+                    .get_query_api_endpoint(&org, &target.service_id, &target.endpoint_id)
+                    .await?,
+                json,
+            )
+        }
+        QueryApiEndpointCommands::Delete(target) => {
+            let org = resolve_org_id(client, args.org_id.as_deref()).await?;
+            let data = client
+                .delete_query_api_endpoint(&org, &target.service_id, &target.endpoint_id)
+                .await?;
+            if json {
+                output(&data, true)
+            } else {
+                crate::cloud::output::print_line(format!(
+                    "Deleted Query API endpoint {}",
+                    target.endpoint_id
+                ));
+                Ok(())
+            }
+        }
+    }
+}
+
+fn output<T: Serialize>(data: &T, json: bool) -> CloudResult<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(data)?);
+    } else {
+        print_human(data)?;
+    }
+    Ok(())
+}
+
+fn print_endpoints(data: QueryApiEndpointListResponse) {
+    #[derive(Tabled)]
+    struct Row {
+        id: String,
+        name: String,
+        database: String,
+        owner_type: String,
+        url: String,
+    }
+    if let Some(items) = data.items {
+        let rows = items.into_iter().map(|item| Row {
+            id: or_absent(item.id),
+            name: or_absent(item.name),
+            database: or_absent(item.database),
+            owner_type: or_absent(item.owner_type),
+            url: or_absent(item.url),
+        });
+        println!("{}", Table::new(rows).with(Style::rounded()));
+    } else {
+        println!("Query API endpoints: {ABSENT}");
+    }
+    if let Some(cursor) = data
+        .pagination
+        .and_then(|pagination| pagination.next_cursor)
+    {
+        println!("Next cursor: {cursor}");
+    }
+}
+
+fn build_query_api_endpoint_request(value: Value) -> CloudResult<PublicQueryApiEndpointRequest> {
+    let request: PublicQueryApiEndpointRequest =
+        deserialize_strict_config(value, "Query API endpoint definition")?;
+    for (field, value) in [
+        ("name", &request.name),
+        ("sql", &request.sql),
+        ("database", &request.database),
+    ] {
+        if value.trim().is_empty() {
+            return Err(CloudError::new(format!(
+                "`{field}` must contain a non-whitespace character"
+            )));
+        }
+    }
+    if request.sql.chars().count() > 4_194_304 {
+        return Err(CloudError::new(
+            "`sql` must contain at most 4194304 characters",
+        ));
+    }
+    if request.api_key_ids.is_empty() {
+        return Err(CloudError::new(
+            "`apiKeyIds` must contain at least one API key ID",
+        ));
+    }
+    if request.roles.is_empty() || request.roles.iter().any(String::is_empty) {
+        return Err(CloudError::new(
+            "`roles` must contain at least one nonempty role and no empty roles",
+        ));
+    }
+    Ok(request)
+}
+
+impl CloudClient {
+    async fn create_query_api_endpoint(
+        &self,
+        org: &str,
+        service: &str,
+        body: &PublicQueryApiEndpointRequest,
+    ) -> CloudResult<PublicQueryApiEndpoint> {
+        let response = self
+            .api()
+            .query_api_endpoint_create(org, service, body)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn update_query_api_endpoint(
+        &self,
+        org: &str,
+        service: &str,
+        endpoint: &str,
+        body: &PublicQueryApiEndpointRequest,
+    ) -> CloudResult<PublicQueryApiEndpoint> {
+        let response = self
+            .api()
+            .query_api_endpoint_update(org, service, endpoint, body)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn get_query_api_endpoint(
+        &self,
+        org: &str,
+        service: &str,
+        endpoint: &str,
+    ) -> CloudResult<PublicQueryApiEndpoint> {
+        let response = self
+            .api()
+            .query_api_endpoint_get(org, service, endpoint)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn list_query_api_endpoints(
+        &self,
+        org: &str,
+        service: &str,
+        cursor: Option<&str>,
+        limit: Option<i64>,
+    ) -> CloudResult<QueryApiEndpointListResponse> {
+        let response = self
+            .api()
+            .query_api_endpoint_list(org, service, cursor, limit)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Self::unwrap_response(response)
+    }
+    async fn delete_query_api_endpoint(
+        &self,
+        org: &str,
+        service: &str,
+        endpoint: &str,
+    ) -> CloudResult<DeleteResponse> {
+        let response = self
+            .api()
+            .query_api_endpoint_delete(org, service, endpoint)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use crate::cloud::cli::CloudCommands;
+    use clap::Parser;
+    use serde_json::json;
+
+    fn minimal() -> Value {
+        json!({"name": "daily totals", "sql": "SELECT 1", "database": "default", "apiKeyIds": ["00000000-0000-4000-8000-000000000001"], "roles": ["reader"]})
+    }
+
+    #[test]
+    fn query_api_endpoint_builder_minimal() {
+        let request = build_query_api_endpoint_request(minimal()).unwrap();
+        assert_eq!(request.name, "daily totals");
+        assert_eq!(request.sql, "SELECT 1");
+        assert_eq!(request.database, "default");
+        assert_eq!(
+            request.api_key_ids,
+            vec![uuid::Uuid::parse_str("00000000-0000-4000-8000-000000000001").unwrap()]
+        );
+        assert_eq!(request.roles, vec!["reader"]);
+        assert!(request.parameters.is_none());
+        assert!(request.allowed_origins.is_none());
+    }
+
+    #[test]
+    fn query_api_endpoint_builder_maximal() {
+        let mut value = minimal();
+        value["parameters"] = json!({"kind": "page view", "limit": "10"});
+        value["allowedOrigins"] = json!(["https://example.com", "https://other.example.com"]);
+        value["roles"] = json!(["reader", "analyst"]);
+        value["apiKeyIds"] = json!([
+            "00000000-0000-4000-8000-000000000001",
+            "00000000-0000-4000-8000-000000000002"
+        ]);
+        let request = build_query_api_endpoint_request(value).unwrap();
+        assert_eq!(request.name, "daily totals");
+        assert_eq!(request.sql, "SELECT 1");
+        assert_eq!(request.database, "default");
+        assert_eq!(request.api_key_ids.len(), 2);
+        assert_eq!(
+            request.api_key_ids[1].to_string(),
+            "00000000-0000-4000-8000-000000000002"
+        );
+        assert_eq!(request.roles, vec!["reader", "analyst"]);
+        let parameters = request.parameters.unwrap();
+        assert_eq!(parameters.len(), 2);
+        assert_eq!(parameters["kind"], "page view");
+        assert_eq!(parameters["limit"], "10");
+        assert_eq!(
+            request.allowed_origins.unwrap(),
+            vec!["https://example.com", "https://other.example.com"]
+        );
+    }
+
+    #[test]
+    fn query_api_endpoint_builder_rejects_invalid_definitions() {
+        for field in ["name", "sql", "database", "apiKeyIds", "roles"] {
+            let mut value = minimal();
+            value.as_object_mut().unwrap().remove(field);
+            assert!(
+                build_query_api_endpoint_request(value).is_err(),
+                "missing {field}"
+            );
+        }
+        for (field, replacement) in [
+            ("name", json!(" \n")),
+            ("sql", json!("\t")),
+            ("database", json!("")),
+            ("apiKeyIds", json!([])),
+            ("apiKeyIds", json!(["invalid"])),
+            ("roles", json!([])),
+            ("roles", json!(["reader", ""])),
+            ("parameters", json!({"limit": 10})),
+            ("allowedOrigins", json!([true])),
+            ("unknownField", json!(true)),
+        ] {
+            let mut value = minimal();
+            value[field] = replacement;
+            assert!(
+                build_query_api_endpoint_request(value).is_err(),
+                "invalid {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn query_api_endpoint_builder_counts_sql_characters() {
+        let mut value = minimal();
+        value["sql"] = json!("é".repeat(4_194_304));
+        assert!(build_query_api_endpoint_request(value.clone()).is_ok());
+        value["sql"] = json!("é".repeat(4_194_305));
+        assert!(build_query_api_endpoint_request(value).is_err());
+    }
+
+    fn parse(extra: &[&str]) -> QueryApiEndpointArgs {
+        let mut args = vec!["chctl", "cloud", "query-api-endpoint"];
+        args.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(args).unwrap();
+        let Commands::Cloud(cloud) = cli.command else {
+            panic!("cloud command")
+        };
+        let CloudCommands::QueryApiEndpoint(args) = cloud.command else {
+            panic!("endpoint command")
+        };
+        args
+    }
+
+    #[test]
+    fn query_api_endpoint_clap_classifies_reads_and_writes() {
+        for (args, write) in [
+            (vec!["list", "svc"], false),
+            (vec!["get", "svc", "endpoint"], false),
+            (
+                vec!["create", "svc", "--config-file", "definition.json"],
+                true,
+            ),
+            (
+                vec!["update", "svc", "endpoint", "--config-file", "-"],
+                true,
+            ),
+            (vec!["delete", "svc", "endpoint"], true),
+        ] {
+            assert_eq!(parse(&args).is_write(), write);
+        }
+    }
+
+    #[test]
+    fn query_api_endpoint_clap_parses_config_targets_and_org_placement() {
+        let args = parse(&[
+            "--org-id",
+            "org",
+            "create",
+            "svc",
+            "--config-file",
+            "definition.json",
+        ]);
+        assert_eq!(args.org_id.as_deref(), Some("org"));
+        let QueryApiEndpointCommands::Create(input) = args.command else {
+            panic!("create")
+        };
+        assert_eq!(input.service_id, "svc");
+        assert_eq!(input.input.config_file, "definition.json");
+        let args = parse(&[
+            "update",
+            "svc",
+            "endpoint",
+            "--config-file",
+            "-",
+            "--org-id",
+            "org",
+        ]);
+        assert_eq!(args.org_id.as_deref(), Some("org"));
+        let QueryApiEndpointCommands::Update { target, input } = args.command else {
+            panic!("update")
+        };
+        assert_eq!(target.service_id, "svc");
+        assert_eq!(target.endpoint_id, "endpoint");
+        assert_eq!(input.config_file, "-");
+        for command in ["get", "delete"] {
+            let args = parse(&[command, "svc", "endpoint"]);
+            let target = match args.command {
+                QueryApiEndpointCommands::Get(target)
+                | QueryApiEndpointCommands::Delete(target) => target,
+                _ => panic!("target"),
+            };
+            assert_eq!(target.service_id, "svc");
+            assert_eq!(target.endpoint_id, "endpoint");
+        }
+    }
+
+    #[test]
+    fn query_api_endpoint_clap_pagination_defaults_and_bounds() {
+        let QueryApiEndpointCommands::List {
+            service_id,
+            cursor,
+            limit,
+        } = parse(&["list", "svc"]).command
+        else {
+            panic!("list")
+        };
+        assert_eq!(service_id, "svc");
+        assert!(cursor.is_none());
+        assert!(limit.is_none());
+        for limit_value in ["1", "100"] {
+            let QueryApiEndpointCommands::List { cursor, limit, .. } =
+                parse(&["list", "svc", "--cursor", "next+/=", "--limit", limit_value]).command
+            else {
+                panic!("list")
+            };
+            assert_eq!(cursor.as_deref(), Some("next+/="));
+            assert_eq!(limit, Some(limit_value.parse().unwrap()));
+        }
+        for value in ["-1", "0", "101", "not-a-number"] {
+            let error = Cli::try_parse_from([
+                "chctl",
+                "cloud",
+                "query-api-endpoint",
+                "list",
+                "svc",
+                "--limit",
+                value,
+            ])
+            .err()
+            .unwrap();
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+        let negative_equals = Cli::try_parse_from([
+            "chctl",
+            "cloud",
+            "query-api-endpoint",
+            "list",
+            "svc",
+            "--limit=-1",
+        ])
+        .err()
+        .unwrap();
+        assert_eq!(
+            negative_equals.kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+        for args in [vec!["create", "svc"], vec!["update", "svc", "endpoint"]] {
+            let mut command = vec!["chctl", "cloud", "query-api-endpoint"];
+            command.extend(args);
+            assert_eq!(
+                Cli::try_parse_from(command).err().unwrap().kind(),
+                clap::error::ErrorKind::MissingRequiredArgument
+            );
+        }
+    }
+}

--- a/crates/clickhousectl/src/cloud/query_api_endpoints.rs
+++ b/crates/clickhousectl/src/cloud/query_api_endpoints.rs
@@ -174,17 +174,19 @@ fn print_endpoints(data: QueryApiEndpointListResponse) {
         owner_type: String,
         url: String,
     }
-    if let Some(items) = data.items {
-        let rows = items.into_iter().map(|item| Row {
-            id: or_absent(item.id),
-            name: or_absent(item.name),
-            database: or_absent(item.database),
-            owner_type: or_absent(item.owner_type),
-            url: or_absent(item.url),
-        });
-        println!("{}", Table::new(rows).with(Style::rounded()));
-    } else {
-        println!("Query API endpoints: {ABSENT}");
+    match data.items {
+        Some(items) if items.is_empty() => println!("No Query API endpoints found"),
+        Some(items) => {
+            let rows = items.into_iter().map(|item| Row {
+                id: or_absent(item.id),
+                name: or_absent(item.name),
+                database: or_absent(item.database),
+                owner_type: or_absent(item.owner_type),
+                url: or_absent(item.url),
+            });
+            println!("{}", Table::new(rows).with(Style::rounded()));
+        }
+        None => println!("Query API endpoints: {ABSENT}"),
     }
     if let Some(cursor) = data
         .pagination

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -23602,6 +23602,34 @@ async fn query_api_endpoint_human_reads_tolerate_sparse_fields_and_show_next_cur
             "Query API endpoints: -\n"
         );
     }
+
+    let empty_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(QUERY_API_ENDPOINTS_PATH))
+        .respond_with(query_api_endpoint_envelope(
+            200,
+            serde_json::json!({
+                "items": [],
+                "pagination": {"nextCursor": "after-empty-page"}
+            }),
+        ))
+        .expect(1)
+        .mount(&empty_server)
+        .await;
+    let empty_project = tempfile::tempdir().unwrap();
+    let empty = invoke_query_api_endpoint(
+        &empty_server,
+        empty_project.path(),
+        false,
+        false,
+        &["list", "svc-1", "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&empty);
+    assert_eq!(
+        String::from_utf8_lossy(&empty.stdout),
+        "No Query API endpoints found\nNext cursor: after-empty-page\n"
+    );
 }
 
 #[tokio::test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -23170,3 +23170,625 @@ async fn service_settings_list_preserves_mixed_json_types_and_renders_sparse_row
         assert!(rows.contains(&expected), "missing {expected:?} in {stdout}");
     }
 }
+
+// Query API endpoint management (#766).
+
+const QUERY_API_ENDPOINTS_PATH: &str = "/v1/organizations/org-1/services/svc-1/query-api-endpoints";
+const QUERY_API_ENDPOINT_ID: &str = "11111111-2222-3333-8444-555555555555";
+const QUERY_API_KEY_ID: &str = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+fn query_api_endpoint_config() -> Value {
+    serde_json::json!({
+        "name": "orders",
+        "sql": "SELECT * FROM orders WHERE id = {id:String}",
+        "database": "analytics",
+        "parameters": {"id": "default-id", "region": "eu-west"},
+        "apiKeyIds": [QUERY_API_KEY_ID],
+        "roles": ["query_api", "reader"],
+        "allowedOrigins": []
+    })
+}
+
+fn query_api_endpoint_response() -> Value {
+    let mut response = query_api_endpoint_config();
+    response.as_object_mut().unwrap().extend(
+        serde_json::json!({
+            "id": QUERY_API_ENDPOINT_ID,
+            "url": format!("https://queries.clickhouse.cloud/run/{QUERY_API_ENDPOINT_ID}"),
+            "ownerType": "queryApiEndpoint"
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    response
+}
+
+fn invoke_query_api_endpoint(
+    server: &MockServer,
+    project: &Path,
+    oauth: bool,
+    json: bool,
+    args: &[&str],
+    stdin: Option<&str>,
+) -> std::process::Output {
+    let home = project.join("home");
+    let cloud_dir = home.join(".clickhouse");
+    std::fs::create_dir_all(&cloud_dir).unwrap();
+    if oauth {
+        write_oauth_tokens(&cloud_dir, &server.uri());
+    }
+    let mut command = Command::new(clickhousectl_binary());
+    clear_inherited_env(&mut command);
+    command
+        .env("HOME", home)
+        .env("DO_NOT_TRACK", "1")
+        .current_dir(project)
+        .args(["cloud", "--url", &server.uri()]);
+    if !oauth {
+        command.args([
+            "--api-key",
+            "query-endpoint-key",
+            "--api-secret",
+            "query-endpoint-secret",
+        ]);
+    }
+    if json {
+        command.arg("--json");
+    }
+    command.arg("query-api-endpoint").args(args);
+    if let Some(input) = stdin {
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .unwrap();
+        child.wait_with_output().unwrap()
+    } else {
+        command.stdin(Stdio::null()).output().unwrap()
+    }
+}
+
+fn query_api_endpoint_envelope(status: u16, result: Value) -> ResponseTemplate {
+    ResponseTemplate::new(status).set_body_json(serde_json::json!({
+        "status": status,
+        "requestId": "query-api-endpoint-request",
+        "result": result
+    }))
+}
+
+#[tokio::test]
+async fn query_api_endpoint_all_verbs_use_exact_routes_auth_and_complete_bodies() {
+    let server = MockServer::start().await;
+    let endpoint = query_api_endpoint_response();
+    let list = serde_json::json!({
+        "items": [{
+            "id": QUERY_API_ENDPOINT_ID,
+            "name": "orders",
+            "database": "analytics",
+            "apiKeyIds": [QUERY_API_KEY_ID],
+            "roles": ["query_api", "reader"],
+            "allowedOrigins": [],
+            "url": format!("https://queries.clickhouse.cloud/run/{QUERY_API_ENDPOINT_ID}"),
+            "ownerType": "queryApiEndpoint"
+        }],
+        "pagination": {"currentCursor": "current", "limit": 100, "totalRecords": 1}
+    });
+    for (verb, suffix, body, status, result) in [
+        (
+            "POST",
+            "",
+            Some(query_api_endpoint_config()),
+            201,
+            endpoint.clone(),
+        ),
+        (
+            "PUT",
+            QUERY_API_ENDPOINT_ID,
+            Some(query_api_endpoint_config()),
+            200,
+            endpoint.clone(),
+        ),
+        ("GET", "", None, 200, list.clone()),
+        ("GET", QUERY_API_ENDPOINT_ID, None, 200, endpoint.clone()),
+    ] {
+        let route = if suffix.is_empty() {
+            QUERY_API_ENDPOINTS_PATH.to_string()
+        } else {
+            format!("{QUERY_API_ENDPOINTS_PATH}/{suffix}")
+        };
+        let mut mock =
+            Mock::given(method(verb))
+                .and(path(route))
+                .and(wiremock::matchers::basic_auth(
+                    "query-endpoint-key",
+                    "query-endpoint-secret",
+                ));
+        if let Some(body) = body {
+            mock = mock.and(body_json(body));
+        }
+        mock.respond_with(query_api_endpoint_envelope(status, result))
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "{QUERY_API_ENDPOINTS_PATH}/{QUERY_API_ENDPOINT_ID}"
+        )))
+        .and(wiremock::matchers::basic_auth(
+            "query-endpoint-key",
+            "query-endpoint-secret",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200, "requestId": "query-api-endpoint-delete"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    let config_path = project.path().join("endpoint.json");
+    std::fs::write(&config_path, query_api_endpoint_config().to_string()).unwrap();
+    let create = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &[
+            "--org-id",
+            "org-1",
+            "create",
+            "svc-1",
+            "--config-file",
+            config_path.to_str().unwrap(),
+        ],
+        None,
+    );
+    assert_success(&create);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&create.stdout).unwrap(),
+        endpoint
+    );
+
+    let request_stdin = query_api_endpoint_config().to_string();
+    let update = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &[
+            "update",
+            "svc-1",
+            QUERY_API_ENDPOINT_ID,
+            "--config-file",
+            "-",
+            "--org-id",
+            "org-1",
+        ],
+        Some(&request_stdin),
+    );
+    assert_success(&update);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&update.stdout).unwrap(),
+        endpoint
+    );
+
+    let list_output = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &["list", "svc-1", "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&list_output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&list_output.stdout).unwrap(),
+        list
+    );
+    let get = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &["get", "svc-1", QUERY_API_ENDPOINT_ID, "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&get);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&get.stdout).unwrap(),
+        endpoint
+    );
+    let delete = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &[
+            "delete",
+            "svc-1",
+            QUERY_API_ENDPOINT_ID,
+            "--org-id",
+            "org-1",
+        ],
+        None,
+    );
+    assert_success(&delete);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&delete.stdout).unwrap(),
+        serde_json::json!({"status": 200, "requestId": "query-api-endpoint-delete"})
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 5);
+    let list_request = requests
+        .iter()
+        .find(|request| {
+            request.method == wiremock::http::Method::GET
+                && request.url.path() == QUERY_API_ENDPOINTS_PATH
+        })
+        .unwrap();
+    assert!(list_request.url.query().is_none());
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == wiremock::http::Method::GET)
+            .count(),
+        2,
+        "update must not prefetch the endpoint"
+    );
+}
+
+#[tokio::test]
+async fn query_api_endpoint_reads_support_oauth_and_preserve_reserved_list_cursor() {
+    let server = MockServer::start().await;
+    let result = serde_json::json!({
+        "items": [{}],
+        "pagination": {
+            "currentCursor": "page /+?",
+            "nextCursor": null,
+            "limit": 2,
+            "totalRecords": 3
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path(QUERY_API_ENDPOINTS_PATH))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(query_api_endpoint_envelope(200, result.clone()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "{QUERY_API_ENDPOINTS_PATH}/{QUERY_API_ENDPOINT_ID}"
+        )))
+        .and(header("authorization", "Bearer test-bearer-token"))
+        .respond_with(query_api_endpoint_envelope(200, serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let project = tempfile::tempdir().unwrap();
+    let list = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        true,
+        true,
+        &[
+            "list", "svc-1", "--cursor", "page /+?", "--limit", "2", "--org-id", "org-1",
+        ],
+        None,
+    );
+    assert_success(&list);
+    let mut expected = result;
+    expected["pagination"]
+        .as_object_mut()
+        .unwrap()
+        .remove("nextCursor");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&list.stdout).unwrap(),
+        expected
+    );
+    let get = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        true,
+        true,
+        &["get", "svc-1", QUERY_API_ENDPOINT_ID, "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&get);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&get.stdout).unwrap(),
+        serde_json::json!({})
+    );
+
+    let request = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|request| request.url.path() == QUERY_API_ENDPOINTS_PATH)
+        .unwrap();
+    let query: std::collections::HashMap<_, _> = request.url.query_pairs().into_owned().collect();
+    assert_eq!(query.get("cursor").map(String::as_str), Some("page /+?"));
+    assert_eq!(query.get("limit").map(String::as_str), Some("2"));
+}
+
+#[tokio::test]
+async fn query_api_endpoint_human_reads_tolerate_sparse_fields_and_show_next_cursor() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "{QUERY_API_ENDPOINTS_PATH}/{QUERY_API_ENDPOINT_ID}"
+        )))
+        .respond_with(query_api_endpoint_envelope(200, serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(QUERY_API_ENDPOINTS_PATH))
+        .respond_with(query_api_endpoint_envelope(
+            200,
+            serde_json::json!({
+                "items": [
+                    {},
+                    {
+                        "id": QUERY_API_ENDPOINT_ID,
+                        "name": "orders",
+                        "database": "analytics",
+                        "ownerType": "futureOwner",
+                        "url": "https://queries.clickhouse.cloud/run/example"
+                    }
+                ],
+                "pagination": {"nextCursor": "next /+?"}
+            }),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let project = tempfile::tempdir().unwrap();
+    let get = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        false,
+        &["get", "svc-1", QUERY_API_ENDPOINT_ID, "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&get);
+    assert_eq!(String::from_utf8_lossy(&get.stdout), "{}\n");
+    let list = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        false,
+        &["list", "svc-1", "--org-id", "org-1"],
+        None,
+    );
+    assert_success(&list);
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    for value in ["orders", "analytics", "futureOwner", "next /+?", "-"] {
+        assert!(stdout.contains(value), "missing {value}:\n{stdout}");
+    }
+
+    for result in [serde_json::json!({}), serde_json::json!({"items": null})] {
+        let sparse_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(QUERY_API_ENDPOINTS_PATH))
+            .respond_with(query_api_endpoint_envelope(200, result))
+            .expect(1)
+            .mount(&sparse_server)
+            .await;
+        let sparse_project = tempfile::tempdir().unwrap();
+        let output = invoke_query_api_endpoint(
+            &sparse_server,
+            sparse_project.path(),
+            false,
+            false,
+            &["list", "svc-1", "--org-id", "org-1"],
+            None,
+        );
+        assert_success(&output);
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "Query API endpoints: -\n"
+        );
+    }
+}
+
+#[tokio::test]
+async fn query_api_endpoint_delete_has_a_typed_human_confirmation() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "{QUERY_API_ENDPOINTS_PATH}/{QUERY_API_ENDPOINT_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200, "requestId": "delete-request"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let project = tempfile::tempdir().unwrap();
+    let output = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        false,
+        &[
+            "delete",
+            "svc-1",
+            QUERY_API_ENDPOINT_ID,
+            "--org-id",
+            "org-1",
+        ],
+        None,
+    );
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("Deleted Query API endpoint {QUERY_API_ENDPOINT_ID}\n")
+    );
+}
+
+#[tokio::test]
+async fn query_api_endpoint_invalid_configs_fail_before_org_discovery() {
+    let server = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    let valid = query_api_endpoint_config();
+    let cases = [
+        ("malformed.json", "{".to_string(), "parse"),
+        (
+            "unknown.json",
+            {
+                let mut body = valid.clone();
+                body["typo"] = serde_json::json!(true);
+                body.to_string()
+            },
+            "typo",
+        ),
+        ("missing.json", serde_json::json!({}).to_string(), "name"),
+    ];
+    for (file_name, body, expected) in cases {
+        let file = project.path().join(file_name);
+        std::fs::write(&file, body).unwrap();
+        let output = invoke_query_api_endpoint(
+            &server,
+            project.path(),
+            false,
+            true,
+            &["create", "svc-1", "--config-file", file.to_str().unwrap()],
+            None,
+        );
+        assert_eq!(output.status.code(), Some(1), "{file_name}");
+        assert!(output.stdout.is_empty(), "{file_name}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(expected), "{file_name}: {stderr}");
+    }
+    let missing_file = project.path().join("does-not-exist.json");
+    let output = invoke_query_api_endpoint(
+        &server,
+        project.path(),
+        false,
+        true,
+        &[
+            "update",
+            "svc-1",
+            QUERY_API_ENDPOINT_ID,
+            "--config-file",
+            missing_file.to_str().unwrap(),
+        ],
+        None,
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("does-not-exist.json"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn query_api_endpoint_writes_reject_oauth_before_config_or_http() {
+    let server = MockServer::start().await;
+    for args in [
+        vec!["create", "svc-1", "--config-file", "does-not-exist.json"],
+        vec![
+            "update",
+            "svc-1",
+            QUERY_API_ENDPOINT_ID,
+            "--config-file",
+            "does-not-exist.json",
+        ],
+        vec!["delete", "svc-1", QUERY_API_ENDPOINT_ID],
+    ] {
+        let project = tempfile::tempdir().unwrap();
+        let output = invoke_query_api_endpoint(&server, project.path(), true, true, &args, None);
+        assert_eq!(output.status.code(), Some(4), "{args:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("API key"),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn query_api_endpoint_list_rejects_limits_outside_one_to_one_hundred() {
+    let server = MockServer::start().await;
+    let project = tempfile::tempdir().unwrap();
+    for args in [
+        vec!["list", "svc-1", "--limit", "0", "--org-id", "org-1"],
+        vec!["list", "svc-1", "--limit", "101", "--org-id", "org-1"],
+        vec!["list", "svc-1", "--limit", "-1", "--org-id", "org-1"],
+        vec!["list", "svc-1", "--limit=-1", "--org-id", "org-1"],
+    ] {
+        let output = invoke_query_api_endpoint(&server, project.path(), false, true, &args, None);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+    }
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn query_api_endpoint_api_errors_preserve_auth_and_generic_exit_codes() {
+    for (verb, status, expected_exit) in [("GET", 403, 4), ("PUT", 409, 1), ("PUT", 500, 1)] {
+        let server = MockServer::start().await;
+        let project = tempfile::tempdir().unwrap();
+        let config_path = project.path().join("endpoint.json");
+        std::fs::write(&config_path, query_api_endpoint_config().to_string()).unwrap();
+        let mut mock = Mock::given(method(verb))
+            .and(path(format!(
+                "{QUERY_API_ENDPOINTS_PATH}/{QUERY_API_ENDPOINT_ID}"
+            )))
+            .and(wiremock::matchers::basic_auth(
+                "query-endpoint-key",
+                "query-endpoint-secret",
+            ));
+        if verb == "PUT" {
+            mock = mock.and(body_json(query_api_endpoint_config()));
+        }
+        let error = format!("query endpoint failure {status}");
+        mock.respond_with(
+            ResponseTemplate::new(status).set_body_json(serde_json::json!({
+                "status": status,
+                "requestId": "query-api-endpoint-error",
+                "error": error
+            })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+        let args = if verb == "GET" {
+            vec!["get", "svc-1", QUERY_API_ENDPOINT_ID, "--org-id", "org-1"]
+        } else {
+            vec![
+                "update",
+                "svc-1",
+                QUERY_API_ENDPOINT_ID,
+                "--config-file",
+                config_path.to_str().unwrap(),
+                "--org-id",
+                "org-1",
+            ]
+        };
+        let output = invoke_query_api_endpoint(&server, project.path(), false, true, &args, None);
+        assert_eq!(output.status.code(), Some(expected_exit), "{verb} {status}");
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(&error),
+            "{verb} {status}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+}

--- a/scripts/classify-cloud-integration.py
+++ b/scripts/classify-cloud-integration.py
@@ -16,6 +16,7 @@ NO_SUITES = frozenset()
 SOURCE_PATH_SUITES = {
     "crates/clickhousectl/src/cloud/clickstack.rs": NO_SUITES,
     "crates/clickhousectl/src/cloud/config.rs": NO_SUITES,
+    "crates/clickhousectl/src/cloud/query_api_endpoints.rs": NO_SUITES,
     "crates/clickhousectl/src/cloud/udfs.rs": NO_SUITES,
     "crates/clickhouse-cloud-api/src/client.rs": ALL_SUITES,
     "crates/clickhouse-cloud-api/src/client/activity.rs": frozenset({"organization"}),

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -46,6 +46,7 @@ NON_INSTALL_EXACT_PATHS = frozenset(
         "crates/clickhouse-cloud-api/src/models/query_api_endpoints.rs",
         "crates/clickhousectl/src/cloud/clickstack.rs",
         "crates/clickhousectl/src/cloud/config.rs",
+        "crates/clickhousectl/src/cloud/query_api_endpoints.rs",
         "crates/clickhousectl/src/cloud/udfs.rs",
         "crates/clickhousectl/src/dotenv.rs",
         "crates/clickhousectl/src/failure.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -120,6 +120,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
                     "crates/clickhouse-cloud-api/src/models/query_api_endpoints.rs",
                     "crates/clickhousectl/src/cloud/clickstack.rs",
                     "crates/clickhousectl/src/cloud/config.rs",
+                    "crates/clickhousectl/src/cloud/query_api_endpoints.rs",
                     "crates/clickhousectl/src/cloud/udfs.rs",
                     "crates/clickhousectl/src/dotenv.rs",
                     "crates/clickhousectl/src/failure.rs",


### PR DESCRIPTION
Add `cloud query-api-endpoint` commands for create, get, list, update, and delete, exposing the beta endpoint-management methods added in #865.

Create/update read a complete JSON definition from `--config-file PATH` or stdin (`-`). They reject malformed, unknown, missing, or invalid fields before organization discovery; update replaces the definition, with omitted optional fields reset to defaults. List supports cursor pagination and limits of 1–100, preserving the pagination object in JSON and displaying the next cursor in human output. Detail output follows the shared tolerant renderer; empty lists print a friendly message rather than an unfinished table. Writes require API key authentication; list/get also support OAuth.

The new domain goes through `CloudClient` wrappers and leaves the existing `cloud service query-endpoint` binding commands intact. README examples explain both surfaces, database roles, writable fields, replacement behavior, curl execution and CORS semantics. The new module is classified explicitly in both CI path classifiers.

Refs #766. Depends on #865 and appends to GitHub stack #769.

Validation:
- Focused clap and request-builder tests cover command targets, org flag placement, read/write classification, pagination bounds, required/minimal/maximal JSON bodies, and input constraints.
- Real CLI subprocess tests against wiremock cover requests, file/stdin handling, pre-discovery failures, OAuth policy, API errors, and sparse human/JSON output.
- Passed: `cargo fmt --all`; default CLI Clippy; telemetry-disabled check and all-target Clippy; full CLI suite (1,837 passed, four existing ignored); all 91 Python/classifier tests. Python fixture commits used signing disabled.
- One initial full-suite run hit the existing five-second mock EOF timeout in `file_and_stdin_preserve_psql_error_status`; the isolated retry and complete suite rerun passed. No local Postgres code or tests were changed.
- API prerequisite #865's live service lifecycle, including endpoint CRUD and pagination, passed in https://github.com/ClickHouse/clickhousectl/actions/runs/34686771040. The CLI companion also received the manual real-Cloud validation described below.

Manual real-Cloud validation (12 September 2026):
- Built the PR release binary, installed it as the local system `clickhousectl`, authenticated from the project directory, and created a temporary AWS eu-west-1 service with synthetic tables and three named endpoints.
- Exercised all five management operations, file/stdin input, three-page pagination, full replacement/reset behavior, API-key binding changes, JSON/human output, help screens and invalid configurations through the installed CLI.
- Executed the returned URLs with curl: GET/POST parameters (numbers, strings, booleans, arrays, dates, Unicode and injection-like literals), data correctness, JSONEachRow/CSV output, attempted SQL override, restricted/admin database roles, missing/incorrect/unbound/disabled credentials, exact/empty/wildcard allowed origins, positive/negative preflights and post-delete 404s.
- Live review found an empty human-list rendering issue; fixed it with a subprocess regression. Rebuilt/reinstalled the final binary and verified the corrected output against Cloud. Full CLI suite passed again (1,837 passed, four ignored), along with both Clippy configurations and telemetry-disabled build.

Observed runtime findings (outside this CLI's management implementation):
- Stored parameter defaults are returned by management GET but not applied during execution: missing/partial parameters return 400 / ClickHouse 456. Explicit parameters work. README now instructs callers to supply every placeholder.
- Malformed execution JSON returned HTTP 500.
- `Origin: null` with an explicit allowlist timed out after 45 seconds for GET and preflight on two attempts; wildcard origins succeeded. Cause unconfirmed. Other disallowed origins omitted CORS headers as expected. These were HTTP probes, not automated browser tests.
- A disabled key was still accepted immediately, but rejected by the 30-second probe and at 60/120 seconds; management GET confirmed disabled throughout. This demonstrates a propagation window, not an exact TTL.
- UInt32 overflow (`4294967296`) returned 0; negative and non-numeric inputs returned 400.

This was manual validation, not an additional automated cloud suite. OAuth and user-owned endpoint management were not exercised live in this API-key session.

Cleanup verified: all three endpoints, the temporary service and all four created keys (including the auto-provisioned query key) were deleted. Final service/key IDs exactly match the pre-test inventories; temporary local service-query credentials were removed. Project authentication remains configured.
