### PR TITLE
fix(clickpipes): show source and destination in list table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,8 @@ Every ClickPipe `--auth` flag lists its accepted canonical modes in `--help`.
 
 Manage ClickPipes for ingesting data into ClickHouse Cloud from external sources. See the [ClickPipes documentation](https://clickhouse.com/docs/integrations/clickpipes).
 
+`clickpipe list` displays a table with name, ID, source kind, destination and state. The destination shows `database.table`, or the available component when only one is returned; absent values display as `-`. With `--json` or coding-agent detection, the command retains the API-shaped JSON array.
+
 ```bash
 # List ClickPipes for a service
 clickhousectl cloud clickpipe list <service-id>

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -2,7 +2,7 @@ use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::config::{
     config_source_label, deserialize_strict_config, read_config_value, read_typed_config,
 };
-use crate::cloud::output::{or_absent, print_human};
+use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, resolve_org_id};
 use clap::builder::{PossibleValue, PossibleValuesParser, TypedValueParser};
 use clap::{ArgGroup, Args, Subcommand};
@@ -2129,15 +2129,47 @@ async fn clickpipe_list(
     } else if clickpipes.is_empty() {
         println!("No ClickPipes found");
     } else {
-        println!("ClickPipes:");
-        for clickpipe in &clickpipes {
-            println!(
-                "  {} ({}) - {}",
-                or_absent(clickpipe.name.as_deref()),
-                or_absent(clickpipe.id.as_ref()),
-                or_absent(clickpipe.state.as_ref())
-            );
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Name")]
+            name: String,
+            #[tabled(rename = "ID")]
+            id: String,
+            #[tabled(rename = "Source")]
+            source: &'static str,
+            #[tabled(rename = "Destination")]
+            destination: String,
+            #[tabled(rename = "State")]
+            state: String,
         }
+        let rows = clickpipes.iter().map(|clickpipe| {
+            let destination = clickpipe.destination.as_ref();
+            let database = destination.and_then(|destination| destination.database.as_deref());
+            let table = destination.and_then(|destination| destination.table.as_deref());
+            Row {
+                name: or_absent(clickpipe.name.as_deref()),
+                id: or_absent(clickpipe.id.as_ref()),
+                source: match classify_clickpipe_source(clickpipe) {
+                    ClickPipeSourceKind::Kafka => "Kafka",
+                    ClickPipeSourceKind::Kinesis => "Kinesis",
+                    ClickPipeSourceKind::PubSub => "Pub/Sub",
+                    ClickPipeSourceKind::ObjectStorage => "Object storage",
+                    ClickPipeSourceKind::Postgres => "Postgres",
+                    ClickPipeSourceKind::MySql => "MySQL",
+                    ClickPipeSourceKind::MongoDb => "MongoDB",
+                    ClickPipeSourceKind::BigQuery => "BigQuery",
+                    ClickPipeSourceKind::Absent => ABSENT,
+                },
+                destination: match (database, table) {
+                    (Some(database), Some(table)) => format!("{database}.{table}"),
+                    (Some(database), None) => database.to_string(),
+                    (None, Some(table)) => table.to_string(),
+                    (None, None) => ABSENT.to_string(),
+                },
+                state: or_absent(clickpipe.state.as_ref()),
+            }
+        });
+        println!("{}", Table::new(rows).with(Style::markdown()));
     }
     Ok(())
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -23955,3 +23955,133 @@ async fn query_api_endpoint_api_errors_preserve_auth_and_generic_exit_codes() {
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 }
+
+#[tokio::test]
+async fn clickpipe_list_renders_source_destination_table_and_preserves_json() {
+    let mock = MockServer::start().await;
+    let sources = [
+        ("objectStorage", "Object storage"),
+        ("kafka", "Kafka"),
+        ("kinesis", "Kinesis"),
+        ("pubsub", "Pub/Sub"),
+        ("postgres", "Postgres"),
+        ("mysql", "MySQL"),
+        ("mongodb", "MongoDB"),
+        ("bigquery", "BigQuery"),
+    ];
+    let mut pipes: Vec<Value> = sources
+        .iter()
+        .enumerate()
+        .map(|(index, (source, _))| {
+            serde_json::json!({
+                "id": format!("00000000-0000-0000-0000-{index:012}"),
+                "name": format!("pipe-{index}"),
+                "source": { *source: {} },
+                "destination": { "database": "analytics", "table": format!("events_{index}") },
+                "state": "Running"
+            })
+        })
+        .collect();
+    pipes.extend([
+        serde_json::json!({}),
+        serde_json::json!({"source": {}, "destination": {}}),
+        serde_json::json!({"destination": {"database": "database_only"}, "state": "FutureState"}),
+        serde_json::json!({"destination": {"table": "table_only"}}),
+    ]);
+    let result = serde_json::json!(pipes);
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes"))
+        .and(header(
+            "authorization",
+            "Basic ZmFrZS1rZXktZm9yLXRlc3RzOmZha2Utc2VjcmV0LWZvci10ZXN0cw==",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": result})),
+        )
+        .expect(3)
+        .mount(&mock)
+        .await;
+    let args = ["clickpipe", "list", "svc-1", "--org-id", "org-1"];
+    let human = invoke_cli_with_cloud_credentials_human(&mock, &args);
+    assert_success(&human);
+    let stdout = String::from_utf8(human.stdout).unwrap();
+    let rows: Vec<Vec<&str>> = stdout
+        .lines()
+        .map(|line| line.trim_matches('|').split('|').map(str::trim).collect())
+        .collect();
+    assert_eq!(rows.len(), pipes.len() + 2, "{stdout}");
+    assert_eq!(rows[0], ["Name", "ID", "Source", "Destination", "State"]);
+    for (index, (_, label)) in sources.iter().enumerate() {
+        assert_eq!(
+            rows[index + 2],
+            [
+                format!("pipe-{index}"),
+                format!("00000000-0000-0000-0000-{index:012}"),
+                label.to_string(),
+                format!("analytics.events_{index}"),
+                "Running".to_string(),
+            ],
+            "{stdout}"
+        );
+    }
+    assert_eq!(rows[10], ["-", "-", "-", "-", "-"]);
+    assert_eq!(rows[11], ["-", "-", "-", "-", "-"]);
+    assert_eq!(rows[12], ["-", "-", "-", "database_only", "FutureState"]);
+    assert_eq!(rows[13], ["-", "-", "-", "table_only", "-"]);
+
+    let explicit = invoke_cli_with_cloud_credentials(&mock, &args);
+    assert_success(&explicit);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&explicit.stdout).unwrap(),
+        result
+    );
+
+    let project = tempfile::tempdir().unwrap();
+    let home = project.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let agent = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("AI_AGENT", "1")
+        .env("HOME", home)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(project.path())
+        .args(["cloud", "--url", &mock.uri()])
+        .args(args)
+        .output()
+        .unwrap();
+    assert_success(&agent);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&agent.stdout).unwrap(),
+        result
+    );
+    for request in mock.received_requests().await.unwrap() {
+        assert_eq!(request.url.query(), None);
+        assert!(request.body.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn clickpipe_list_empty_results_keep_human_message_and_json_array() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": []})))
+        .expect(2)
+        .mount(&mock)
+        .await;
+    let args = ["clickpipe", "list", "svc-1", "--org-id", "org-1"];
+    let human = invoke_cli_with_cloud_credentials_human(&mock, &args);
+    assert_success(&human);
+    assert_eq!(
+        String::from_utf8(human.stdout).unwrap(),
+        "No ClickPipes found\n"
+    );
+    let json = invoke_cli_with_cloud_credentials(&mock, &args);
+    assert_success(&json);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&json.stdout).unwrap(),
+        serde_json::json!([])
+    );
+}


### PR DESCRIPTION
`cloud clickpipe list` now shows a table with Name, ID, Source, Destination and State, replacing the bullet list. All eight supported source kinds are identified, destination displays `database.table` or the available component, and absent fields display `-`.

Explicit JSON and coding-agent output retain the API-shaped array. Empty human lists retain their existing message. README documents the human/JSON behavior.

Closes #843.

Validation: real-binary wiremock regressions cover all source kinds, sparse responses, partial destinations, unknown future states, empty lists, explicit JSON and agent-detected JSON. Combined stack validation passed formatting, default CLI Clippy and 1,846 passing CLI tests (four existing ignored), telemetry-disabled check/all-target Clippy, and all 91 Python/classifier tests.

Appended in stack #769. No existing stack commits were rewritten.
