### PR TITLE
fix(postgres): preserve tags on name and size updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,7 +1210,9 @@ clickhousectl cloud postgres update <pg-id> \
 clickhousectl cloud postgres update <pg-id> --clear-tags
 
 # --clear-tags replaces the tag list with an empty list and conflicts with
-# --add-tag and --remove-tag; omitting all three leaves tags unchanged.
+# --add-tag and --remove-tag; omitting all three preserves the fetched tags.
+# Updates read the complete tag list first (except --clear-tags) and fail if it
+# cannot be read safely. Avoid concurrent tag changes: PATCH replaces that snapshot.
 
 # Delete (works from any state, including running; no stop needed first)
 clickhousectl cloud postgres delete <pg-id>

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1234,7 +1234,7 @@ fn merge_tags(
     merged
 }
 
-/// Merges `--add-tag`/`--remove-tag` against the tag list a GET returned.
+/// Preserves or merges the tag list a GET returned before every update.
 ///
 /// An omitted `tags` in the response is indistinguishable from a field the API
 /// dropped, so a read-modify-write must not proceed on it: `tags` is replaced
@@ -1248,9 +1248,9 @@ fn merge_response_tags(
 ) -> CloudResult<Vec<ResourceTagsV1>> {
     let current = current.ok_or_else(|| {
         CloudError::new(
-            "the API response omitted the tags field, so --add-tag/--remove-tag cannot be merged \
-             safely: an update replaces the tag set wholesale, and merging against an assumed empty \
-             set would delete any tags the service already has",
+            "the API response omitted the tags field or returned null, so the update cannot preserve \
+             tags safely: an update replaces the tag set wholesale, and assuming an empty set \
+             would delete any tags the service already has",
         )
     })?;
     let existing = current
@@ -1644,10 +1644,11 @@ pub async fn postgres_update(
         .transpose()?;
 
     // Clearing is already a complete replacement, so it never needs a GET.
-    // Add/remove still merges against a complete current tag snapshot.
+    // The API clears tags when PATCH omits them, even for a rename or resize.
+    // Every other update must preserve a complete current tag snapshot.
     let tags = if opts.clear_tags {
         Some(Vec::new())
-    } else if !opts.add_tag.is_empty() || !opts.remove_tag.is_empty() {
+    } else {
         let current = client
             .api()
             .postgres_service_get(&org_id, postgres_id)
@@ -1656,8 +1657,6 @@ pub async fn postgres_update(
         let current = unwrap_api(current)?;
         let add = parse_tags(opts.add_tag)?.unwrap_or_default();
         Some(merge_response_tags(current.tags, &add, opts.remove_tag)?)
-    } else {
-        None
     };
 
     let req = build_postgres_update_request(opts.name, size, ha_type, tags);

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3675,59 +3675,113 @@ async fn postgres_delete_json_emits_the_resource_object_not_the_envelope() {
 
 // ── Postgres update --name (issue #663) ────────────────────────────────────
 
-/// `postgres update --name` must PATCH the API with only `name` set: no
-/// `size`, `haType`, or `tags` key should appear when only `--name` is
-/// passed, and no discovery `GET` is issued (no tag diff was requested).
+/// Non-tag updates must echo the current tag snapshot while omitting unrelated
+/// update fields. An empty list is known empty; key-only and empty-value tags
+/// remain distinct under the API model's optional-value contract.
 #[tokio::test]
-async fn postgres_update_name_sends_only_the_name_field() {
-    let mock = MockServer::start().await;
-    let postgres_id = "11111111-2222-3333-4444-555555555555";
-    Mock::given(method("PATCH"))
-        .and(path(format!(
-            "/v1/organizations/org-1/postgres/{postgres_id}"
-        )))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "result": {
-                "id": postgres_id,
-                "name": "renamed-pg",
-                "state": "running",
-            },
-            "status": 200,
-            "requestId": "stub-postgres-update",
-        })))
-        .expect(1)
-        .mount(&mock)
-        .await;
+async fn postgres_update_preserves_tags_when_changing_other_fields() {
+    for (flag, field, value) in [
+        ("--name", "name", "renamed-pg"),
+        ("--size", "size", "c6gd.large"),
+        ("--ha-type", "haType", "async"),
+    ] {
+        for tags in [
+            serde_json::json!([]),
+            serde_json::json!([
+                {"key": "env", "value": "prod"},
+                {"key": "owner", "value": "me"},
+                {"key": "key-only"},
+                {"key": "empty", "value": ""}
+            ]),
+        ] {
+            let mock = MockServer::start().await;
+            let postgres_id = "11111111-2222-3333-4444-555555555555";
+            let postgres_path = format!("/v1/organizations/org-1/postgres/{postgres_id}");
+            Mock::given(method("GET"))
+                .and(path(&postgres_path))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": {"id": postgres_id, "tags": tags},
+                })))
+                .expect(1)
+                .mount(&mock)
+                .await;
+            let expected_body = serde_json::json!({field: value, "tags": tags});
+            Mock::given(method("PATCH"))
+                .and(path(&postgres_path))
+                .and(body_json(expected_body))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": {"id": postgres_id, "tags": tags},
+                })))
+                .expect(1)
+                .mount(&mock)
+                .await;
+            let output = invoke_cli_with_cloud_credentials(
+                &mock,
+                &[
+                    "postgres",
+                    "update",
+                    postgres_id,
+                    "--org-id",
+                    "org-1",
+                    flag,
+                    value,
+                ],
+            );
+            assert_success(&output);
+            assert_eq!(
+                received_request_shape(&mock).await,
+                vec![
+                    ("GET".into(), postgres_path.clone()),
+                    ("PATCH".into(), postgres_path)
+                ]
+            );
+            let output: Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(output["tags"], tags);
+        }
+    }
+}
 
-    let output = invoke_cli_with_cloud_credentials(
-        &mock,
-        &[
-            "postgres",
-            "update",
-            postgres_id,
-            "--org-id",
-            "org-1",
-            "--name",
-            "renamed-pg",
-        ],
-    );
-
-    assert_success(&output);
-
-    let requests = mock.received_requests().await.unwrap();
-    assert_eq!(
-        requests.len(),
-        1,
-        "expected only the PATCH, no discovery GET"
-    );
-    assert_eq!(requests[0].method, wiremock::http::Method::PATCH);
-
-    let body: Value = serde_json::from_slice(&requests[0].body).expect("PATCH body wasn't JSON");
-    assert_eq!(body["name"], "renamed-pg");
-    assert!(
-        body.get("size").is_none() && body.get("haType").is_none() && body.get("tags").is_none(),
-        "unexpected keys in PATCH body: {body}"
-    );
+#[tokio::test]
+async fn postgres_update_without_tag_flags_refuses_incomplete_or_failed_reads() {
+    for response in [
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": {}})),
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": {"tags": null}})),
+        ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({"result": {"tags": [{"value": "prod"}]}})),
+        ResponseTemplate::new(200).set_body_json(
+            serde_json::json!({"result": {"tags": [{"key": null, "value": "prod"}]}}),
+        ),
+        ResponseTemplate::new(403).set_body_json(serde_json::json!({"error": "forbidden"})),
+        ResponseTemplate::new(500).set_body_json(serde_json::json!({"error": "read failed"})),
+    ] {
+        let mock = MockServer::start().await;
+        let postgres_id = "11111111-2222-3333-4444-555555555555";
+        let postgres_path = format!("/v1/organizations/org-1/postgres/{postgres_id}");
+        Mock::given(method("GET"))
+            .and(path(&postgres_path))
+            .respond_with(response)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "postgres",
+                "update",
+                postgres_id,
+                "--org-id",
+                "org-1",
+                "--name",
+                "renamed",
+            ],
+        );
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            received_request_shape(&mock).await,
+            vec![("GET".into(), postgres_path)]
+        );
+    }
 }
 
 // ── Postgres list --filter validation (issue #603) ────────────────────────


### PR DESCRIPTION
Postgres name, size and HA-only updates previously omitted `tags`, which the deployed API treats as clearing the tag list. Every update except explicit `--clear-tags` now fetches and preserves the complete current tag snapshot, applying requested tag additions/removals to it.

Missing/null tag lists, incomplete tag identities and failed reads prevent PATCH. Key-only and empty-string-valued tags retain their distinct representations; explicit clearing still needs no GET. README documents that the API replaces the snapshot, so concurrent tag changes can still race with an update.

Closes #827.

Validation: real-binary wiremock coverage for name/size/HA changes against empty/populated tags, missing/null response fields, failed reads, additions/removals and explicit clearing. Focused merge tests passed. Combined stack validation passed formatting, default CLI Clippy and 1,846 passing CLI tests (four existing ignored), telemetry-disabled check/all-target Clippy, and all 91 Python/classifier tests. The deployed backend effect was established in the issue; this change was verified locally against mocks, without modifying a live service.

Appended in stack #769. No existing stack commits were rewritten.
