### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.4.2", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.5.0", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.5.0"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
Bump the release version from `0.4.2` to `0.5.0` in the CLI crate, API library, CLI API dependency, Cargo.lock, and npm package. PyPI derives its version from the CLI manifest.

Six version substitutions across four files. This is the final PR on stack #769, based on #866.

Closes #867.

Validation: formatting, both CLI Clippy configurations, the no-default-features build, library Clippy, CLI tests, library/analyzer tests, and 91 Python tests. All six version references and PyPI's dynamic version source agree. One telemetry pipe test failed on the first run; all 50 tests in that binary passed on rerun.
