### PR TITLE
fix(telemetry): keep status read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -2825,7 +2825,7 @@ A failed *runtime* invocation may also carry up to six failure-classification fi
 
 These are fixed strings compiled into the binary (plus one allowlisted status), set only where a failure is owned — never derived from an error text. No classification is attached to a successful run.
 
-Exactly one event is recorded per invocation. `local client` and `local postgres client` `exec()` into the native client, so clickhousectl's event is recorded just before the handover with the censored outcome `exec_attempt` and a fixed exit code `0` — it means "the handoff was reached", not "the native client succeeded". Failures clickhousectl can see itself (missing/non-executable binary, `psql` not on `PATH`) are refused first and report their real exit code.
+Except for the read-only `telemetry status` command, exactly one event is recorded per invocation. `local client` and `local postgres client` `exec()` into the native client, so clickhousectl's event is recorded just before the handover with the censored outcome `exec_attempt` and a fixed exit code `0` — it means "the handoff was reached", not "the native client succeeded". Failures clickhousectl can see itself (missing/non-executable binary, `psql` not on `PATH`) are refused first and report their real exit code.
 
 Nothing is sent before you have seen the notice unless you explicitly enable telemetry with `clickhousectl telemetry enable`. The first run normally prints a one-time notice to stderr, records that it was shown in `~/.clickhouse/telemetry.json`, and sends nothing. Sending starts from the following run. Explicitly enabling telemetry starts it immediately and skips the notice. The send happens in a short-lived detached process, so command latency is unaffected even when the endpoint is unreachable.
 
@@ -2842,7 +2842,7 @@ export DO_NOT_TRACK=1
 clickhousectl telemetry status
 ```
 
-On a machine that has never seen the notice, `telemetry status` reports "not yet configured" and then completes the first run itself: it writes `~/.clickhouse/telemetry.json` and prints the notice, so sending starts from the next run.
+`telemetry status` only reads the current preference. It does not create `~/.clickhouse/telemetry.json`, record an event or refresh the update-check cache. On a machine that has never seen the notice, it reports "not yet configured"; the next ordinary command performs the usual first-run notice flow.
 
 To see exactly what would be sent without sending it, set `CHCTL_TELEMETRY_DEBUG=1` — the payload is printed to stderr and nothing leaves the machine.
 

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -65,8 +65,9 @@ async fn main() {
             // a clap derive bug, not a user error.
             let cli = Cli::from_arg_matches(&matches)
                 .expect("Cli::from_arg_matches must accept matches from Cli::command()");
+            let read_only_telemetry_status = is_read_only_telemetry_status(&cli.command);
             let run_result = match validate_post_parse(&cli, &mut cmd) {
-                Ok(()) => run_parsed(cli).await,
+                Ok(()) => run_parsed(cli, read_only_telemetry_status).await,
                 Err(e) => {
                     let _ = e.print();
                     (e.exit_code(), false, false)
@@ -79,7 +80,12 @@ async fn main() {
             }
             #[cfg(not(feature = "telemetry"))]
             let _ = is_child_exit;
-            (exit_code, invocation, defer_telemetry_notice)
+            (
+                exit_code,
+                invocation,
+                defer_telemetry_notice,
+                read_only_telemetry_status,
+            )
         }
         Err(e) => {
             // clap keeps its own formatting and colors; help/version print to
@@ -109,19 +115,23 @@ async fn main() {
             // clap's own exit codes: 0 for help/version, 2 for usage errors.
             // Dispatched commands reserve 3 for cancellation, so 2 remains
             // unambiguous to shell callers.
-            (e.exit_code(), invocation, false)
+            (e.exit_code(), invocation, false, false)
         }
     };
-    let (exit_code, telemetry_invocation, defer_telemetry_notice) = outcome;
+    let (exit_code, telemetry_invocation, defer_telemetry_notice, read_only_telemetry_status) =
+        outcome;
 
     // Consent is evaluated here, after the command ran, so `telemetry disable`
     // silences its own event and `telemetry enable` sends one.
     #[cfg(feature = "telemetry")]
-    telemetry::finalize(telemetry_invocation, exit_code, defer_telemetry_notice);
+    if !read_only_telemetry_status {
+        telemetry::finalize(telemetry_invocation, exit_code, defer_telemetry_notice);
+    }
     #[cfg(not(feature = "telemetry"))]
     {
         let () = telemetry_invocation;
         let _ = defer_telemetry_notice;
+        let _ = read_only_telemetry_status;
     }
 
     std::process::exit(exit_code);
@@ -203,7 +213,7 @@ fn validate_post_parse(cli: &Cli, cmd: &mut clap::Command) -> std::result::Resul
 /// The hidden `telemetry send` child is the one deliberate early exit in the
 /// binary: it does exactly one POST — no update-cache refresh, no dispatch,
 /// and no telemetry hook of its own, so a send can never trigger another send.
-async fn run_parsed(cli: Cli) -> (i32, bool, bool) {
+async fn run_parsed(cli: Cli, read_only_telemetry_status: bool) -> (i32, bool, bool) {
     #[cfg(feature = "telemetry")]
     if matches!(
         cli.command,
@@ -219,7 +229,7 @@ async fn run_parsed(cli: Cli) -> (i32, bool, bool) {
     // commands. The refresh is gated to one network call per 24h; the notice
     // below is driven off whatever the cache currently holds.
     let is_update_cmd = matches!(cli.command, Commands::Update(_));
-    let cache_refresh = if !is_update_cmd {
+    let cache_refresh = if !is_update_cmd && !read_only_telemetry_status {
         Some(tokio::spawn(update::refresh_update_cache()))
     } else {
         None
@@ -287,6 +297,25 @@ async fn run_parsed(cli: Cli) -> (i32, bool, bool) {
     }
 
     (exit_code, is_child_exit, defer_telemetry_notice)
+}
+
+/// `telemetry status` reports persisted consent without changing any global
+/// state itself: it neither records a telemetry event nor refreshes the update
+/// cache. Keep this check on the parsed enum so aliases or argument text can
+/// never accidentally select the exemption.
+#[cfg(feature = "telemetry")]
+fn is_read_only_telemetry_status(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Telemetry(cli::TelemetryArgs {
+            command: cli::TelemetryCommands::Status
+        })
+    )
+}
+
+#[cfg(not(feature = "telemetry"))]
+fn is_read_only_telemetry_status(_command: &Commands) -> bool {
+    false
 }
 
 /// The explicit `--json` flag for a command, or `None` for commands that never

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -1243,6 +1243,45 @@ async fn disable_persists_and_silences() {
 }
 
 #[tokio::test]
+async fn status_is_read_only_when_telemetry_is_unconfigured() {
+    let sandbox = Sandbox::new().await;
+
+    let output = sandbox.run(&["telemetry", "status"]);
+    assert!(output.status.success());
+    assert!(stdout_of(&output).contains("not yet configured"));
+    assert!(!stderr_of(&output).contains("anonymous usage data"));
+    assert!(!sandbox.state_path().exists());
+    assert!(
+        !sandbox
+            .home
+            .path()
+            .join(".clickhouse/last_update_check")
+            .exists()
+    );
+    sandbox.assert_no_requests().await;
+}
+
+#[tokio::test]
+async fn status_is_read_only_when_telemetry_is_enabled() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let original_state = std::fs::read(sandbox.state_path()).unwrap();
+
+    let output = sandbox.run(&["telemetry", "status"]);
+    assert!(output.status.success());
+    assert!(stdout_of(&output).contains("Telemetry is enabled"));
+    assert_eq!(std::fs::read(sandbox.state_path()).unwrap(), original_state);
+    assert!(
+        !sandbox
+            .home
+            .path()
+            .join(".clickhouse/last_update_check")
+            .exists()
+    );
+    sandbox.assert_no_requests().await;
+}
+
+#[tokio::test]
 async fn enable_sends_an_event_for_itself() {
     let sandbox = Sandbox::new().await;
     sandbox.write_state(true);


### PR DESCRIPTION
`telemetry status` now only inspects the current preference. It no longer initializes telemetry state, records an event, emits a first-run notice, or refreshes the update-check cache. An unconfigured installation stays unconfigured until an ordinary command performs the normal notice flow.

The exemption is selected from the parsed command enum. Enable/disable and ordinary command behavior remain covered by the existing telemetry suite. README describes the read-only status contract.

Closes #861.

Validation: new subprocess regressions inspect fresh and enabled telemetry state, checking for no state/cache writes or telemetry requests; all 52 telemetry integration tests passed. Combined stack validation passed formatting, default CLI Clippy and 1,846 passing CLI tests (four existing ignored), telemetry-disabled check/all-target Clippy, and all 91 Python/classifier tests.

Appended in stack #769. No existing stack commits were rewritten.
