### PR TITLE
fix(cloud): reject malformed resource tag filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,10 @@ clickhousectl cloud org usage \
 `org get` and `org update` still accept the legacy positional organization ID.
 Prefer `--org-id` in new commands; supplying both forms is a usage error (exit 2).
 
+`cloud service list` and `cloud org usage` accept repeatable `--filter tag:KEY=VALUE`
+or `--filter tag:KEY` (tag existence). A missing `tag:` prefix or empty key is a
+usage error (exit 2), rejected before authentication or HTTP requests.
+
 BYOC create, update, and delete require API key authentication. Update requires
 `--display-name`, so it cannot send an empty/no-op patch. The API has no separate
 BYOC list command; `cloud org get` returns the organization's `byocConfig` entries.

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,7 +1,7 @@
 use crate::cloud::client::{CloudClient, CloudError, ResourceLookup, Result as CloudResult};
 use crate::cloud::config::read_typed_config;
 use crate::cloud::output::{ABSENT, or_absent, print_human};
-use crate::cloud::shared::{parse_date_only, resolve_org_id};
+use crate::cloud::shared::{parse_date_only, parse_tag_filter, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
@@ -136,8 +136,8 @@ CONTEXT FOR AGENTS:
         #[arg(long, value_parser = parse_date_only)]
         to_date: String,
 
-        /// Filter by resource tag: `tag:Key=Value` or `tag:Key` (repeatable)
-        #[arg(long)]
+        /// Filter by resource tag: `tag:KEY=VALUE` or `tag:KEY` (repeatable)
+        #[arg(long, value_parser = parse_tag_filter)]
         filter: Vec<String>,
     },
 }
@@ -2266,6 +2266,50 @@ mod tests {
         assert_eq!(legacy_org_id, None);
         assert_eq!(from_date, "2025-01-01");
         assert_eq!(to_date, "2025-01-31");
+    }
+
+    #[test]
+    fn org_usage_tag_filters_preserve_api_grammar() {
+        let base_args = [
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ];
+        let filters = ["tag:env=prod", "tag:active", "tag:empty=", "tag:expr=a=b"];
+        let cli = Cli::try_parse_from(
+            base_args
+                .into_iter()
+                .chain(filters.iter().flat_map(|value| ["--filter", *value])),
+        )
+        .unwrap();
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org {
+            command: OrgCommands::Usage { filter, .. },
+        } = args.command
+        else {
+            panic!("expected org usage");
+        };
+        assert_eq!(filter, filters);
+        for value in [
+            "garbage",
+            "state=running",
+            "env=prod",
+            "tag:",
+            "tag:=x",
+            "tag: =x",
+        ] {
+            let error = Cli::try_parse_from(base_args.into_iter().chain(["--filter", value]))
+                .err()
+                .expect("malformed filter must fail");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -9,7 +9,9 @@ use crate::cloud::output::{
     ABSENT, CloudErrorCode, CloudErrorDetail, eprint_line, or_absent, print_human, print_line,
 };
 use crate::cloud::service_query::{RepairVerification, existing_open_api_keys};
-use crate::cloud::shared::{parse_ip_access_entries, parse_serde_enum, parse_tags, resolve_org_id};
+use crate::cloud::shared::{
+    parse_ip_access_entries, parse_serde_enum, parse_tag_filter, parse_tags, resolve_org_id,
+};
 use crate::cloud::types::DeleteResponse;
 use crate::failure::{self, ApiFailure, FailureKind, FailureStage, ProvisioningState};
 use clap::builder::PossibleValuesParser;
@@ -65,8 +67,8 @@ pub enum ServiceCommands {
         #[arg(long)]
         org_id: Option<String>,
 
-        /// Filter by resource tag, e.g. "tag:env=production" (repeatable)
-        #[arg(long)]
+        /// Filter by resource tag: `tag:KEY=VALUE` or `tag:KEY` (repeatable)
+        #[arg(long, value_parser = parse_tag_filter)]
         filter: Vec<String>,
     },
 
@@ -4860,6 +4862,44 @@ mod tests {
         };
         assert_eq!(org_id.as_deref(), Some("org-1"));
         assert_eq!(filter, vec!["tag:env=prod", "tag:team=analytics"]);
+    }
+
+    #[test]
+    fn service_list_tag_filters_preserve_api_grammar() {
+        for value in ["tag:env=prod", "tag:active", "tag:empty=", "tag:expr=a=b"] {
+            let command = parse_service(&[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "list",
+                "--filter",
+                value,
+            ]);
+            let ServiceCommands::List { filter, .. } = command else {
+                panic!("expected service list");
+            };
+            assert_eq!(filter, [value]);
+        }
+        for value in [
+            "garbage",
+            "state=running",
+            "env=prod",
+            "tag:",
+            "tag:=x",
+            "tag: =x",
+        ] {
+            let error = Cli::try_parse_from([
+                "clickhousectl",
+                "cloud",
+                "service",
+                "list",
+                "--filter",
+                value,
+            ])
+            .err()
+            .expect("malformed filter must fail");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/shared.rs
+++ b/crates/clickhousectl/src/cloud/shared.rs
@@ -78,6 +78,21 @@ pub(super) fn parse_tags(values: &[String]) -> CloudResult<Option<Vec<ResourceTa
     }
 }
 
+/// Validate the API's equality and existence tag filters without changing the
+/// key or value sent on the wire. Tag values may be empty or contain `=`.
+pub(super) fn parse_tag_filter(value: &str) -> Result<String, String> {
+    let key = value
+        .strip_prefix("tag:")
+        .map(|tag| tag.split_once('=').map_or(tag, |(key, _)| key));
+    if key.is_none_or(|key| key.trim().is_empty()) {
+        return Err(
+            "expected tag:KEY=VALUE or tag:KEY with a nonempty key (e.g. tag:env=production)"
+                .to_string(),
+        );
+    }
+    Ok(value.to_string())
+}
+
 /// Parse an IP allowlist argument in `SOURCE[=DESCRIPTION]` form.
 ///
 /// `=` keeps the description delimiter unambiguous for IPv6 sources. The

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -5220,6 +5220,87 @@ async fn org_usage_auto_detects_the_only_organization() {
 }
 
 #[tokio::test]
+async fn tag_filters_reject_malformed_values_before_auth_or_http() {
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    for mut args in [
+        vec!["service", "list"],
+        vec![
+            "org",
+            "usage",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ],
+    ] {
+        args.extend(["--filter", "tag:env=prod", "--filter", "garbage"]);
+        let mut command = Command::new(clickhousectl_binary());
+        clear_inherited_env(&mut command);
+        let output = command
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", dir.path())
+            .current_dir(dir.path())
+            .args(["cloud", "--url", &mock.uri(), "--json"])
+            .args(args)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("tag:KEY"));
+    }
+    assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn tag_filters_preserve_repeated_equality_and_existence_filters_on_wire() {
+    let mock = MockServer::start().await;
+    for endpoint in ["services", "usageCost"] {
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/organizations/org-1/{endpoint}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": 200,
+                "result": if endpoint == "services" { serde_json::json!([]) } else { serde_json::json!({}) }
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+    }
+    let filters = [
+        "tag:env=prod",
+        "tag:active",
+        "tag:empty=",
+        "tag:expression=a=b & c",
+    ];
+    for mut args in [
+        vec!["service", "list"],
+        vec![
+            "org",
+            "usage",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ],
+    ] {
+        args.extend(["--org-id", "org-1"]);
+        args.extend(filters.iter().flat_map(|value| ["--filter", *value]));
+        assert_success(&invoke_cli_with_cloud_credentials(&mock, &args));
+    }
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    for request in requests {
+        let actual: Vec<_> = request
+            .url
+            .query_pairs()
+            .filter(|(key, _)| key == "filter")
+            .map(|(_, value)| value.into_owned())
+            .collect();
+        assert_eq!(actual, filters);
+    }
+}
+
+#[tokio::test]
 async fn org_prometheus_accepts_legacy_positional_org_id() {
     let mock = start_mock_org_auto_detection_api().await;
     let output =


### PR DESCRIPTION
`cloud service list` and `cloud org usage` now reject filters without `tag:` or with an empty key during clap parsing, before authentication or HTTP. This prevents a malformed filter from returning an unfiltered result set.

Preserve the API's existing equality (`tag:KEY=VALUE`) and existence (`tag:KEY`) forms, repeated filters, and exact value bytes, including empty values and embedded `=`. The vendored OpenAPI explicitly documents existence filters, so these remain accepted despite the issue's narrower initial proposal. Both help screens and README describe the accepted grammar.

Closes #830.

Validation: clap regressions for both commands; real-binary wiremock checks for early rejection without credentials/requests and exact repeated query parameters. Combined stack validation passed formatting, default CLI Clippy and 1,846 passing CLI tests (four existing ignored), telemetry-disabled check/all-target Clippy, and all 91 Python/classifier tests.

Appended above #868 in stack #769. No existing stack commits were rewritten.
